### PR TITLE
fix: fire music-score-loaded after score is in the DOM

### DIFF
--- a/src/test/score.test.ts
+++ b/src/test/score.test.ts
@@ -113,35 +113,58 @@ describe("MusicScore custom element", () => {
     ) as SVGRectElement;
     expect(hBar).not.toBeNull(); // highlight has been added
     expect(hBar?.getAttribute("width")).toBe("0"); // but currently invisible
-  });
+  }, 10000);
 
   it("Check all scores have the same number of bars", async () => {
-    const elem = document.querySelector("music-score") as MusicScore;
+    // Create 8 fresh elements so each can load its SVG in parallel
+    document.body.innerHTML = Array.from(
+      { length: config.choirs[0].length },
+      (_, c) => `<music-score id="score-${c}"></music-score>`
+    ).join("");
 
-    elem.scrollTo = vi.fn(); // jsdom doesn't seem to implement HTMLElement.scrollTo()
+    const promises = [];
+    for (let c = 0; c < config.choirs[0].length; c++) {
+      const elem = document.getElementById(`score-${c}`) as MusicScore;
+      elem.scrollTo = vi.fn();
 
-    for (var c = 0; c < config.choirs[0].length; c++) {
-      // wait for score to be loaded
-      const waitingForLoaded = waitForEvent(
-        elem,
-        "music-score-loaded",
-        handleScoreLoaded,
-        0,
-        null,
-        0
+      const loaded = new Promise<void>((resolve) => {
+        elem.addEventListener("music-score-loaded", () => resolve(), {
+          once: true,
+        });
+      });
+
+      elem.setAttribute("choir", String(c));
+
+      promises.push(
+        loaded.then(() => {
+          const svg = elem.querySelector("svg");
+          expect(svg).not.toBeNull();
+
+          expect(elem.bars.length).toBe(139);
+          expect(elem.bars[0]).toBe(0);
+          expect(elem.bars[138]).toBe(elem.svgWidth);
+        })
       );
-      elem?.setAttribute("choir", String(c));
-      const loadResult = await waitingForLoaded;
-      expect(loadResult).toStrictEqual(true);
-
-      const svg = document.querySelector("svg");
-      expect(svg).not.toBeNull();
-
-      expect(elem.bars.length).toBe(139);
-      expect(elem.bars[0]).toBe(0);
-      expect(elem.bars[138]).toBe(elem.svgWidth);
     }
+    await Promise.all(promises);
   }, 20000);
+
+  it("music-score-loaded fires after SVG is in the DOM", async () => {
+    const elem = document.querySelector("music-score") as MusicScore;
+    elem.scrollTo = vi.fn();
+
+    const loaded = new Promise<void>((resolve) => {
+      elem.addEventListener("music-score-loaded", () => resolve(), {
+        once: true,
+      });
+    });
+
+    elem.setAttribute("choir", "0");
+    await loaded;
+
+    expect(elem.querySelector("svg")).not.toBeNull();
+    expect(elem.svg).not.toBeNull();
+  }, 10000);
 
   it("Changing bar sets the highlight correctly", async () => {
     const elem = document.querySelector("music-score") as MusicScore;
@@ -168,7 +191,7 @@ describe("MusicScore custom element", () => {
     expect(elem.highlightBar.getAttribute("width")).not.toBe("0");
     expect(elem.highlightBar.style.fillOpacity).not.toBe("0");
     expect(elem.highlightBar.getAttribute("x")).toBe(String(elem.bars[39]));
-  });
+  }, 10000);
 
   it("Bar 138 highlight uses last bar width", async () => {
     const elem = document.querySelector("music-score") as MusicScore;

--- a/src/ts/MusicScore.ts
+++ b/src/ts/MusicScore.ts
@@ -136,7 +136,6 @@ export class MusicScore extends MusicElement {
       const svgModule = await import(
         `../scores/Hugh Keyte/${this.scoreType}/Choir ${choirName}.svg?raw`
       );
-      this.fireEvent("music-score-loaded");
       return svgModule.default;
     } catch (error) {
       console.error(`Error loading SVG: ${error}`);
@@ -178,6 +177,7 @@ export class MusicScore extends MusicElement {
     // Highlight and scroll to the current bar
     this.highlight();
     this.scrollSmooth();
+    this.fireEvent("music-score-loaded");
   }
 
   async setChoir(c: string | number) {


### PR DESCRIPTION
Fixes #273

Moves `music-score-loaded` event dispatch from `#loadSvg()` to the end of `#loadScore()`, ensuring the event fires only after the SVG is in the DOM, highlights are injected, and bars are extracted.

**Changes:**
- `src/ts/MusicScore.ts`: Event moved from inside `#loadSvg()` to after `scrollSmooth()` in `#loadScore()`
- `src/test/score.test.ts`: 
  - Restructured "Check all scores have the same number of bars" to load all 8 choirs in parallel via `Promise.all`
  - Added focused test verifying `music-score-loaded` fires after SVG is queryable in the DOM
  - Added appropriate timeouts for tests that load SVGs under parallel suite contention

**Test results:**
- Full Vitest suite: 124/124 pass
- Lint: pass
- TypeScript: pass
- Production build: pass
