### PR TITLE
fix: help panel overlaps header

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -47,6 +47,23 @@ test.describe("Spem Player smoke tests", () => {
     await expect(backdrop).toBeHidden();
   });
 
+  test("help panel does not overlap header (#249)", async ({ page }) => {
+    await page.goto("/");
+
+    const help = page.locator("#help");
+    const header = page.locator("header");
+
+    await page.locator("#info").click();
+    await expect(help).toBeVisible();
+
+    const helpBox = await help.boundingBox();
+    const headerBox = await header.boundingBox();
+
+    expect(helpBox).not.toBeNull();
+    expect(headerBox).not.toBeNull();
+    expect(helpBox!.y).toBeGreaterThanOrEqual(headerBox!.y + headerBox!.height);
+  });
+
   test("URL parameters initialise state", async ({ page }) => {
     await page.goto("/?choir=3&part=2&bar=10");
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -202,6 +202,7 @@ header {
   border: 2px solid var(--color-border);
   border-radius: 10px;
   position: absolute;
+  top: 50px;
   background: var(--color-background-lighter);
   max-width: 80%;
   left: 10%;


### PR DESCRIPTION
﻿Adds 	op: 50px to the #help panel in src/scss/style.scss to prevent it from overlapping the header when opened.

Includes a Playwright e2e test that verifies the help panel's bounding box does not overlap the header bounding box.

Fixes #249
