### PR TITLE
fix: reject invalid bar input and prevent keyboard shortcut leak in MusicControls

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -67,4 +67,33 @@ test.describe("Spem Player smoke tests", () => {
 
     await expect(controls).toHaveAttribute("choir", "3");
   });
+
+  test("bar input typing does not change choir (#182)", async ({ page }) => {
+    await page.goto("/");
+
+    const controls = page.locator("music-controls");
+    const barInput = page.locator("#bar-field");
+    await expect(controls).toHaveAttribute("choir", "0");
+
+    await barInput.fill("2");
+    await barInput.blur();
+
+    await expect(controls).toHaveAttribute("choir", "0");
+    await expect(controls).toHaveAttribute("bar", "2");
+  });
+
+  test("bar input clamps out-of-range values (#184)", async ({ page }) => {
+    await page.goto("/");
+
+    const controls = page.locator("music-controls");
+    const barInput = page.locator("#bar-field");
+
+    await barInput.fill("999");
+    await barInput.blur();
+    await expect(controls).toHaveAttribute("bar", "137");
+
+    await barInput.fill("-5");
+    await barInput.blur();
+    await expect(controls).toHaveAttribute("bar", "0");
+  });
 });

--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -1,5 +1,6 @@
 import { MusicControls } from "../ts/MusicControls";
 import config from "../ts/config";
+import { processLilypond, barCount } from "../ts/lily";
 
 var expectedBar: any;
 var expectedChoir: any;
@@ -41,6 +42,7 @@ function matchesWildcard(pattern: string, str: string): boolean {
 describe("MusicControls custom element", () => {
   beforeAll(() => {
     MusicControls.define("music-controls");
+    processLilypond();
 
     // mock the Media element so we know if it's being played
     vi.spyOn(HTMLMediaElement.prototype, "load").mockReturnThis();
@@ -373,5 +375,69 @@ describe("MusicControls custom element", () => {
     choir.dispatchEvent(new Event("change", { bubbles: true }));
     const changeResult = await waitingforChange;
     expect(changeResult).toBe(true);
+  });
+
+  it("adds control class to all interactive elements (#182)", () => {
+    expect(document.getElementById("playpausebutton")?.classList.contains("control")).toBe(true);
+    expect(document.getElementById("choir-select")?.classList.contains("control")).toBe(true);
+    expect(document.getElementById("part-select")?.classList.contains("control")).toBe(true);
+    expect(document.getElementById("bar-field")?.classList.contains("control")).toBe(true);
+  });
+
+  it("rejects letter keydown on bar input (#184)", () => {
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    const event = new KeyboardEvent("keydown", { key: "d", bubbles: true });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    bar.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it("accepts digit keydown on bar input (#184)", () => {
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    const event = new KeyboardEvent("keydown", { key: "5", bubbles: true });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    bar.dispatchEvent(event);
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+
+  it("sanitises non-numeric bar input to 0 on change (#184)", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    bar.value = "4d";
+    bar.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(elem.bar).toBe(0);
+    expect(bar.value).toBe("0");
+  });
+
+  it("clamps out-of-range bar input to max on change (#184)", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    const maxBar = barCount > 0 ? barCount - 1 : 0;
+    bar.value = "999";
+    bar.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(elem.bar).toBe(maxBar);
+    expect(bar.value).toBe(String(maxBar));
+  });
+
+  it("clamps negative bar input to 0 on change (#184)", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    bar.value = "-5";
+    bar.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(elem.bar).toBe(0);
+    expect(bar.value).toBe("0");
+  });
+
+  it("handles empty bar input as 0 on change (#184)", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    bar.value = "";
+    bar.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(elem.bar).toBe(0);
+    expect(bar.value).toBe("0");
   });
 });

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -121,4 +121,26 @@ describe("Space bar play/pause", () => {
 
     document.body.removeChild(textarea);
   });
+
+  it("Digit2 in bar input does not change choir (#182)", async () => {
+    const controls = document.querySelector("music-controls") as MusicControls;
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    bar.focus();
+    bar.dispatchEvent(
+      new KeyboardEvent("keydown", { code: "Digit2", key: "2", bubbles: true })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controls.getAttribute("choir")).toBe("0");
+  });
+
+  it("KeyD in choir select does not toggle dark mode (#182)", async () => {
+    const select = document.getElementById("choir-select") as HTMLSelectElement;
+    select.focus();
+    const wasLight = document.body.classList.contains("light-theme");
+    select.dispatchEvent(
+      new KeyboardEvent("keydown", { code: "KeyD", key: "d", bubbles: true })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(document.body.classList.contains("light-theme")).toBe(wasLight);
+  });
 });

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -33,6 +33,7 @@ export class MusicControls extends MusicElement {
     this.playpausebutton = document.createElement("div");
     this.playpausebutton.setAttribute("id", "playpausebutton");
     this.playpausebutton.setAttribute("tabindex", "0");
+    this.playpausebutton.setAttribute("class", "control");
     this.svgLoading = new DOMParser()
       .parseFromString(loadingSVG, "image/svg+xml")
       .querySelector("svg");
@@ -62,6 +63,7 @@ export class MusicControls extends MusicElement {
     this.choirselect = document.createElement("select");
     this.choirselect.setAttribute("name", "choir");
     this.choirselect.setAttribute("id", "choir-select");
+    this.choirselect.setAttribute("class", "control");
     for (var c in config.choirs[0]) {
       const opt = document.createElement("option");
       opt.setAttribute("value", c);
@@ -77,6 +79,7 @@ export class MusicControls extends MusicElement {
     this.partselect = document.createElement("select");
     this.partselect.setAttribute("name", "part");
     this.partselect.setAttribute("id", "part-select");
+    this.partselect.setAttribute("class", "control");
     const opt = document.createElement("option");
     opt.setAttribute("value", "all");
     opt.appendChild(document.createTextNode("All"));
@@ -100,6 +103,7 @@ export class MusicControls extends MusicElement {
     this.barinput.setAttribute("value", "0");
     this.barinput.setAttribute("min", "0");
     this.barinput.setAttribute("max", String(barCount));
+    this.barinput.setAttribute("class", "control");
     label.append(this.barinput);
     this.append(label);
 
@@ -115,6 +119,16 @@ export class MusicControls extends MusicElement {
       "change",
       this.#handleControlsChanged.bind(this)
     );
+    this.barinput.addEventListener("keydown", (e) => {
+      const allowed = [
+        "Backspace", "Delete", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown",
+        "Tab", "Enter", "Escape", "Home", "End",
+      ];
+      if (allowed.includes(e.key) || /^[0-9]$/.test(e.key)) {
+        return;
+      }
+      e.preventDefault();
+    });
     if (this.playpausebutton)
       this.playpausebutton.addEventListener("click", this.playpause.bind(this));
   }
@@ -124,7 +138,18 @@ export class MusicControls extends MusicElement {
     this.choir = Number(this.choirselect.value);
     this.voicePart =
       this.partselect.value == "all" ? "all" : Number(this.partselect.value);
-    this.bar = Number(this.barinput.value);
+
+    const raw = this.barinput.value;
+    const parsed = Number(raw);
+    if (Number.isNaN(parsed) || raw === "") {
+      this.bar = 0;
+    } else {
+      this.bar = Math.max(0, parsed);
+      if (barCount > 0) {
+        this.bar = Math.min(this.bar, barCount - 1);
+      }
+    }
+    this.barinput.value = String(this.bar);
     this.fireEvent("music-controls-changed");
   }
 


### PR DESCRIPTION
Fixes #182
Fixes #184

Changes:
- Add class='control' to all four interactive widgets (play button, choir select, part select, bar input) so keyboard shortcuts are ignored when focus is inside a control.
- Add keydown listener on bar input to reject non-digit and non-navigation keys.
- Validate and clamp bar input on change: empty or non-numeric input defaults to 0; valid numbers are clamped to [0, barCount - 1].