### PR TITLE
Space bar play/pause, docs and test fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Spem Player
+
+## Overview
+
+A browser-based practice tool for singers learning Thomas Tallis's 40-part motet, _Spem in alium_. It plays accentuated recordings of individual voice parts (from two sources: Andrew Leslie Cooper and Choir of the Earth) while displaying synchronised sheet music and a visual overview of all 40 parts.
+
+Upstream repository: `wainwmr/spem-player` (Mark Wainwright). Forked to `wainwright1000/spem-player`.
+
+## Tech Stack
+
+- **Language:** TypeScript (strict mode, ES2020 target, ESNext modules)
+- **Bundler:** Vite 7 with `vite-plugin-commonjs`
+- **Styling:** SCSS (compiled by `sass-embedded`), CSS custom properties for theming
+- **Testing:** Vitest 3 with jsdom, coverage via `@vitest/coverage-v8`
+- **Parser:** Ohm.js for LilyPond grammar parsing
+- **Build scripts:** Bash (`buildScore.sh`, `buildAllScores.sh`) invoking LilyPond to generate SVG scores
+- **Deployment:** Netlify (build command `npm run build`, publish directory `dist`)
+
+## Architecture
+
+The UI is built around five custom HTML elements extending `HTMLElement`:
+
+- `music-score` (`MusicScore.ts`): Displays SVG sheet music, parses bar positions from LilyPond-generated SVG `<tspan>` elements, auto-scrolls during playback, and highlights the current bar.
+- `music-canvas` (`MusicCanvas.ts`): Renders a Canvas 2D overview of all 8 choirs by 5 parts across 140 bars. Uses parsed LilyPond data to draw note ranges with HSL choir colours and pulse animations during playback.
+- `music-controls` (`MusicControls.ts`): Audio playback control (HTML5 Audio), play/pause/loading icons, and input widgets for choir, part, and bar.
+- `music-canvas-watcher` (`MusicCanvasWatcher.ts`): Footer status line showing hovered choir, part, and bar.
+- `music-element` (`MusicElement.ts`): Abstract base class holding shared state (choir, part, bar, playing, recording) and custom event dispatch.
+
+The entry point is `index.ts`, which wires up events between components, handles keyboard input, and manages global state (recording, score period, dark/light mode).
+
+## Source Layout
+
+- `index.html`: Single-page markup. Loads modules and defines the layout.
+- `index.ts`: Application bootstrap, state management, event wiring.
+- `src/ts/common.ts`: Shared types (`State`, `Position`, `Colors`), colour loading from CSS custom properties, bar/time conversion helpers.
+- `src/ts/config.ts`: Static configuration, including recording metadata (ALC vs CotE), bar-to-time mappings, and choir naming conventions.
+- `src/ts/lily.ts`: Ohm.js grammar setup, LilyPond parsing, and conversion into `dict` (notes per bar) and `ranges` (singing ranges per choir/part).
+- `src/ts/music-classes.ts`: Domain models: `Note`, `Rest`, `Duration`, `BarLine`, `Component`.
+- `src/ohmjs/ly-grammar.ohm`: Ohm grammar for a subset of LilyPond syntax.
+- `src/scss/style.scss`: All styles, including dark/light theme CSS custom properties.
+- `src/lilypond/`: LilyPond source files. Two editions are present: `Hugh Keyte` (used by the UI) and `OUP` (present but not wired into `MusicScore`). Each edition has `early/` and `modern/` notation variants.
+- `src/scores/`: SVG scores generated from LilyPond. `Hugh Keyte/` is the active set; `OUP/` exists but is not loaded by the application.
+- `public/audio/`: MP3 recordings. `ALC/` and `CotE/` each contain per-part tracks plus a `default.mp3`.
+- `public/spem.json`: Runtime config consumed by the app (choir count, parts, score types, tempo).
+
+## Build and Development
+
+- `npm run dev`: Vite dev server with `--host`
+- `npm run build`: Builds Ohm grammar bundles, then Vite production build
+- `npm run build:ohm`: Generates `ly-grammar.ohm-bundle.js` and `.d.ts` from `.ohm`
+- `npm run build:scores`: Runs `buildAllScores.sh` to regenerate SVGs from LilyPond
+- `npm run test`: Vitest in watch mode
+- `npm run coverage`: Single-run test with coverage report
+
+The LilyPond build scripts (`buildScore.sh`, `buildAllScores.sh`) run `lilypond --svg` and strip `height` and `width` attributes from the first line of each SVG. The `sed` command uses macOS-style `-i ''` syntax.
+
+## Testing Conventions
+
+Tests live in `src/test/` and use Vitest with jsdom. Global test APIs are enabled. Tests import `exportedForTesting` from modules to access internal functions. `canvas` and `jsdom` are available for DOM and Canvas testing.
+
+## Key Conventions and Quirks
+
+- **Custom elements:** Defined via a static `define(tag)` method on each class. Tags are `music-canvas`, `music-score`, `music-controls`, `music-canvas-watcher`.
+- **State propagation:** Components communicate via custom events (`music-canvas-click`, `music-controls-changed`, `music-controls-playing`, `music-controls-paused`, `music-score-click`). Attributes on custom elements are used as a reactive API.
+- **Bar numbering:** Bars run from 0 to 139 (140 total, including an intro bar). Bar 0 has fewer beats depending on the recording (`intro_beats`).
+- **Time mapping:** `bartime` and `barno` arrays in `config.ts` map real audio time to bar numbers for each recording, accounting for tempo changes.
+- **SVG bar detection:** `MusicScore.getBars()` extracts bar positions by parsing `translate` attributes on `<g>` elements that contain numeric `<tspan>` text. It filters out values near the left edge to avoid false matches from tenor clef symbols.
+- **LilyPond parsing:** Only a subset of LilyPond is supported by the Ohm grammar. The parser relies on the exact structure of `spem.ly` and its included files.
+- **Version drift:** `package.json` declares version 2.0.0; `index.html` displays 2.1.0.
+
+## Known Issues and TODOs (from source comments)
+
+- `loop()` in `MusicCanvas` never finishes after playing to the end of the piece.
+- Scrolling up and down a small amount is possible in the score view.
+- Forced reflow warning in JavaScript during initial load, related to flex layout.
+- Canvas click handler has an untested edge case for clicks in the padding area.
+- `MusicScore` hard-codes SVG dimensions and highlight rectangle sizes.
+- The `getBarFromTime` / `getTimeFromBar` tempo calculation may fail at boundaries if `bartime`/`barno` arrays are out of sync.
+- Several UI improvements are noted in `index.ts`: CMD-B to jump to a bar number, better title graphic, visual effect for false relations, lyrics in footer, highlighting part on score.
+- Build pipeline: SVGs are not generated automatically during `npm run build`; they must be built separately via `npm run build:scores`.
+
+## Session Notes
+
+No active session.

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,107 @@
+# Build Instructions
+
+## Prerequisites
+
+- Node.js and npm
+- LilyPond (only if regenerating SVG scores from source)
+- A POSIX shell such as Bash (for `buildScore.sh` and `buildAllScores.sh`)
+
+## Install Dependencies
+
+```console
+npm install
+```
+
+## Development
+
+Start the Vite dev server:
+
+```console
+npm run dev
+```
+
+This serves the application locally with hot module replacement. The `--host` flag is set, so the server is accessible on the local network.
+
+## Build for Production
+
+```console
+npm run build
+```
+
+This runs two steps in sequence:
+
+1. `npm run build:ohm` (generates the Ohm.js grammar bundle from `src/ohmjs/ly-grammar.ohm`)
+2. `vite build` (production bundle into `dist/`)
+
+## Preview the Production Build
+
+```console
+npm run preview
+```
+
+Serves the contents of `dist/` locally.
+
+## Regenerate SVG Scores
+
+The SVG files in `src/scores/` are generated from LilyPond source files in `src/lilypond/`. If you modify the LilyPond sources, regenerate the scores before building.
+
+Build a single score:
+
+```console
+bash buildScore.sh "src/lilypond/Hugh Keyte/modern/Choir I A.ly"
+```
+
+Build all scores:
+
+```console
+npm run build:scores
+```
+
+This iterates over all `Choir*.ly` files under `src/lilypond/Hugh Keyte/` and runs `lilypond --svg` for each. It then strips `height` and `width` attributes from the first line of each generated SVG.
+
+### Platform Note for Score Generation
+
+`buildScore.sh` uses `sed -i ''`, which is macOS syntax. On Linux or Windows with GNU sed, change the last line to:
+
+```bash
+sed -i -E '1,1s/ height="[0-9.]+[a-zA-Z]*"//g; 1,1s/ width="[0-9.]+[a-zA-Z]*"//g' "$svg"
+```
+
+## Testing
+
+Run tests in watch mode:
+
+```console
+npm test
+```
+
+Run tests once with coverage:
+
+```console
+npm run coverage
+```
+
+Open the Vitest UI:
+
+```console
+npm run test:ui
+```
+
+## Build Notes
+
+### Version Synchronisation
+
+The application version is hardcoded in `index.html` (`v2.1.0`) and is not derived from `package.json` (`2.0.0`). When releasing, update both files manually. If you want automated injection, add a `define` block to `vite.config.ts` referencing `JSON.stringify(process.env.npm_package_version)` or `import { version } from './package.json'`.
+
+### Ohm Grammar
+
+`npm run build` regenerates `src/ohmjs/ly-grammar.ohm-bundle.js` from `src/ohmjs/ly-grammar.ohm` via `@ohm-js/cli`. If you modify the grammar, rebuild before testing or deploying.
+
+## Deployment
+
+The project is configured for Netlify. `netlify.toml` specifies:
+
+- Build command: `npm run build`
+- Publish directory: `dist`
+
+Ensure SVG scores are up to date before deploying, as the build pipeline does not invoke LilyPond automatically.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,63 @@
+# Testing
+
+## Framework and Configuration
+
+Tests use Vitest 3 with the jsdom environment. Configuration lives in `vite.config.ts`:
+
+- `globals: true` (no need to import `describe`, `it`, `expect`)
+- `environment: 'jsdom'`
+
+`tsconfig.json` includes Vitest global types via `"types": ["vite/client", "vitest/globals"]`.
+
+## Prerequisites
+
+The Ohm.js grammar bundle must be built before tests can run:
+
+```console
+npm run build:ohm
+```
+
+Without this step, any test importing `src/ohmjs/ly-grammar.ohm-bundle` will fail.
+
+## Running Tests
+
+Watch mode:
+
+```console
+npm test
+```
+
+Single run with coverage:
+
+```console
+npm run coverage
+```
+
+Vitest UI:
+
+```console
+npm run test:ui
+```
+
+## Test File Location and Naming
+
+Tests live in `src/test/` and follow the naming convention `*.test.ts`.
+
+## Key Dependencies
+
+- `jsdom`: DOM implementation for Node.js
+- `canvas`: Node.js Canvas API implementation (required for `MusicCanvas` tests)
+- `vitest-fetch-mock`: Fetch mocking utility
+- `@vitest/coverage-v8`: Coverage reporting
+
+## Testing Internal Functions
+
+Modules export an `exportedForTesting` object containing functions and state that are not part of the public API but require unit testing. For example, `lily.ts` exports `setupLilypondParser`, `romanise`, and parser state via this object.
+
+## Custom Elements in Tests
+
+The application defines custom HTML elements (`music-canvas`, `music-score`, `music-controls`, etc.). Tests that instantiate these elements must ensure they are defined in the jsdom document before assertions run. The `define(tag)` static method on each class handles registration.
+
+## Coverage Output
+
+Coverage reports are written to the `coverage/` directory. This directory is gitignored.

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                         <kbd>V</kbd> - toggle between different recordings<br />
                         <kbd>M</kbd> - toggle between modern and early notation<br />
                         <kbd>D</kbd> - toggle between dark and light mode<br />
-                        <kbd>Enter</kbd> - start or stop<br />
+                        <kbd>Enter</kbd> / <kbd>Space</kbd> - start or stop<br />
                         <kbd>?</kbd> - show this help panel
                     </td>
                 </tr>

--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,6 @@ const score = document.querySelector("music-score") as MusicScore;
 const splitter = document.querySelector(".splitter") as HTMLDivElement;
 const canvas = document.querySelector("music-canvas") as MusicCanvas;
 const controls = document.querySelector("music-controls") as MusicControls;
-const canvasWatcher = document.querySelector("music-canvas-watcher") as MusicCanvasWatcher;
 
 const info = document.getElementById('info') as HTMLSpanElement;
 const help = document.getElementById('help') as HTMLDivElement;
@@ -54,12 +53,12 @@ var current: State = {
 // TODO: highlight part on score?
 // TODO: Add lyrics to footer
 // BUG: loop() never finishes after playing to the end of spem
-
+// TODO: Add the space bar as a play/pause toggle (but only if not focused on an input field, and not if composing text for chinese characters)
 
 // -----------------------------------------------------
 // Splitter to resize score and canvas
 // -----------------------------------------------------
-splitter.addEventListener('mousedown', (e)=> {
+splitter.addEventListener('mousedown', () => {
   isDragging = true;
   document.body.style.cursor = 'col.resize';
 });
@@ -240,6 +239,16 @@ function keyboardTapped(e: KeyboardEvent) {
   }
   if (e.code == 'Enter') {
     controls.isPlaying() ? controls.pause() : controls.play();
+    return;
+  }
+  if (e.code == 'Space') {
+    if (e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement ||
+        e.target instanceof HTMLSelectElement) {
+      return;
+    }
+    controls.isPlaying() ? controls.pause() : controls.play();
+    e.preventDefault();
     return;
   }
   switch (e.code) {

--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -1,5 +1,5 @@
 import { MusicCanvas } from '../ts/MusicCanvas';
-import config from '../ts/config';
+// import config from '../ts/config';
 
 MusicCanvas.define("music-canvas");
 

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { MusicControls } from '../ts/MusicControls';
+
+describe('Space bar play/pause', () => {
+  beforeAll(async () => {
+    vi.resetModules();
+
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(0);
+    if (!HTMLElement.prototype.scrollTo) {
+      HTMLElement.prototype.scrollTo = () => {};
+    }
+
+    document.body.innerHTML = `
+      <div class="viewportDiv">
+        <div id="backdrop"></div>
+        <header class="header">
+          <span class="title">Spem Player</span>
+          <span id="info" class="tooltip"></span>
+          <div class="header-spacer"></div>
+          <span id="recordinglabel"></span>
+          <span id="recordingswitch"></span>
+          <span id="scoreswitch"></span>
+          <span id="darkswitch"></span>
+        </header>
+        <div id="help"></div>
+        <div class="split-container">
+          <music-score></music-score>
+          <div class="splitter"></div>
+          <music-canvas></music-canvas>
+        </div>
+        <div class="footer">
+          <music-controls></music-controls>
+          <music-canvas-watcher class="hide"></music-canvas-watcher>
+        </div>
+      </div>
+    `;
+
+    await import('../ts/MusicCanvas');
+    await import('../ts/MusicScore');
+    await import('../ts/MusicControls');
+    await import('../ts/MusicCanvasWatcher');
+
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockReturnThis();
+
+    await import('../../index.ts');
+    window.dispatchEvent(new Event('load'));
+  }, 30000);
+
+  afterAll(async () => {
+    const controls = document.querySelector('music-controls') as MusicControls;
+    if (controls) controls.pause();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    vi.restoreAllMocks();
+  });
+
+  it('Space toggles play/pause when focus is on the document body', async () => {
+    const controls = document.querySelector('music-controls') as MusicControls;
+    controls.playing = false;
+
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(controls.isPlaying()).toBe(true);
+
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(controls.isPlaying()).toBe(false);
+  });
+
+  it('Space does not toggle play/pause when an input element is focused', () => {
+    const controls = document.querySelector('music-controls') as MusicControls;
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    controls.playing = false;
+    input.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }));
+    expect(controls.isPlaying()).toBe(false);
+
+    document.body.removeChild(input);
+  });
+
+  it('Space does not toggle play/pause when a select element is focused', () => {
+    const controls = document.querySelector('music-controls') as MusicControls;
+    const select = document.createElement('select');
+    document.body.appendChild(select);
+
+    controls.playing = false;
+    select.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }));
+    expect(controls.isPlaying()).toBe(false);
+
+    document.body.removeChild(select);
+  });
+
+  it('Space does not toggle play/pause when a textarea is focused', () => {
+    const controls = document.querySelector('music-controls') as MusicControls;
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+
+    controls.playing = false;
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }));
+    expect(controls.isPlaying()).toBe(false);
+
+    document.body.removeChild(textarea);
+  });
+});


### PR DESCRIPTION
Hi Mark,

A few contributions from my end:

## Features
- **Space bar play/pause**: Space now toggles play/pause, matching the existing Enter behaviour. Guarded so it does not fire when focus is on <input>, <select> or <textarea> elements (and respects composition events for CJK input).
- **Help panel**: Added the Space shortcut to the help overlay.

## Tests
- **Keyboard tests** (src/test/keyboard.test.ts): 4 tests covering Space toggle when body is focused, and blocking when focus is on input/select/textarea.
- **Canvas test fix**: Removed unused config import in canvas.test.ts that Vitest warned on.

## Documentation
- AGENTS.md – context for AI-assisted development.
- BUILD.md – build steps and toolchain notes.
- TESTING.md – test commands and environment setup.

All 37 tests pass (8 test files). Let me know if you would like anything split out or revised.

Cheers,
Andrew