### PR TITLE
fix: cap Vitest workers at 4 and raise test timeout to 10s

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     exclude: ["e2e/**", "node_modules/**"],
+    maxWorkers: 4,
+    testTimeout: 10000,
     coverage: {
       exclude: [
         "**/*.svg",


### PR DESCRIPTION
## Problem

On machines with 8 logical cores, Vitest spawns 8 fork workers. Every DOM-heavy test file loads the full application via `index.ts` in `beforeAll`, which triggers `processLilypond()`, SVG injection, and Canvas 2D rendering. Eight parallel CPU-bound jsdom processes starve each other, causing non-deterministic timeouts in `canvas.test.ts` and `canvaswatcher.test.ts`.

## Evidence

| Workers | Suite time | Result |
|---|---|---|
| 8 (default) | ~51 s | Timeouts |
| 4 | ~42 s | All 123 tests pass |
| 2 | ~56 s | All 123 tests pass |

Four workers is the sweet spot: faster than 2, reliable where 8 fails.

## Change

Add `maxWorkers: 4` and `testTimeout: 10000` to the Vitest config in `vite.config.ts`.

Closes #215
