### PR TITLE
docs: add Playwright setup, e2e commands, and fix markdownlint errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ State changes flow through `index.ts` helper functions (`setChoir()`, `setPart()
 - `npm run test:e2e:ui`: Playwright interactive UI mode
 - `npm run test:e2e:report`: Show last Playwright HTML report
 
+**Playwright setup:** `@playwright/test` is installed via npm, but browser binaries must be downloaded separately. Run `npx playwright install chromium` after `npm install` to fetch the Chromium binary. Playwright caches browsers in `%LOCALAPPDATA%\ms-playwright` (Windows).
+
 The LilyPond build scripts (`build/buildScore.sh`, `build/buildAllScores.sh`) run `lilypond --svg` and strip `height` and `width` attributes from the first line of each SVG. The `sed` command uses macOS-style `-i ''` syntax.
 
 ## Testing Conventions

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -89,6 +89,12 @@ Open the Vitest UI:
 npm run test:ui
 ```
 
+Run end-to-end tests in a real browser:
+
+```console
+npm run test:e2e
+```
+
 ## Build Notes
 
 ### Version Synchronisation

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -58,7 +58,7 @@ Coverage reports are written to the `coverage/` directory. This directory is git
 
 End-to-end tests run in a real browser using Playwright. They live in `e2e/` and follow the naming convention `*.spec.ts`.
 
-### Prerequisites
+### E2E Prerequisites
 
 The production build must exist before e2e tests run:
 
@@ -86,7 +86,7 @@ View the last HTML report:
 npm run test:e2e:report
 ```
 
-### Key Dependencies
+### E2E Key Dependencies
 
 - `@playwright/test`: test runner and browser automation
 - `chromium`: browser under test (installed via `npx playwright install chromium`)

--- a/doc/notes/issue-89.md
+++ b/doc/notes/issue-89.md
@@ -5,7 +5,7 @@
 
 ---
 
-## What is a false relation?
+## What is a false relation
 
 Two notes with the **same letter name** but **different accidentals** sounding simultaneously (or in close proximity) across different voices — e.g. F♮ in one part against F♯ in another.
 
@@ -17,14 +17,13 @@ Same-part clashes (e.g. both in Alto 1) are ignored because those are voice-lead
 
 ### 1. Data structures (`src/ts/lily.ts`)
 
-| Export | Type | Purpose |
-|--------|------|---------|
-| `activeNotes` | `Map<number, ActiveNote[]>` | All notes sounding at each 1/16-bar position |
-| `falseRelations` | `FalseRelation[]` | Detected false-relation intervals |
-| `noteToPitchClass()` | `(Note) => number` | 0-11 chromatic pitch class |
-| `detectFalseRelations()` | `() => void` | Populates `falseRelations` from `activeNotes` |
+- `activeNotes` - `Map<number, ActiveNote[]>` - All notes sounding at each 1/16-bar position
+- `falseRelations` - `FalseRelation[]` - Detected false-relation intervals
+- `noteToPitchClass()` - `(Note) => number` - 0-11 chromatic pitch class
+- `detectFalseRelations()` - `() => void` - Populates `falseRelations` from `activeNotes`
 
-**`FalseRelation` shape:**
+#### `FalseRelation` shape
+
 ```typescript
 {
   from: number;   // start bar position
@@ -34,9 +33,10 @@ Same-part clashes (e.g. both in Alto 1) are ignored because those are voice-lead
     { c, p, notename, accidental }   // second voice
   ];
 }
-```
+```text
 
-**`detectFalseRelations()` algorithm:**
+#### `detectFalseRelations()` algorithm
+
 1. Iterates every 1/16-bar position in `activeNotes` (sorted).
 2. For each position, compares all pairs of active notes.
 3. If `notename` matches, `accidental` differs, and they are from **different parts** (`!(c===c && p===p)`), it's a false relation.
@@ -44,7 +44,7 @@ Same-part clashes (e.g. both in Alto 1) are ignored because those are voice-lead
 5. **Merges consecutive positions** for the same pair into a single interval (`from`…`to`).
 6. When a pair stops clashing, the accumulated interval is pushed to `falseRelations`.
 
-**`activeNotes` construction:**
+#### `activeNotes` construction
 - Built inside `processLilypond()` as notes are parsed.
 - Each note is pushed into every 1/16-bar position in `[noteStart, noteEnd)`.
 - Step size: `0.0625` (1/16 bar).
@@ -63,14 +63,12 @@ Same-part clashes (e.g. both in Alto 1) are ignored because those are voice-lead
 
 6 new tests added:
 
-| Test | What it checks |
-|------|----------------|
-| `noteToPitchClass maps natural notes correctly` | C=0, D=2, E=4, F=5, G=7, A=9, B=11 |
-| `noteToPitchClass maps accidentals correctly` | `is` +1, `es` −1, `isis` +2, `eses` −2, wrap-around |
-| `detectFalseRelations finds false relations` | F♮ vs F♯ across two choirs → 1 hit |
-| `detectFalseRelations ignores same-part clashes` | Two F's in same part → 0 hits |
-| `detectFalseRelations ignores different letters` | E vs F (semitone, different letter) → 0 hits |
-| `detectFalseRelations merges consecutive positions` | Two adjacent 1/16 positions for same pair → single interval `1.0` to `1.125` |
+- `noteToPitchClass maps natural notes correctly` - C=0, D=2, E=4, F=5, G=7, A=9, B=11
+- `noteToPitchClass maps accidentals correctly` - `is` +1, `es` −1, `isis` +2, `eses` −2, wrap-around
+- `detectFalseRelations finds false relations` - F♮ vs F♯ across two choirs → 1 hit
+- `detectFalseRelations ignores same-part clashes` - Two F's in same part → 0 hits
+- `detectFalseRelations ignores different letters` - E vs F (semitone, different letter) → 0 hits
+- `detectFalseRelations merges consecutive positions` - Two adjacent 1/16 positions for same pair → single interval `1.0` to `1.125`
 
 ---
 
@@ -96,13 +94,11 @@ Same-part clashes (e.g. both in Alto 1) are ignored because those are voice-lead
 
 ## Related code locations
 
-| File | Lines | Content |
-|------|-------|---------|
-| `src/ts/lily.ts` | ~12-22 | `activeNotes`, `FalseRelation`, `falseRelations` exports |
-| `src/ts/lily.ts` | ~47-120 | `noteToPitchClass`, `pairKey`, `detectFalseRelations` |
-| `src/ts/lily.ts` | ~269-318 | `activeNotes` construction inside `processLilypond()` |
-| `src/ts/MusicCanvas.ts` | ~17 | `falseRelationPulses` property |
-| `src/ts/MusicCanvas.ts` | ~96 | `falseRelationPulses` initialisation |
-| `src/ts/MusicCanvas.ts` | ~196-213 | Pulse computation loop |
-| `src/ts/MusicCanvas.ts` | ~317-334 | Circle drawing loop |
-| `src/test/lily.test.ts` | ~66-129 | 6 false-relation tests |
+- `src/ts/lily.ts` - ~12-22 - `activeNotes`, `FalseRelation`, `falseRelations` exports
+- `src/ts/lily.ts` - ~47-120 - `noteToPitchClass`, `pairKey`, `detectFalseRelations`
+- `src/ts/lily.ts` - ~269-318 - `activeNotes` construction inside `processLilypond()`
+- `src/ts/MusicCanvas.ts` - ~17 - `falseRelationPulses` property
+- `src/ts/MusicCanvas.ts` - ~96 - `falseRelationPulses` initialisation
+- `src/ts/MusicCanvas.ts` - ~196-213 - Pulse computation loop
+- `src/ts/MusicCanvas.ts` - ~317-334 - Circle drawing loop
+- `src/test/lily.test.ts` - ~66-129 - 6 false-relation tests


### PR DESCRIPTION
- Adds Playwright browser installation step to AGENTS.md
- Adds 
pm run test:e2e to BUILD.md
- Fixes E2E header consistency in TESTING.md
- Fixes markdownlint errors in doc/notes/issue-89.md (tables to lists, emphasis-as-headings, trailing punctuation)