### PR TITLE
[fix] Fix event listener leak causing UI hang on mobile

### DIFF
--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -323,22 +323,28 @@ export class MusicCanvas extends MusicElement {
     };
   }
 
+  #touchMoveHandler = (evt: TouchEvent) => {
+    evt.preventDefault();
+    this.#moveToPosition(this.#getTouchPos(evt));
+    this.fireEvent("music-canvas-touchmove");
+    this.draw();
+  };
+
+  #touchEndHandler = (evt: TouchEvent) => {
+    evt.preventDefault();
+    this.removeEventListener("touchmove", this.#touchMoveHandler);
+    this.removeEventListener("touchend", this.#touchEndHandler);
+    this.fireEvent("music-canvas-touchend");
+    this.draw();
+  };
+
   #touchStarted(e: TouchEvent) {
     e.preventDefault();
     this.#moveToPosition(this.#getTouchPos(e));
     this.fireEvent("music-canvas-touchstart");
     this.draw();
 
-    this.addEventListener("touchmove", (evt: TouchEvent) => {
-      evt.preventDefault();
-      this.#moveToPosition(this.#getTouchPos(evt));
-      this.fireEvent("music-canvas-touchmove");
-      this.draw();
-    });
-    this.addEventListener("touchend", (evt: TouchEvent) => {
-      evt.preventDefault();
-      this.fireEvent("music-canvas-touchend");
-      this.draw();
-    });
+    this.addEventListener("touchmove", this.#touchMoveHandler);
+    this.addEventListener("touchend", this.#touchEndHandler);
   }
 }


### PR DESCRIPTION
Extracted touchmove/touchend handlers to stable instance properties to prevent exponential event listener accumulation on rapid mobile taps.