### PR TITLE
fix: clamp canvas mouse and touch positions to drawable area

### DIFF
--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -1,4 +1,5 @@
 import { MusicCanvas } from '../ts/MusicCanvas';
+import config from '../ts/config';
 import { processLilypond, dict, ranges } from '../ts/lily';
 
 MusicCanvas.define("music-canvas");
@@ -144,6 +145,119 @@ describe("MusicCanvas custom element", () => {
     Object.defineProperty(touchEnd, 'preventDefault', { value: vi.fn() });
     canvas!.dispatchEvent(touchEnd);
     await endPromise;
+  });
+
+  it("getMousePos returns valid part for clicks in top padding", async () => {
+    expect(canvas).not.toBeNull();
+
+    const promise = new Promise<CustomEvent>((resolve) => {
+      canvas!.addEventListener("music-canvas-click", (e) => resolve(e as CustomEvent), { once: true });
+    });
+
+    canvas!.getBoundingClientRect = vi.fn(() => ({
+      width: 1400, height: 400, top: 0, left: 0, right: 1400, bottom: 400, x: 0, y: 0, toJSON: () => ({})
+    } as DOMRect));
+
+    const mouseEvent = new MouseEvent("click", {
+      bubbles: true, cancelable: true,
+      clientX: 100, clientY: 2
+    });
+    Object.defineProperty(mouseEvent, 'offsetX', { value: 100 });
+    Object.defineProperty(mouseEvent, 'offsetY', { value: 2 });
+
+    canvas!.querySelector("canvas")!.dispatchEvent(mouseEvent);
+    const event = await promise;
+    const pos = event.detail.position;
+    expect(pos.part).toBeGreaterThanOrEqual(0);
+    expect(pos.part).toBeLessThan(config.parts.length);
+    expect(pos.choir).toBeGreaterThanOrEqual(0);
+    expect(pos.choir).toBeLessThan(config.choirs[0].length);
+    expect(pos.bar).toBeGreaterThanOrEqual(0);
+    expect(pos.bar).toBeLessThan(140);
+  });
+
+  it("getMousePos returns valid bar for clicks in left padding", async () => {
+    expect(canvas).not.toBeNull();
+
+    const promise = new Promise<CustomEvent>((resolve) => {
+      canvas!.addEventListener("music-canvas-click", (e) => resolve(e as CustomEvent), { once: true });
+    });
+
+    canvas!.getBoundingClientRect = vi.fn(() => ({
+      width: 1400, height: 400, top: 0, left: 0, right: 1400, bottom: 400, x: 0, y: 0, toJSON: () => ({})
+    } as DOMRect));
+
+    const mouseEvent = new MouseEvent("click", {
+      bubbles: true, cancelable: true,
+      clientX: 2, clientY: 50
+    });
+    Object.defineProperty(mouseEvent, 'offsetX', { value: 2 });
+    Object.defineProperty(mouseEvent, 'offsetY', { value: 50 });
+
+    canvas!.querySelector("canvas")!.dispatchEvent(mouseEvent);
+    const event = await promise;
+    const pos = event.detail.position;
+    expect(pos.bar).toBeGreaterThanOrEqual(0);
+    expect(pos.bar).toBeLessThan(140);
+    expect(pos.choir).toBeGreaterThanOrEqual(0);
+    expect(pos.choir).toBeLessThan(config.choirs[0].length);
+    expect(pos.part).toBeGreaterThanOrEqual(0);
+    expect(pos.part).toBeLessThan(config.parts.length);
+  });
+
+  it("getMousePos returns valid bar for clicks in right padding", async () => {
+    expect(canvas).not.toBeNull();
+
+    const promise = new Promise<CustomEvent>((resolve) => {
+      canvas!.addEventListener("music-canvas-click", (e) => resolve(e as CustomEvent), { once: true });
+    });
+
+    canvas!.getBoundingClientRect = vi.fn(() => ({
+      width: 1400, height: 400, top: 0, left: 0, right: 1400, bottom: 400, x: 0, y: 0, toJSON: () => ({})
+    } as DOMRect));
+
+    const mouseEvent = new MouseEvent("click", {
+      bubbles: true, cancelable: true,
+      clientX: 1398, clientY: 50
+    });
+    Object.defineProperty(mouseEvent, 'offsetX', { value: 1398 });
+    Object.defineProperty(mouseEvent, 'offsetY', { value: 50 });
+
+    canvas!.querySelector("canvas")!.dispatchEvent(mouseEvent);
+    const event = await promise;
+    const pos = event.detail.position;
+    expect(pos.bar).toBeGreaterThanOrEqual(0);
+    expect(pos.bar).toBeLessThan(140);
+    expect(pos.choir).toBeGreaterThanOrEqual(0);
+    expect(pos.choir).toBeLessThan(config.choirs[0].length);
+    expect(pos.part).toBeGreaterThanOrEqual(0);
+    expect(pos.part).toBeLessThan(config.parts.length);
+  });
+
+  it("getTouchPos returns valid bar for touches in left padding", async () => {
+    expect(canvas).not.toBeNull();
+
+    const promise = new Promise<CustomEvent>((resolve) => {
+      canvas!.addEventListener("music-canvas-touchstart", (e) => resolve(e as CustomEvent), { once: true });
+    });
+
+    canvas!.getBoundingClientRect = vi.fn(() => ({
+      width: 1400, height: 400, top: 0, left: 0, right: 1400, bottom: 400, x: 0, y: 0, toJSON: () => ({})
+    } as DOMRect));
+
+    const innerCanvas = canvas!.querySelector("canvas")!;
+    const touch = { clientX: 2, clientY: 50, identifier: 0, target: innerCanvas };
+    const touchStart = new Event("touchstart", { bubbles: true, cancelable: true });
+    Object.defineProperty(touchStart, 'targetTouches', { value: [touch] });
+    Object.defineProperty(touchStart, 'preventDefault', { value: vi.fn() });
+
+    innerCanvas.dispatchEvent(touchStart);
+    const event = await promise;
+    const pos = event.detail.position;
+    expect(pos.bar).toBeGreaterThanOrEqual(0);
+    expect(pos.bar).toBeLessThan(140);
+    expect(pos.choir).toBeGreaterThanOrEqual(0);
+    expect(pos.choir).toBeLessThan(config.choirs[0].length);
   });
 
 });

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -304,16 +304,15 @@ export class MusicCanvas extends MusicElement {
     return !window.matchMedia('(prefers-color-scheme: dark)').matches;
   }
 
-  // BUG: what happens if you click in the canvas padding?
   #getMousePos(e: MouseEvent): Position {
-    // if (!this.config) return { choir: 0, part: 0, bar: 0 };
-
     const rect = this.getBoundingClientRect();
-    const y = ((e.offsetY - this.canvasPadding) * config.choirs[0].length) / (rect.height - (2 * this.canvasPadding));
+    const clampedX = Math.max(this.canvasPadding, Math.min(e.offsetX, rect.width - this.canvasPadding));
+    const clampedY = Math.max(this.canvasPadding, Math.min(e.offsetY, rect.height - this.canvasPadding));
+    const y = ((clampedY - this.canvasPadding) * config.choirs[0].length) / (rect.height - (2 * this.canvasPadding));
     return {
       choir: Math.min(config.choirs[0].length - 1, Math.max(0, Math.floor(y))),
       part: Math.floor((y % 1) * config.parts.length),
-      bar: Math.floor((e.offsetX * 140) / rect.width)
+      bar: Math.floor((clampedX * 140) / rect.width)
     };
   }
 
@@ -336,12 +335,16 @@ export class MusicCanvas extends MusicElement {
 
   #getTouchPos(e: TouchEvent): Position {
     var rect = this.getBoundingClientRect();
+    const touchX = e.targetTouches[0].clientX - rect.left;
+    const touchY = e.targetTouches[0].clientY - rect.top;
+    const clampedX = Math.max(this.canvasPadding, Math.min(touchX, rect.width - this.canvasPadding));
+    const clampedY = Math.max(this.canvasPadding, Math.min(touchY, rect.height - this.canvasPadding));
 
-    const y = ((e.targetTouches[0].clientY - rect.top - this.canvasPadding) * config.choirs[0].length) / (rect.height - (2 * this.canvasPadding));
+    const y = ((clampedY - this.canvasPadding) * config.choirs[0].length) / (rect.height - (2 * this.canvasPadding));
     return {
       choir: Math.min(config.choirs[0].length - 1, Math.max(0, Math.floor(y))),
       part: "all",
-      bar: Math.floor((e.targetTouches[0].clientX - rect.left - this.canvasPadding) * 140 / rect.width)
+      bar: Math.floor((clampedX - this.canvasPadding) * 140 / rect.width)
     };
   }
 


### PR DESCRIPTION
Clamps click and touch coordinates to the drawable area inside the 5px canvas padding before calculating choir, part, and bar positions.

Previously, clicking in the top padding produced a negative part index, and touching in the left padding produced a negative bar index. The clamping ensures all calculated values stay within valid ranges.

Changes:
- #getMousePos: clamp offsetX and offsetY to [canvasPadding, rect.width - canvasPadding] and [canvasPadding, rect.height - canvasPadding] respectively
- #getTouchPos: clamp clientX - rect.left and clientY - rect.top similarly
- Added unit tests for clicks in top, left, and right padding, plus touches in left padding

Fixes #109