### PR TITLE
fix: Prevent duplicate rAF loop when changing choir during playback (#179)

### DIFF
--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -539,4 +539,27 @@ describe("MusicControls custom element", () => {
     window.requestAnimationFrame = originalRAF;
 
   });
+
+  it("play() rejection resets the button to the play icon", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const spinner = document.getElementById("spinner");
+    const play = document.getElementById("play");
+    const pause = document.getElementById("pause");
+
+    // Override the play mock to reject (autoplay blocked)
+    vi.mocked(HTMLMediaElement.prototype.play).mockRejectedValueOnce(
+      new DOMException("NotAllowedError", "NotAllowedError")
+    );
+
+    // Call play() — the rejection is caught internally
+    await elem.play();
+
+    // After rejection: spinner hidden, play icon visible, pause hidden
+    expect(spinner?.style.display, document.body.innerHTML).toBe("none");
+    expect(play?.style.display, document.body.innerHTML).toBe("block");
+    expect(pause?.style.display, document.body.innerHTML).toBe("none");
+
+    // Internal state must be consistent
+    expect(elem.isPlaying()).toBe(false);
+  });
 });

--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -1,4 +1,4 @@
-import { MusicControls } from "../ts/MusicControls";
+﻿import { MusicControls } from "../ts/MusicControls";
 import config from "../ts/config";
 import { processLilypond, barCount } from "../ts/lily";
 
@@ -377,6 +377,7 @@ describe("MusicControls custom element", () => {
     expect(changeResult).toBe(true);
   });
 
+
   it("adds control class to all interactive elements (#182)", () => {
     expect(
       document.getElementById("playpausebutton")?.classList.contains("control")
@@ -447,5 +448,94 @@ describe("MusicControls custom element", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(elem.bar).toBe(0);
     expect(bar.value).toBe("0");
+
+  it("calling play() while already playing does not start a duplicate rAF loop", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+
+    // Capture all requestAnimationFrame callbacks
+    const rafCallbacks: Array<(time: number) => void> = [];
+    const originalRAF = window.requestAnimationFrame;
+    window.requestAnimationFrame = (callback: (time: number) => void) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    };
+
+    // Start playback (schedules the first loop)
+    const waitingForPlay = waitForEvent(
+      elem,
+      "music-controls-playing",
+      handleAudioStarted
+    );
+    elem.setAttribute("playing", "true");
+    await waitingForPlay;
+
+    // Call play() again, as setChoir/setPart/setRecording would
+    await elem.play();
+
+    // Count music-controls-changed events when running captured callbacks
+    let _eventCount = 0;
+    const countListener = () => {
+      _eventCount++;
+    };
+    elem.addEventListener("music-controls-changed", countListener);
+
+    // Run each captured callback once
+    rafCallbacks.forEach((cb) => cb(0));
+
+    // Before the fix: two loops fire, so two events
+    // After the fix: one loop fires, so one event
+    expect(_eventCount).toBe(1);
+
+    // Cleanup
+    elem.removeEventListener("music-controls-changed", countListener);
+    window.requestAnimationFrame = originalRAF;
+  });
+
+  it("pausing after duplicate play() clears all loops without zombies", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+
+    const rafCallbacks: Array<(time: number) => void> = [];
+    const originalRAF = window.requestAnimationFrame;
+    window.requestAnimationFrame = (callback: (time: number) => void) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    };
+
+    // Start playback and duplicate the loop
+    const waitingForPlay = waitForEvent(
+      elem,
+      "music-controls-playing",
+      handleAudioStarted
+    );
+    elem.setAttribute("playing", "true");
+    await waitingForPlay;
+    await elem.play();
+
+    // Pause
+    const waitingForPause = waitForEvent(
+      elem,
+      "music-controls-paused",
+      handleAudioStarted
+    );
+    elem.pause();
+    await waitingForPause;
+
+    // Run all captured callbacks that were scheduled before or during pause
+    const callbacksBeforeRun = rafCallbacks.length;
+    let _eventCount = 0;
+    const countListener = () => {
+      _eventCount++;
+    };
+    elem.addEventListener("music-controls-changed", countListener);
+    rafCallbacks.forEach((cb) => cb(0));
+
+    // After pause, no loop should reschedule itself, so the callback count
+    // should not grow beyond what existed before the run
+    expect(rafCallbacks.length).toBe(callbacksBeforeRun);
+    expect(elem.isPlaying()).toBe(false);
+
+    elem.removeEventListener("music-controls-changed", countListener);
+    window.requestAnimationFrame = originalRAF;
+
   });
 });

--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -448,6 +448,7 @@ describe("MusicControls custom element", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(elem.bar).toBe(0);
     expect(bar.value).toBe("0");
+  });
 
   it("calling play() while already playing does not start a duplicate rAF loop", async () => {
     const elem = document.querySelector("music-controls") as MusicControls;

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -221,7 +221,17 @@ export class MusicControls extends MusicElement {
       this.audio.currentTime = getTimeFromBar(this.bar, this.recording);
     }
 
-    await this.audio.play();
+    try {
+      await this.audio.play();
+    } catch {
+      if (this.svgPlay && this.svgLoading && this.svgPause) {
+        this.svgPlay.style.display = "block";
+        this.svgPause.style.display = "none";
+        this.svgLoading.style.display = "none";
+      }
+      this.playing = false;
+      return;
+    }
 
     this.playing = true;
     if (this.svgPlay && this.svgLoading && this.svgPause) {

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -22,6 +22,8 @@ export class MusicControls extends MusicElement {
   svgPlay: SVGElement | null = null;
   svgPause: SVGElement | null = null;
 
+  #isLooping = false;
+
   constructor() {
     super();
   }
@@ -229,6 +231,9 @@ export class MusicControls extends MusicElement {
     }
     this.fireEvent("music-controls-playing");
 
+    if (this.#isLooping) return;
+    this.#isLooping = true;
+
     const self = this;
 
     function loop() {
@@ -242,6 +247,8 @@ export class MusicControls extends MusicElement {
 
       if (self.isPlaying()) {
         window.requestAnimationFrame(loop);
+      } else {
+        self.#isLooping = false;
       }
     }
     window.requestAnimationFrame(loop);
@@ -249,6 +256,7 @@ export class MusicControls extends MusicElement {
 
   pause() {
     this.playing = false;
+    this.#isLooping = false;
     if (this.svgPlay && this.svgLoading && this.svgPause) {
       this.svgPlay.style.display = "block";
       this.svgPause.style.display = "none";


### PR DESCRIPTION
This PR now bundles fixes for both #179 and #180.

- #179: Prevent duplicate rAF loop when changing choir during playback
- #180: Reset loading spinner when audio.play() is rejected (autoplay blocked)

Both fixes touch MusicControls.ts and controls.test.ts, so bundling prevents merge conflicts.