### PR TITLE
docs: add Playwright browser setup note and e2e test commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ State changes flow through `index.ts` helper functions (`setChoir()`, `setPart()
 - `npm run test:e2e:ui`: Playwright interactive UI mode
 - `npm run test:e2e:report`: Show last Playwright HTML report
 
+**Playwright setup:** `@playwright/test` is installed via npm, but browser binaries must be downloaded separately. Run `npx playwright install chromium` after `npm install` to fetch the Chromium binary. Playwright caches browsers in `%LOCALAPPDATA%\ms-playwright` (Windows).
+
 The LilyPond build scripts (`build/buildScore.sh`, `build/buildAllScores.sh`) run `lilypond --svg` and strip `height` and `width` attributes from the first line of each SVG. The `sed` command uses macOS-style `-i ''` syntax.
 
 ## Testing Conventions

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -89,6 +89,12 @@ Open the Vitest UI:
 npm run test:ui
 ```
 
+Run end-to-end tests in a real browser:
+
+```console
+npm run test:e2e
+```
+
 ## Build Notes
 
 ### Version Synchronisation

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -58,7 +58,7 @@ Coverage reports are written to the `coverage/` directory. This directory is git
 
 End-to-end tests run in a real browser using Playwright. They live in `e2e/` and follow the naming convention `*.spec.ts`.
 
-### Prerequisites
+### E2E Prerequisites
 
 The production build must exist before e2e tests run:
 
@@ -86,7 +86,7 @@ View the last HTML report:
 npm run test:e2e:report
 ```
 
-### Key Dependencies
+### E2E Key Dependencies
 
 - `@playwright/test`: test runner and browser automation
 - `chromium`: browser under test (installed via `npx playwright install chromium`)


### PR DESCRIPTION
Adds the 
px playwright install chromium setup step to AGENTS.md and the 
pm run test:e2e command to BUILD.md. Also fixes E2E header consistency in TESTING.md.