### PR TITLE
ci: bump actions/upload-artifact to v6 for Node.js 24 compatibility (#160)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps
       - run: npx playwright test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: playwright-report


### PR DESCRIPTION
Fixes #160

Bumps `actions/upload-artifact` from v4 to v6 in `.github/workflows/e2e.yml` to resolve the GitHub Actions Node.js 20 deprecation warning.

**Context:**
- `actions/checkout` and `actions/setup-node` were already bumped to v6 in previous commits (`fb81e4f`, `3e9ccaa`).
- `actions/upload-artifact@v4` was the remaining deprecated Node 20 action in the workflow files.
- v6 is the minimum major version that natively targets Node.js 24.

**Verification:**
- Local `npm run build`, `npx tsc --noEmit`, and Vitest suite all pass.
- The e2e workflow will be verified on the next scheduled run after merge.
