### PR TITLE
docs: restructure README and add CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,20 @@ The UI is built around five custom HTML elements extending `HTMLElement`:
 
 The entry point is `index.ts`, which wires up events between components, handles keyboard input, and manages global state (recording, score period, dark/light mode).
 
+### State Management
+
+The central `State` interface (defined in `src/ts/common.ts`) tracks:
+
+- `recording` — 0 for ALC, 1 for CotE
+- `viewmode` — `"dark"` or `"light"`
+- `period` — `"modern"` or `"early"`
+- `choir` — 0 to 7
+- `part` — `"all"` or 0 to 4
+- `bar` — 0 to 139
+- `status` — `"playing"`, `"paused"`, or `"loading"`
+
+State changes flow through `index.ts` helper functions (`setChoir()`, `setPart()`, `setBar()`), which update component attributes. Components react via `attributeChangedCallback` and fire custom events to propagate changes back to `index.ts`.
+
 ## Source Layout
 
 - `index.html`: Single-page markup. Loads modules and defines the layout.

--- a/BUILD.md
+++ b/BUILD.md
@@ -97,6 +97,14 @@ The application version is hardcoded in `index.html` (`v2.1.0`) and is not deriv
 
 `npm run build` regenerates `src/ohmjs/ly-grammar.ohm-bundle.js` from `src/ohmjs/ly-grammar.ohm` via `@ohm-js/cli`. If you modify the grammar, rebuild before testing or deploying.
 
+## Build Output
+
+The production build writes to `dist/`:
+
+- `dist/assets/` — bundled JavaScript and CSS
+- `dist/audio/` — audio files copied from `public/`
+- Other files from `public/` (favicons, manifest, etc.)
+
 ## Deployment
 
 The project is configured for Netlify. `netlify.toml` specifies:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to Spem Player
+
+## Getting Started
+
+See `BUILD.md` for development setup, prerequisites, and build commands.
+
+## Workflow
+
+The project uses a GitHub Project board as the canonical register of work. See `WORKFLOW.md` for the full schema and lifecycle.
+
+### Board Statuses
+
+- **Todo** — new item. Exit when Type, Area, and Difficulty are defined and the Description is clear enough to act on.
+- **Specified** — assessed; recommended fix or test plan exists. Exit when a developer claims it.
+- **In Progress** — coding started, branch created. Exit when code is complete, tests pass, and work is committed to `dev`.
+- **Ready for Main** — committed to `dev`; awaiting final check. Exit when merged to `main`.
+- **Done** — on `main`; running in production.
+
+### Branching
+
+- `main` — production branch.
+- `dev` — integration branch.
+- Feature branches are created from `upstream/dev`.
+
+Pull requests from this fork target `upstream/dev`.
+
+### Ticket Lifecycle
+
+1. Create a GitHub issue and add it to the board with Status **Todo**.
+2. Assess: set Type, Area, and Difficulty. Write a clear Description.
+3. Specify: write Recommended fix, Test plan, and Dependencies. Move to **Specified**.
+4. Develop: claim the ticket, create a feature branch, implement, and test.
+5. Open a PR against `upstream/dev`. Move Status to **In Progress**.
+6. When merged to `dev`, move to **Ready for Main**.
+7. When `dev` is merged to `main`, move to **Done**.
+
+## Code Style
+
+- TypeScript strict mode.
+- Meaningful variable and function names.
+- JSDoc comments for public APIs.
+- Keep functions focused and single-purpose.
+- Explicit types where helpful.
+- Prefer interfaces over types for object shapes.
+- Use `const` for immutable values.
+- Use `let` only when reassignment is needed.
+- Avoid `any`; use `unknown` if necessary.
+
+## Lint and Type Checking
+
+The CI pipeline runs `npm run lint` and `npx tsc --noEmit`. Pull requests must pass both.
+
+The project uses an ESLint flat config (`eslint.config.js`) with `typescript-eslint`. Some rules are relaxed because the codebase predates them (for example, `no-var` and `@typescript-eslint/no-explicit-any` are currently off). Follow the existing patterns in the file you are editing rather than refactoring legacy code to meet stricter rules.
+
+Formatting standards are under active review (see issue #155). Until a formatter is adopted, match the indentation and quote style of the surrounding code.
+
+## Component Conventions
+
+All UI components are native custom elements extending `MusicElement`.
+
+When creating or modifying a component:
+
+1. Extend `MusicElement`.
+2. Define `observedAttributes` static property.
+3. Implement `attributeChangedCallback` for reactive updates.
+4. Use `fireEvent()` to communicate state changes.
+5. Register the element via a static `define(tag)` method.
+
+## Pull Request Process
+
+1. Create a feature branch from `main`.
+2. Make your changes, add tests, and update documentation.
+3. Ensure tests pass: `npm test`.
+4. Check for lint and type errors:
+
+   ```console
+   npm run lint
+   npx tsc --noEmit
+   ```
+
+5. Commit with a clear message referencing the issue number.
+6. Push to your fork.
+7. Open a PR to `upstream/dev`.
+8. Include `Fixes #NNN` in the description only if the PR fully resolves the issue.
+
+## Commit Messages
+
+Use conventional commit format where possible:
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `docs:` — documentation
+- `test:` — tests
+- `refactor:` — code restructuring
+- `build:` — build system or tooling
+
+## Testing
+
+See `TESTING.md` for test framework details, running tests, and coverage.
+
+## Best Practices
+
+- Incremental changes over monolithic refactors.
+- Tests for new behaviour.
+- Do not break the build pipeline.
+- Preserve existing user-facing behaviour unless the change is the point.
+- Run diagnostics after file writes and fix errors before proceeding.
+- Scratch files go in `temp/` and should be deleted before the session ends.
+- Report scope creep immediately rather than silently upgrading difficulty.
+
+## Questions
+
+Open an issue for discussion or refer to `AGENTS.md` and `AGENTS-LOCAL.md` for project conventions.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Toggle between recordings using the button in the top-right corner.
 
 ### Canvas Overview
 
-- Visual map of all 8 choirs × 5 parts across all 140 bars
+- Visual map of all 8 choirs by 5 parts across all 140 bars
 - Colour-coded by choir (HSL palette)
 - Pulse animation shows active notes during playback
 - Click or tap any bar to jump directly to that position
@@ -40,21 +40,19 @@ Toggle between recordings using the button in the top-right corner.
 
 ### Keyboard Shortcuts
 
-| Key | Action |
-| --- | ------ |
-| `1` – `8` | Select choir |
-| `S` | Soprano |
-| `A` | Alto |
-| `T` | Tenor |
-| `R` | Baritone |
-| `B` | Bass |
-| `X` | All voice parts |
-| `←` / `→` | Select bar |
-| `V` | Toggle between recordings |
-| `M` | Toggle modern / early notation |
-| `D` | Toggle dark / light mode |
-| `Enter` / `Space` | Start or stop |
-| `?` | Show help panel |
+- `1`–`8`: select choir
+- `S`: soprano
+- `A`: alto
+- `T`: tenor
+- `R`: baritone
+- `B`: bass
+- `X`: all voice parts
+- `←` / `→`: select bar
+- `V`: toggle between recordings
+- `M`: toggle modern / early notation
+- `D`: toggle dark / light mode
+- `Enter` or `Space`: start or stop playback
+- `?`: show help panel
 
 Shortcuts are ignored when focus is on an input field or `<select>` element.
 
@@ -64,29 +62,14 @@ Shortcuts are ignored when focus is on an input field or `<select>` element.
 - Responsive layout for desktop and mobile
 - Splitter between score and canvas allows resizing
 
-## Tech Stack
+## For Developers
 
-- TypeScript (strict, ES2020, ESNext modules)
-- Vite 7 + `vite-plugin-commonjs`
-- SCSS with CSS custom properties for theming
-- Vitest 3 + jsdom for testing
-- Ohm.js for LilyPond grammar parsing
-- Netlify deployment (auto-deploy on merge to `main`)
+- `BUILD.md` — development setup, build commands, and deployment
+- `TESTING.md` — running and writing tests
+- `CONTRIBUTING.md` — contribution process, code style, and board workflow
+- `WORKFLOW.md` — ticket lifecycle and best practices
+- `AGENTS.md` — architecture overview and conventions
 
-## Development
+## Licence
 
-```bash
-npm run dev          # Start dev server
-npm run build        # Production build (includes Ohm bundle generation)
-npm run build:ohm    # Regenerate Ohm grammar bundles
-npm run build:scores # Regenerate SVG scores from LilyPond
-npm run test         # Run tests in watch mode
-npm run coverage     # Single-run tests with coverage report
-```
-
-LilyPond SVG generation uses `buildScore.sh` / `buildAllScores.sh`.
-
-## Repository
-
-- **Upstream:** [wainwmr/spem-player](https://github.com/wainwmr/spem-player) (Mark Wainwright)
-- **Fork:** [wainwright1000/spem-player](https://github.com/wainwright1000/spem-player)
+MIT. See `LICENSE`.


### PR DESCRIPTION
Restructures README.md to be end-user focused, removing developer setup details and replacing them with links to dedicated documentation files.

- README.md: end-user focus, links to BUILD.md/TESTING.md/CONTRIBUTING.md/WORKFLOW.md/AGENTS.md
- CONTRIBUTING.md: new file covering board workflow, code style, lint/type-check requirements, component conventions, and PR process
- BUILD.md: adds Build Output section
- AGENTS.md: adds State Management section

Fixes #3