### PR TITLE
docs: Add MIT license exclusions and copyright headers (#216)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,16 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+This license applies to the software source code in this repository
+(TypeScript, HTML, CSS, shell scripts, and build configuration).
+It does NOT apply to:
+
+- Audio recordings in public/audio/ (licensed separately by their
+  respective copyright holders).
+- Generated musical scores in src/scores/ (derived from editorial
+  editions with their own copyright status).
+- Lilypond source files in src/lilypond/ (see individual files for
+  attribution).

--- a/README.md
+++ b/README.md
@@ -72,4 +72,17 @@ Shortcuts are ignored when focus is on an input field or `<select>` element.
 
 ## Licence
 
-MIT. See `LICENSE`.
+The software source code in this repository (TypeScript, HTML, CSS, shell scripts,
+and build configuration) is licensed under the MIT Licence. See `LICENSE` for
+the full text.
+
+This licence does **not** apply to:
+
+- **Audio recordings** in `public/audio/` — licensed separately by their
+  respective copyright holders (Andrew Leslie Cooper and Choir of the Earth).
+- **Musical scores** in `src/scores/` — derived from editorial editions with
+  their own copyright status.
+- **Lilypond source files** in `src/lilypond/` — see individual files for
+  attribution.
+
+Score and audio licensing is tracked in ticket #217.

--- a/build/buildAllScores.sh
+++ b/build/buildAllScores.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) 2024 Mark Wainwright
+# SPDX-License-Identifier: MIT
 set -euo pipefail
 
 echo "$(date): Building all scores..."

--- a/build/buildScore.sh
+++ b/build/buildScore.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) 2024 Mark Wainwright
+# SPDX-License-Identifier: MIT
 set -euo pipefail
 
 if [ $# -eq 0 ] || [ ! -f "$1" ]; then

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import "./src/scss/style.scss";
 
 import config from "./src/ts/config";

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import config from "./config";
 import { PartType, Position, colors } from "./common";
 import { MusicElement } from "./MusicElement";

--- a/src/ts/MusicCanvasWatcher.ts
+++ b/src/ts/MusicCanvasWatcher.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import config from "./config";
 import { MusicElement } from "./MusicElement";
 

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import config from "./config";
 import { getBarFromTime, getTimeFromBar } from "./common";
 import { MusicElement } from "./MusicElement";

--- a/src/ts/MusicElement.ts
+++ b/src/ts/MusicElement.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import config from "./config";
 import { PartType, Position, toNum } from "./common";
 

--- a/src/ts/MusicScore.ts
+++ b/src/ts/MusicScore.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import config from "./config";
 import { colors, toNum } from "./common";
 

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import config from "./config";
 
 export type PartType = "all" | number;

--- a/src/ts/config.ts
+++ b/src/ts/config.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 export default {
   parts: ["Soprano", "Alto", "Tenor", "Baritone", "Bass"],
   scores: ["modern", "early"],

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 import config from "./config";
 import lyGrammar from "../ohmjs/ly-grammar.ohm-bundle";
 import * as ohm from "ohm-js";

--- a/src/ts/music-classes.ts
+++ b/src/ts/music-classes.ts
@@ -1,3 +1,6 @@
+// Copyright (c) 2024 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
 export class Duration {
   duration: string;
   dotted: string;


### PR DESCRIPTION
Adds explicit exclusions for non-code assets (audio recordings and musical scores) to the MIT licence, expands the README licensing section, and adds SPDX copyright headers to all core source files and build scripts.

**Changes:**

- LICENSE — added exclusion paragraph clarifying that MIT does not cover audio or scores
- README.md — expanded Licence section with explicit asset exclusions
- src/ts/*.ts (9 files) — added // Copyright (c) 2024 Mark Wainwright // SPDX-License-Identifier: MIT headers
- uild/*.sh (2 files) — added bash comment headers (preserving shebang on line 1)
- index.ts — added copyright header

**Verification:**

- scripts/verify_headers.py confirms all core files have headers and generated files do not
- eslint passes
- 	sc --noEmit passes
- 
px vite build passes

Fixes #216