### PR TITLE
build: add typecheck script and align ci with CI workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build": "npm run format:check && npm run lint && npm run build:ohm && vite build",
     "build:scores": "node build/buildScores.mjs",
     "build:ohm": "npx ohm generateBundles --withTypes src/ohmjs/ly-grammar.ohm",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
@@ -50,7 +51,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
-    "ci": "npm run build && vitest --run && npm run test:e2e",
+    "ci": "npm run typecheck && npm run build && vitest --run && npm run test:e2e",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
Align the local `npm run ci` script with the GitHub Actions CI workflow by adding a `typecheck` step.

**Changes**
- Add `"typecheck": "tsc --noEmit"` to `package.json`
- Update `"ci"` to run `typecheck` before `build`, matching CI order

Fixes #277
