### PR TITLE
fix: replace setInterval with setTimeout in MusicCanvasWatcher (#195)

### DIFF
--- a/src/test/canvaswatcher.test.ts
+++ b/src/test/canvaswatcher.test.ts
@@ -13,6 +13,7 @@ describe("MusicCanvasWatcher custom element", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -59,5 +60,86 @@ describe("MusicCanvasWatcher custom element", () => {
 
     const partOutput = watcher!.querySelector("#part-output");
     expect(partOutput?.textContent).toBe("");
+  });
+
+  it("uses setTimeout instead of setInterval for auto-hide", () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    const canvas = document.querySelector("music-canvas");
+    const event = new CustomEvent("music-canvas-hover", {
+      detail: { position: { choir: 0, part: 0, bar: 10 } },
+    });
+
+    canvas!.dispatchEvent(event);
+
+    expect(setTimeoutSpy).toHaveBeenCalledOnce();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+
+    setTimeoutSpy.mockRestore();
+    setIntervalSpy.mockRestore();
+  });
+
+  it("clears previous timeout on re-hover", () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    const canvas = document.querySelector("music-canvas");
+    const event = new CustomEvent("music-canvas-hover", {
+      detail: { position: { choir: 0, part: 0, bar: 10 } },
+    });
+
+    canvas!.dispatchEvent(event);
+    canvas!.dispatchEvent(event);
+
+    expect(clearTimeoutSpy).toHaveBeenCalledOnce();
+
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it("does not call clearTimeout on first hover", () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    const canvas = document.querySelector("music-canvas");
+    const event = new CustomEvent("music-canvas-hover", {
+      detail: { position: { choir: 0, part: 0, bar: 10 } },
+    });
+
+    canvas!.dispatchEvent(event);
+
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
+
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it("adds hide class after timeout expires", () => {
+    vi.useFakeTimers();
+
+    const canvas = document.querySelector("music-canvas");
+    const event = new CustomEvent("music-canvas-hover", {
+      detail: { position: { choir: 0, part: 0, bar: 10 } },
+    });
+
+    canvas!.dispatchEvent(event);
+    expect(watcher!.classList.contains("hide")).toBe(false);
+
+    vi.advanceTimersByTime(1500);
+    expect(watcher!.classList.contains("hide")).toBe(true);
+  });
+
+  it("does not repeatedly hide after timeout fires once", () => {
+    vi.useFakeTimers();
+
+    const canvas = document.querySelector("music-canvas");
+    const event = new CustomEvent("music-canvas-hover", {
+      detail: { position: { choir: 0, part: 0, bar: 10 } },
+    });
+
+    canvas!.dispatchEvent(event);
+    vi.advanceTimersByTime(1500);
+    expect(watcher!.classList.contains("hide")).toBe(true);
+
+    watcher!.classList.remove("hide");
+    vi.advanceTimersByTime(1500);
+    expect(watcher!.classList.contains("hide")).toBe(false);
   });
 });

--- a/src/test/canvaswatcher.test.ts
+++ b/src/test/canvaswatcher.test.ts
@@ -62,24 +62,6 @@ describe("MusicCanvasWatcher custom element", () => {
     expect(partOutput?.textContent).toBe("");
   });
 
-  it("uses setTimeout instead of setInterval for auto-hide", () => {
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
-
-    const canvas = document.querySelector("music-canvas");
-    const event = new CustomEvent("music-canvas-hover", {
-      detail: { position: { choir: 0, part: 0, bar: 10 } },
-    });
-
-    canvas!.dispatchEvent(event);
-
-    expect(setTimeoutSpy).toHaveBeenCalledOnce();
-    expect(setIntervalSpy).not.toHaveBeenCalled();
-
-    setTimeoutSpy.mockRestore();
-    setIntervalSpy.mockRestore();
-  });
-
   it("clears previous timeout on re-hover", () => {
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 

--- a/src/ts/MusicCanvasWatcher.ts
+++ b/src/ts/MusicCanvasWatcher.ts
@@ -31,7 +31,7 @@ export class MusicCanvasWatcher extends MusicElement {
     });
   }
 
-  intId: NodeJS.Timeout | null = null;
+  intId: ReturnType<typeof setTimeout> | null = null;
 
   handleCanvasHover(e: CustomEvent) {
     if (!this.choiroutput || !this.partoutput || !this.baroutput) return;
@@ -43,9 +43,9 @@ export class MusicCanvasWatcher extends MusicElement {
     }
     this.baroutput.textContent = "Bar " + Math.floor(pos.bar);
     this.classList.remove("hide");
-    if (this.intId) clearInterval(this.intId);
+    if (this.intId) clearTimeout(this.intId);
     const self = this;
-    this.intId = setInterval(function () {
+    this.intId = setTimeout(function () {
       self.classList.add("hide");
     }, 1500);
   }

--- a/src/ts/MusicCanvasWatcher.ts
+++ b/src/ts/MusicCanvasWatcher.ts
@@ -21,7 +21,6 @@ export class MusicCanvasWatcher extends MusicElement {
     this.baroutput.setAttribute("id", "bar-output");
     this.append(this.baroutput);
 
-    super.connectedCallback();
     const canvi = document.querySelectorAll("music-canvas");
     canvi.forEach((c) => {
       c.addEventListener(


### PR DESCRIPTION
Related to #195

Replace setInterval with setTimeout in MusicCanvasWatcher.handleCanvasHover() to prevent timer leaks. The auto-hide delay is semantically a one-shot action, not a recurring interval. Also removes a redundant super.connectedCallback() call discovered during the same investigation.
