### PR TITLE
fix: Reset loading spinner when audio.play() is rejected (#180)

### DIFF
--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -377,7 +377,6 @@ describe("MusicControls custom element", () => {
     expect(changeResult).toBe(true);
   });
 
-<<<<<<< HEAD
   it("adds control class to all interactive elements (#182)", () => {
     expect(
       document.getElementById("playpausebutton")?.classList.contains("control")

--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -377,6 +377,7 @@ describe("MusicControls custom element", () => {
     expect(changeResult).toBe(true);
   });
 
+<<<<<<< HEAD
   it("adds control class to all interactive elements (#182)", () => {
     expect(
       document.getElementById("playpausebutton")?.classList.contains("control")
@@ -447,5 +448,28 @@ describe("MusicControls custom element", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(elem.bar).toBe(0);
     expect(bar.value).toBe("0");
+  });
+
+  it("play() rejection resets the button to the play icon", async () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const spinner = document.getElementById("spinner");
+    const play = document.getElementById("play");
+    const pause = document.getElementById("pause");
+
+    // Override the play mock to reject (autoplay blocked)
+    vi.mocked(HTMLMediaElement.prototype.play).mockRejectedValueOnce(
+      new DOMException("NotAllowedError", "NotAllowedError")
+    );
+
+    // Call play() — the rejection is caught internally
+    await elem.play();
+
+    // After rejection: spinner hidden, play icon visible, pause hidden
+    expect(spinner?.style.display, document.body.innerHTML).toBe("none");
+    expect(play?.style.display, document.body.innerHTML).toBe("block");
+    expect(pause?.style.display, document.body.innerHTML).toBe("none");
+
+    // Internal state must be consistent
+    expect(elem.isPlaying()).toBe(false);
   });
 });

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -219,7 +219,17 @@ export class MusicControls extends MusicElement {
       this.audio.currentTime = getTimeFromBar(this.bar, this.recording);
     }
 
-    await this.audio.play();
+    try {
+      await this.audio.play();
+    } catch {
+      if (this.svgPlay && this.svgLoading && this.svgPause) {
+        this.svgPlay.style.display = "block";
+        this.svgPause.style.display = "none";
+        this.svgLoading.style.display = "none";
+      }
+      this.playing = false;
+      return;
+    }
 
     this.playing = true;
     if (this.svgPlay && this.svgLoading && this.svgPause) {


### PR DESCRIPTION
Wraps audio.play() in try/catch so that when the browser blocks autoplay or the network fails, the loading spinner is reset to the play icon instead of staying stuck indefinitely.

- On rejection: hides spinner and pause icon, shows play icon, sets playing false.
- No user-visible error message or retry logic (out of scope per ticket).

Includes a unit test that mocks HTMLMediaElement.prototype.play to reject with DOMException('NotAllowedError') and asserts the UI returns to the play state.

Related to #180
