### PR TITLE
fix(canvas): clamp seek() to valid bar range (#173)

### DIFF
--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -1,6 +1,6 @@
 import { MusicCanvas } from "../ts/MusicCanvas";
 import config from "../ts/config";
-import { processLilypond, dict, ranges } from "../ts/lily";
+import { processLilypond, dict, ranges, barCount } from "../ts/lily";
 
 MusicCanvas.define("music-canvas");
 processLilypond();
@@ -57,16 +57,24 @@ describe("MusicCanvas custom element", () => {
     canvas!.voicePart = "all";
   });
 
-  it("seek() finds next section change", () => {
+  it("seek() clamps to lower bound when seeking backward from bar 0", () => {
     expect(canvas).not.toBeNull();
-    expect(canvas!.dict.length).toBeGreaterThan(0);
-    const pos: { choir: number; part: "all"; bar: number } = {
-      choir: 0,
-      part: "all",
-      bar: 1,
-    };
-    const next = canvas!.seek(pos, 1);
-    expect(typeof next).toBe("number");
+    const pos = { choir: 0, part: "all" as const, bar: 0 };
+    expect(canvas!.seek(pos, -1)).toBe(0);
+  });
+
+  it("seek() clamps to upper bound when seeking forward from last bar", () => {
+    expect(canvas).not.toBeNull();
+    const pos = { choir: 0, part: "all" as const, bar: barCount };
+    expect(canvas!.seek(pos, +1)).toBe(barCount);
+  });
+
+  it("seek() finds next section change forward from bar 1", () => {
+    expect(canvas).not.toBeNull();
+    const pos = { choir: 0, part: "all" as const, bar: 1 };
+    const result = canvas!.seek(pos, +1);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(barCount);
   });
 
   it("canvas click fires music-canvas-click event", async () => {

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -158,17 +158,18 @@ export class MusicCanvas extends MusicElement {
 
   seek(pos: Position, direction: 1 | -1) {
     var intbar = Math.floor(pos.bar);
-    const choirnotes = this.dict[intbar].filter((x) => x.c == pos.choir);
+    const choirnotes = (this.dict[intbar] ?? []).filter(
+      (x) => x.c == pos.choir
+    );
     const singing = choirnotes.length != 0;
 
     // loop until we find a bar where choir is not doing what it's doing in currentBar
-    var changed;
-    do {
+    while (intbar + direction >= 0 && intbar + direction <= barCount) {
       intbar = intbar + direction;
       const newsinging =
         this.dict[intbar].filter((x) => x.c == pos.choir).length != 0;
-      changed = singing != newsinging;
-    } while (!changed && intbar > 0 && intbar <= barCount);
+      if (singing !== newsinging) break;
+    }
     return intbar;
   }
 


### PR DESCRIPTION
Closes #173.

- Rewrites MusicCanvas.seek() to stay within valid bar range (0..barCount).
- Handles sparse dict array safely with ?? [].
- Adds boundary and forward-seek unit tests.