### PR TITLE
fix: correct spelling of 'nunquam' in help title (#207)

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         </header>
 
         <div id="help">
-            <p><em>Spem in alium nuquam habui</em><br />Thomas Tallis (1505 - 1585)
+            <p><em>Spem in alium nunquam habui</em><br />Thomas Tallis (1505 - 1585)
             <table>
                 <tr>
                     <th>Mouse</th>


### PR DESCRIPTION
Fixes #207

Corrects the Latin title spelling in the help panel from "nuquam" to "nunquam", matching the LilyPond source (`src/lilypond/Hugh Keyte/basic.ly`).
