### PR TITLE
fix: add @typescript-eslint/no-deprecated rule and remove redundant keyCode check

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,7 @@ export default tseslint.config(
         varsIgnorePattern: '^_',
       }],
       '@typescript-eslint/no-unused-expressions': ['error', { allowTernary: true }],
+      '@typescript-eslint/no-deprecated': 'error',
     },
   },
   {

--- a/index.ts
+++ b/index.ts
@@ -224,7 +224,7 @@ function keyboardTapped(e: KeyboardEvent) {
     return;
   }
   // don't handle keyboard events if composing text (chinese characters)
-  if (e.isComposing || e.keyCode === 229) {
+  if (e.isComposing) {
     return;
   }
   if (e.metaKey || e.ctrlKey) {


### PR DESCRIPTION
Adds `@typescript-eslint/no-deprecated` as an error-level ESLint rule and removes the only existing deprecated usage in the codebase.

**Changes:**
- `eslint.config.js`: add `'@typescript-eslint/no-deprecated': 'error'`
- `index.ts`: remove redundant `e.keyCode === 229` check in `keyboardTapped()`; `isComposing` already covers IME composition in all modern browsers

**Verification:**
- `npm run lint` passes with zero errors and zero warnings
- `npx tsc --noEmit` passes
- Full Vitest suite passes (122/123; one unrelated flaky darkmode test timeout)

Fixes #276
