### PR TITLE
feat: add Ctrl/Cmd+B shortcut to focus bar input field (#95)

### DIFF
--- a/e2e/keyboard-bar-jump.spec.ts
+++ b/e2e/keyboard-bar-jump.spec.ts
@@ -29,9 +29,7 @@ test.describe("Alt+B bar jump keyboard shortcut", () => {
     await expect(barInput).not.toBeFocused();
   });
 
-  test("focus returns to the previously focused element after Enter", async ({
-    page,
-  }) => {
+  test("focus returns to the play button after Enter", async ({ page }) => {
     await page.goto("/");
 
     const playButton = page.locator("#playpausebutton");
@@ -47,6 +45,25 @@ test.describe("Alt+B bar jump keyboard shortcut", () => {
     await barInput.press("Enter");
 
     await expect(playButton).toBeFocused();
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("focus returns to the canvas after Enter", async ({ page }) => {
+    await page.goto("/");
+
+    const canvas = page.locator("music-canvas");
+    const barInput = page.locator("#bar-field");
+
+    await canvas.click();
+    await expect(canvas).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("10");
+    await barInput.press("Enter");
+
+    await expect(canvas).toBeFocused();
     await expect(barInput).not.toBeFocused();
   });
 

--- a/e2e/keyboard-bar-jump.spec.ts
+++ b/e2e/keyboard-bar-jump.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Alt+B bar jump keyboard shortcut", () => {
-  test("Alt+B focuses the bar input", async ({ page }) => {
+  test("Alt+B focuses the bar input from document body", async ({ page }) => {
     await page.goto("/");
 
     const barInput = page.locator("#bar-field");
@@ -11,7 +11,7 @@ test.describe("Alt+B bar jump keyboard shortcut", () => {
     await expect(barInput).toBeFocused();
   });
 
-  test("typing bar number and Enter changes bar and returns focus", async ({
+  test("typing bar number and Enter changes bar and returns focus to body", async ({
     page,
   }) => {
     await page.goto("/");
@@ -67,7 +67,26 @@ test.describe("Alt+B bar jump keyboard shortcut", () => {
     await expect(barInput).not.toBeFocused();
   });
 
-  test("Alt+B works when a control input is focused", async ({ page }) => {
+  test("focus returns to the score after Enter", async ({ page }) => {
+    await page.goto("/");
+
+    const score = page.locator("music-score");
+    const barInput = page.locator("#bar-field");
+
+    await score.click();
+    await expect(score).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("15");
+    await barInput.press("Enter");
+
+    await expect(score).toBeFocused();
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("focus returns to the choir select after Enter", async ({ page }) => {
     await page.goto("/");
 
     const choirSelect = page.locator("#choir-select");
@@ -77,7 +96,112 @@ test.describe("Alt+B bar jump keyboard shortcut", () => {
     await expect(choirSelect).toBeFocused();
 
     await page.keyboard.press("Alt+b");
-
     await expect(barInput).toBeFocused();
+
+    await barInput.fill("20");
+    await barInput.press("Enter");
+
+    await expect(choirSelect).toBeFocused();
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("focus returns to the part select after Enter", async ({ page }) => {
+    await page.goto("/");
+
+    const partSelect = page.locator("#part-select");
+    const barInput = page.locator("#bar-field");
+
+    await partSelect.focus();
+    await expect(partSelect).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("30");
+    await barInput.press("Enter");
+
+    await expect(partSelect).toBeFocused();
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("Alt+B re-focuses bar input and selects text when already focused", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const barInput = page.locator("#bar-field");
+
+    await barInput.focus();
+    await barInput.fill("5");
+    await expect(barInput).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    // After Alt+B, the text should be selected. Typing a new value should replace it.
+    await barInput.fill("35");
+    await barInput.press("Enter");
+
+    const controls = page.locator("music-controls");
+    await expect(controls).toHaveAttribute("bar", "35");
+  });
+
+  test("focus returns to the dark switch after Enter", async ({ page }) => {
+    await page.goto("/");
+
+    const darkSwitch = page.locator("#darkswitch");
+    const barInput = page.locator("#bar-field");
+
+    await darkSwitch.click();
+    await expect(darkSwitch).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("40");
+    await barInput.press("Enter");
+
+    await expect(darkSwitch).toBeFocused();
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("focus returns to the score switch after Enter", async ({ page }) => {
+    await page.goto("/");
+
+    const scoreSwitch = page.locator("#scoreswitch");
+    const barInput = page.locator("#bar-field");
+
+    await scoreSwitch.click();
+    await expect(scoreSwitch).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("45");
+    await barInput.press("Enter");
+
+    await expect(scoreSwitch).toBeFocused();
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("focus returns to the recording switch after Enter", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const recordingSwitch = page.locator("#recordingswitch");
+    const barInput = page.locator("#bar-field");
+
+    await recordingSwitch.click();
+    await expect(recordingSwitch).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("55");
+    await barInput.press("Enter");
+
+    await expect(recordingSwitch).toBeFocused();
+    await expect(barInput).not.toBeFocused();
   });
 });

--- a/e2e/keyboard-bar-jump.spec.ts
+++ b/e2e/keyboard-bar-jump.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Alt+B bar jump keyboard shortcut", () => {
+  test("Alt+B focuses the bar input", async ({ page }) => {
+    await page.goto("/");
+
+    const barInput = page.locator("#bar-field");
+
+    await page.keyboard.press("Alt+b");
+
+    await expect(barInput).toBeFocused();
+  });
+
+  test("typing bar number and Enter changes bar and returns focus", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const controls = page.locator("music-controls");
+    const barInput = page.locator("#bar-field");
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("50");
+    await barInput.press("Enter");
+
+    await expect(controls).toHaveAttribute("bar", "50");
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("focus returns to the previously focused element after Enter", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const playButton = page.locator("#playpausebutton");
+    const barInput = page.locator("#bar-field");
+
+    await playButton.focus();
+    await expect(playButton).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+    await expect(barInput).toBeFocused();
+
+    await barInput.fill("25");
+    await barInput.press("Enter");
+
+    await expect(playButton).toBeFocused();
+    await expect(barInput).not.toBeFocused();
+  });
+
+  test("Alt+B works when a control input is focused", async ({ page }) => {
+    await page.goto("/");
+
+    const choirSelect = page.locator("#choir-select");
+    const barInput = page.locator("#bar-field");
+
+    await choirSelect.focus();
+    await expect(choirSelect).toBeFocused();
+
+    await page.keyboard.press("Alt+b");
+
+    await expect(barInput).toBeFocused();
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -237,11 +237,19 @@ function keyboardTapped(e: KeyboardEvent) {
         controls.pause();
         setBar(canvas.seek(current, -1));
         break;
+      default:
+        break;
+    }
+    return;
+  }
+  if (e.altKey) {
+    switch (e.code) {
       case "KeyB": {
         const barInput = document.getElementById(
           "bar-field"
         ) as HTMLInputElement;
         if (barInput) {
+          controls.pause();
           controls.setReturnFocus(document.activeElement);
           barInput.focus();
           barInput.select();

--- a/index.ts
+++ b/index.ts
@@ -237,6 +237,17 @@ function keyboardTapped(e: KeyboardEvent) {
         controls.pause();
         setBar(canvas.seek(current, -1));
         break;
+      case "KeyB": {
+        const barInput = document.getElementById(
+          "bar-field"
+        ) as HTMLInputElement;
+        if (barInput) {
+          controls.setReturnFocus(document.activeElement);
+          barInput.focus();
+          barInput.select();
+        }
+        break;
+      }
       default:
         break;
     }

--- a/index.ts
+++ b/index.ts
@@ -220,7 +220,7 @@ function keyboardTapped(e: KeyboardEvent) {
   // don't handle keyboard events on the four control widgets
   // cos it messes with the UI interaction
   const classes = [...e.target.classList];
-  if (classes.includes("control")) {
+  if (classes.includes("control") && !e.altKey) {
     return;
   }
   // don't handle keyboard events if composing text (chinese characters)
@@ -242,22 +242,24 @@ function keyboardTapped(e: KeyboardEvent) {
     }
     return;
   }
-  if (e.altKey) {
-    switch (e.code) {
-      case "KeyB": {
-        const barInput = document.getElementById(
-          "bar-field"
-        ) as HTMLInputElement;
-        if (barInput) {
-          controls.pause();
-          controls.setReturnFocus(document.activeElement);
-          barInput.focus();
-          barInput.select();
-        }
-        break;
+  if (e.altKey && e.code === "KeyB") {
+    const barInput = document.getElementById(
+      "bar-field"
+    ) as HTMLInputElement;
+    if (barInput) {
+      controls.pause();
+      const active = document.activeElement;
+      if (
+        active &&
+        active !== document.body &&
+        active !== document.documentElement
+      ) {
+        controls.setReturnFocus(active);
+      } else {
+        controls.setReturnFocus(null);
       }
-      default:
-        break;
+      barInput.focus();
+      barInput.select();
     }
     return;
   }

--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,10 @@ recordingswitch.innerHTML = recordingswitchSvg;
 scoreswitch.innerHTML = scoreswitchSvg;
 darkswitch.innerHTML = darkswitchSvg;
 
+recordingswitch.setAttribute("tabindex", "-1");
+scoreswitch.setAttribute("tabindex", "-1");
+darkswitch.setAttribute("tabindex", "-1");
+
 let isDragging = false;
 
 var current: State = {

--- a/index.ts
+++ b/index.ts
@@ -247,6 +247,7 @@ function keyboardTapped(e: KeyboardEvent) {
     return;
   }
   if (e.altKey && e.code === "KeyB") {
+    e.preventDefault();
     const barInput = document.getElementById(
       "bar-field"
     ) as HTMLInputElement;

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from "vitest";
+﻿import { describe, it, expect, beforeAll, vi } from "vitest";
 import { MusicControls } from "../ts/MusicControls";
 
 describe("Space bar play/pause", () => {
@@ -144,7 +144,7 @@ describe("Space bar play/pause", () => {
     expect(document.body.classList.contains("light-theme")).toBe(wasLight);
   });
 
-  it("Ctrl+B focuses the bar input and selects its value", async () => {
+  it("Alt+B focuses the bar input and selects its value", async () => {
     const bar = document.getElementById("bar-field") as HTMLInputElement;
     const selectSpy = vi.spyOn(bar, "select");
 
@@ -152,7 +152,7 @@ describe("Space bar play/pause", () => {
     document.body.dispatchEvent(
       new KeyboardEvent("keydown", {
         code: "KeyB",
-        ctrlKey: true,
+        altKey: true,
         bubbles: true,
       })
     );
@@ -163,7 +163,7 @@ describe("Space bar play/pause", () => {
     selectSpy.mockRestore();
   });
 
-  it("Ctrl+B is blocked when an input element is focused", async () => {
+  it("Alt+B is blocked when an input element is focused", async () => {
     const input = document.createElement("input");
     input.classList.add("control");
     document.body.appendChild(input);
@@ -172,7 +172,7 @@ describe("Space bar play/pause", () => {
     input.dispatchEvent(
       new KeyboardEvent("keydown", {
         code: "KeyB",
-        ctrlKey: true,
+        altKey: true,
         bubbles: true,
       })
     );
@@ -188,11 +188,11 @@ describe("Space bar play/pause", () => {
     document.body.appendChild(previous);
     previous.focus();
 
-    // Ctrl+B to focus bar
+    // Alt+B to focus bar
     previous.dispatchEvent(
       new KeyboardEvent("keydown", {
         code: "KeyB",
-        ctrlKey: true,
+        altKey: true,
         bubbles: true,
       })
     );
@@ -215,18 +215,22 @@ describe("Space bar play/pause", () => {
     document.body.removeChild(previous);
   });
 
-  it("Ctrl+B with Cmd key (metaKey) also focuses bar input", async () => {
+  it("Alt+B pauses playback before focusing bar input", async () => {
+    const controls = document.querySelector("music-controls") as MusicControls;
+    controls.play();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controls.isPlaying()).toBe(true);
+
     document.body.focus();
     document.body.dispatchEvent(
       new KeyboardEvent("keydown", {
         code: "KeyB",
-        metaKey: true,
+        altKey: true,
         bubbles: true,
       })
     );
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const bar = document.getElementById("bar-field") as HTMLInputElement;
-    expect(document.activeElement).toBe(bar);
+    expect(controls.isPlaying()).toBe(false);
   });
 });

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -163,11 +163,13 @@ describe("Space bar play/pause", () => {
     selectSpy.mockRestore();
   });
 
-  it("Alt+B is blocked when an input element is focused", async () => {
+  it("Alt+B focuses bar input even when a control input is focused", async () => {
     const input = document.createElement("input");
     input.classList.add("control");
     document.body.appendChild(input);
     input.focus();
+
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
 
     input.dispatchEvent(
       new KeyboardEvent("keydown", {
@@ -178,7 +180,7 @@ describe("Space bar play/pause", () => {
     );
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(document.activeElement).toBe(input);
+    expect(document.activeElement).toBe(bar);
     document.body.removeChild(input);
   });
 

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -143,4 +143,90 @@ describe("Space bar play/pause", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(document.body.classList.contains("light-theme")).toBe(wasLight);
   });
+
+  it("Ctrl+B focuses the bar input and selects its value", async () => {
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    const selectSpy = vi.spyOn(bar, "select");
+
+    document.body.focus();
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code: "KeyB",
+        ctrlKey: true,
+        bubbles: true,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(document.activeElement).toBe(bar);
+    expect(selectSpy).toHaveBeenCalled();
+    selectSpy.mockRestore();
+  });
+
+  it("Ctrl+B is blocked when an input element is focused", async () => {
+    const input = document.createElement("input");
+    input.classList.add("control");
+    document.body.appendChild(input);
+    input.focus();
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code: "KeyB",
+        ctrlKey: true,
+        bubbles: true,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(document.activeElement).toBe(input);
+    document.body.removeChild(input);
+  });
+
+  it("Enter in bar input returns focus to the previous element", async () => {
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    const previous = document.createElement("button");
+    document.body.appendChild(previous);
+    previous.focus();
+
+    // Ctrl+B to focus bar
+    previous.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code: "KeyB",
+        ctrlKey: true,
+        bubbles: true,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(document.activeElement).toBe(bar);
+
+    // Type and press Enter
+    bar.value = "50";
+    bar.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code: "Enter",
+        key: "Enter",
+        bubbles: true,
+      })
+    );
+    bar.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(document.activeElement).toBe(previous);
+    document.body.removeChild(previous);
+  });
+
+  it("Ctrl+B with Cmd key (metaKey) also focuses bar input", async () => {
+    document.body.focus();
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        code: "KeyB",
+        metaKey: true,
+        bubbles: true,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const bar = document.getElementById("bar-field") as HTMLInputElement;
+    expect(document.activeElement).toBe(bar);
+  });
 });

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { MusicControls } from "../ts/MusicControls";
 
 describe("Space bar play/pause", () => {

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -144,6 +144,22 @@ describe("Space bar play/pause", () => {
     expect(document.body.classList.contains("light-theme")).toBe(wasLight);
   });
 
+  it("Alt+B prevents default to avoid macOS special-character insertion", async () => {
+    const event = new KeyboardEvent("keydown", {
+      code: "KeyB",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+
+    document.body.dispatchEvent(event);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    preventDefaultSpy.mockRestore();
+  });
+
   it("Alt+B focuses the bar input and selects its value", async () => {
     const bar = document.getElementById("bar-field") as HTMLInputElement;
     const selectSpy = vi.spyOn(bar, "select");

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -91,6 +91,7 @@ export class MusicCanvas extends MusicElement {
 
   async connectedCallback() {
     super.connectedCallback();
+    this.setAttribute("tabindex", "-1");
     await this.#init();
   }
 

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -25,6 +25,8 @@ export class MusicControls extends MusicElement {
   svgPlay: SVGElement | null = null;
   svgPause: SVGElement | null = null;
 
+  returnFocusTarget: Element | null = null;
+
   #isLooping = false;
 
   constructor() {
@@ -139,12 +141,25 @@ export class MusicControls extends MusicElement {
         "End",
       ];
       if (allowed.includes(e.key) || /^[0-9]$/.test(e.key)) {
+        if (e.key === "Enter" && this.returnFocusTarget) {
+          const target = this.returnFocusTarget;
+          this.returnFocusTarget = null;
+          setTimeout(() => {
+            if (target instanceof HTMLElement) {
+              target.focus();
+            }
+          }, 0);
+        }
         return;
       }
       e.preventDefault();
     });
     if (this.playpausebutton)
       this.playpausebutton.addEventListener("click", this.playpause.bind(this));
+  }
+
+  setReturnFocus(element: Element | null) {
+    this.returnFocusTarget = element;
   }
 
   async #handleControlsChanged() {

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -135,7 +135,7 @@ export class MusicControls extends MusicElement {
             this.returnFocusTarget = null;
             target.focus();
           } else {
-            this.barinput.blur();
+            this.barinput?.blur();
           }
         }
         return;

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -141,15 +141,6 @@ export class MusicControls extends MusicElement {
         "End",
       ];
       if (allowed.includes(e.key) || /^[0-9]$/.test(e.key)) {
-        if (e.key === "Enter" && this.returnFocusTarget) {
-          const target = this.returnFocusTarget;
-          this.returnFocusTarget = null;
-          setTimeout(() => {
-            if (target instanceof HTMLElement) {
-              target.focus();
-            }
-          }, 0);
-        }
         return;
       }
       e.preventDefault();
@@ -180,6 +171,14 @@ export class MusicControls extends MusicElement {
     }
     this.barinput.value = String(this.bar);
     this.fireEvent("music-controls-changed");
+
+    if (this.returnFocusTarget && document.activeElement === this.barinput) {
+      const target = this.returnFocusTarget;
+      this.returnFocusTarget = null;
+      if (target instanceof HTMLElement) {
+        target.focus();
+      }
+    }
   }
 
   playpause() {

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -127,6 +127,19 @@ export class MusicControls extends MusicElement {
       this.#handleControlsChanged.bind(this)
     );
     this.barinput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        this.#handleControlsChanged();
+        if (document.activeElement === this.barinput) {
+          if (this.returnFocusTarget instanceof HTMLElement) {
+            const target = this.returnFocusTarget;
+            this.returnFocusTarget = null;
+            target.focus();
+          } else {
+            this.barinput.blur();
+          }
+        }
+        return;
+      }
       const allowed = [
         "Backspace",
         "Delete",
@@ -135,7 +148,6 @@ export class MusicControls extends MusicElement {
         "ArrowUp",
         "ArrowDown",
         "Tab",
-        "Enter",
         "Escape",
         "Home",
         "End",
@@ -171,14 +183,6 @@ export class MusicControls extends MusicElement {
     }
     this.barinput.value = String(this.bar);
     this.fireEvent("music-controls-changed");
-
-    if (this.returnFocusTarget && document.activeElement === this.barinput) {
-      const target = this.returnFocusTarget;
-      this.returnFocusTarget = null;
-      if (target instanceof HTMLElement) {
-        target.focus();
-      }
-    }
   }
 
   playpause() {

--- a/src/ts/MusicScore.ts
+++ b/src/ts/MusicScore.ts
@@ -39,6 +39,7 @@ export class MusicScore extends MusicElement {
 
   async connectedCallback() {
     super.connectedCallback();
+    this.setAttribute("tabindex", "-1");
 
     this.highlightPosition.setAttribute("id", "hPos");
     this.highlightPosition.setAttribute("x", "0");


### PR DESCRIPTION
Fixes #95

Adds an `Alt+B` keyboard shortcut that focuses the existing bar input field and selects its current value, allowing the user to type a bar number and jump directly to it.

**Behaviour:**
- `Alt+B` focuses the bar input and selects all text
- The user types a number and hits Enter
- Focus returns to the previously focused element so keyboard navigation (arrow keys, digit keys, etc.) continues to work

**Implementation:**
- `index.ts`: Added Alt+B handler inside `keyboardTapped()` with `e.preventDefault()` to avoid macOS special-character insertion
- `MusicControls.ts`: Added `setReturnFocus()` and focus-return logic on Enter in the bar input
- `keyboard.test.ts`: Added tests covering focus, select, focus-return, pause, and preventDefault
- `e2e/keyboard-bar-jump.spec.ts`: Comprehensive e2e tests for focus return from all interactive elements
