### PR TITLE
Update documentation for main-only workflow

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -109,8 +109,12 @@ Specification depth matches ticket difficulty. Use the template that fits:
   [XS / S template](Specification-Template-XS-S).
 - **M / L** — structural changes, new features, and cross-file refactors. See
   the [M / L template](Specification-Template-M-L).
+- **Architectural** — repository restructuring, build pipeline changes,
+  technology choices, dependency migrations, and decisions about data ownership
+  or copyright. See the
+  [Architectural template](Specification-Template-Architectural).
 
-Both templates require the same rigour. An XS ticket needs precise root cause
+All templates require the same rigour. An XS ticket needs precise root cause
 and test plan, not a twelve-section dissertation.
 
 A well-formed ticket body contains:
@@ -146,7 +150,7 @@ A well-formed ticket body contains:
    ```
 
 5. Commit with a clear message referencing the ticket number.
-6. Push to your fork.
+6. Push to origin (Mark's repository).
 7. Open a PR to `origin/main`.
 8. Include `See #NNN` or `Fixes #NNN` in the PR description to link it to the
    board item. `Fixes` will close the ticket automatically when the PR merges
@@ -158,15 +162,20 @@ A well-formed ticket body contains:
 
 - **Board columns:** `Todo`, `In Progress`, `Review`, `Done`.
 - **`Specified` is a label, not a column.** Tickets stay in `Todo` after specification; the `specified` label indicates readiness.
-- **Auto-close keywords:** PR descriptions may use `Fixes #NNN` or `See #NNN`. Because PRs merge to `main` (the default branch), `Fixes` will close the ticket on merge.
+- **Auto-close keywords:** PR descriptions may use `Fixes #NNN`, `Closes #NNN`,
+  `Resolves #NNN`, or `See #NNN`. `Fixes`, `Closes`, and `Resolves` close the
+  ticket on merge; `See` links the PR without closing.
 - **Stale-PR checks:** the startup routine now reports any open PR with `CHANGES_REQUESTED`.
-- **Linked pull requests:** the board displays linked PRs automatically when `See #NNN` is used.
+- **Linked pull requests:** Both `Fixes #NNN` and `See #NNN` link the PR to the
+  board item automatically. The difference is that `Fixes` also closes the issue
+  on merge; `See` does not.
 
 #### What you do when you receive a PR
 
 - **Approve and merge** - Submit `Approve` review, merge PR to `main` - Move ticket from `Review` to `Done`
 - **Request changes** - Submit `Request changes` review - Leave ticket in `Review`; author will push fixes to the same branch
-- **Reject / close without merge** - Close the PR - Move ticket back to `In Progress` or `Todo` and tell the author why
+- **Reject / close without merge** - Close the PR and leave a review comment or
+  PR comment explaining why. Move ticket back to `In Progress` or `Todo`.
 - **Merge conflicts** - Leave a PR comment - Leave ticket in `Review`; author will rebase and push
 
 **Do not close a PR and ask for a new one.** Keep the same PR open and request changes. Closing destroys the conversation history.

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -65,9 +65,15 @@ Mark's kanban workflow with explicit entry and exit criteria:
 ### Branching
 
 - `main` — production branch.
-- Feature branches are created from `upstream/main` (fork contributors) or from `main` (direct collaborators).
+- Feature branches are created from `origin/main`.
 
-Pull requests from forks target `upstream/main`.
+**Branch naming convention:** `andrew/<ticket-number>-short-description`.
+This makes ownership clear and traces the branch back to its ticket.
+
+**Do not use a fork.** Push feature branches directly to `wainwmr/spem-player`
+(Mark's repository). Pull requests are opened from branches inside the main
+repository, not from a fork. This avoids Netlify's external-contributor approval
+gate and enables automatic deploy previews.
 
 ### Ticket Lifecycle
 
@@ -121,7 +127,7 @@ A well-formed ticket body contains:
 
 ### Pull Request Process
 
-1. Create a feature branch from `upstream/main`.
+1. Create a feature branch from `origin/main`.
 2. Make your changes, add tests, and update documentation.
 3. Ensure tests pass:
 
@@ -141,7 +147,7 @@ A well-formed ticket body contains:
 
 5. Commit with a clear message referencing the ticket number.
 6. Push to your fork.
-7. Open a PR to `upstream/main`.
+7. Open a PR to `origin/main`.
 8. Include `See #NNN` or `Fixes #NNN` in the PR description to link it to the
    board item. `Fixes` will close the ticket automatically when the PR merges
    to `main`.


### PR DESCRIPTION
Fixes #258

This PR completes the documentation updates for the main-only workflow.

## What Mark already merged (thank you)

- Deleted WORKFLOW-TRANSITION-PLAN.md.
- Fixed duplicate LilyPond prerequisite in BUILD.md.
- Updated auto-close wording to allow Fixes.

## What this PR adds

1. **Branch naming convention** (`andrew/<ticket>-description`) and clear guidance to push branches directly to Mark's repository instead of using a fork. This avoids Netlify's external-contributor approval gate.
2. **Remote reference updates** throughout CONTRIBUTING.md (origin/main instead of upstream/main).
3. **Architectural specification template** alongside XS/S and M/L.
4. **Complete auto-close keyword list** (Fixes, Closes, Resolves, See).
5. **Accurate board linking note** — both Fixes and See create board links automatically.
6. **Rejection communication mechanism** — specify leaving a review comment or PR comment when rejecting a PR.
