### PR TITLE
fix: parse fraction denominator in LilyPond parser

### DIFF
--- a/src/test/lily.test.ts
+++ b/src/test/lily.test.ts
@@ -164,4 +164,38 @@ describe("lilypond parsing tests", () => {
     expect(frLocations[1].from).toBe(1.0);
     expect(frLocations[1].to).toBe(1.125);
   });
+
+  it("parses fraction with denominator 3/4", () => {
+    const s = setupLilypondParser();
+    const result = lyGrammar.match("3/4", "fraction");
+    expect(result.succeeded()).toBe(true);
+    const value = s(result).parse();
+    expect(value).toBe(0.75);
+  });
+
+  it("parses fraction with denominator 1/2", () => {
+    const s = setupLilypondParser();
+    const result = lyGrammar.match("1/2", "fraction");
+    expect(result.succeeded()).toBe(true);
+    const value = s(result).parse();
+    expect(value).toBe(0.5);
+  });
+
+  it("parses fraction without denominator", () => {
+    const s = setupLilypondParser();
+    const result = lyGrammar.match("2", "fraction");
+    expect(result.succeeded()).toBe(true);
+    const value = s(result).parse();
+    expect(value).toBe(2);
+  });
+
+  it("parses durationScaled with fraction multiplier", () => {
+    const s = setupLilypondParser();
+    const result = lyGrammar.match("4*3/4", "durationScaled");
+    expect(result.succeeded()).toBe(true);
+    const value = s(result).parse() as Duration;
+    expect(value).toBeInstanceOf(Duration);
+    expect(value.multiplier).toBe(0.75);
+    expect(value.sfths).toBe(12);
+  });
 });

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -238,9 +238,13 @@ function setupLilypondParser(): ohm.Semantics {
 
       return new Duration(x.duration, x.dotted, m);
     },
-    fraction(a, _, _2) {
-      // HACK: we're ignoring the denominator altogether.  Let's hope it's not there
-      return parseInt(a.sourceString);
+    fraction(_a, _b, _c) {
+      const text = (this as unknown as ohm.Node).sourceString;
+      if (text.includes("/")) {
+        const [numStr, denStr] = text.split("/");
+        return parseInt(numStr) / parseInt(denStr);
+      }
+      return parseInt(text);
     },
     variable(v) {
       return v.sourceString;


### PR DESCRIPTION
fix: parse fraction denominator in LilyPond parser

The `fraction` semantic action in `lily.ts` was ignoring the denominator, returning only the numerator. This meant durations like `4*3/4` were parsed as `4*3` instead of `4*0.75`.

**Fix:** Use the full matched source string of the fraction rule to parse both numerator and denominator. If a `/` is present, split and divide; otherwise return the integer value.

**Tests added:**
- `parses fraction with denominator 3/4` → 0.75
- `parses fraction with denominator 1/2` → 0.5
- `parses fraction without denominator` → 2
- `parses durationScaled with fraction multiplier` → Duration with sfths = 12

Fixes #100
