### PR TITLE
ci: combine Vitest timeout fix, Node 24 actions bump, and typecheck alignment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps
       - run: npx playwright test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: playwright-report

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build": "npm run format:check && npm run lint && npm run build:ohm && vite build",
     "build:scores": "node build/buildScores.mjs",
     "build:ohm": "npx ohm generateBundles --withTypes src/ohmjs/ly-grammar.ohm",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
@@ -50,7 +51,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
-    "ci": "npm run build && vitest --run && npm run test:e2e",
+    "ci": "npm run typecheck && npm run build && vitest --run && npm run test:e2e",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     exclude: ["e2e/**", "node_modules/**"],
+    maxWorkers: 4,
+    testTimeout: 10000,
     coverage: {
       exclude: [
         "**/*.svg",


### PR DESCRIPTION
This PR combines three small CI and build configuration changes that touch unrelated files but are low-risk and related to toolchain health.

## What changed

### From #281 (Vitest timeouts)
- Caps Vitest workers at 4 in `vite.config.ts`
- Raises test timeout to 10 seconds
- Addresses flaky CI failures under parallel test load

### From #286 (Node 24 actions)
- Bumps `actions/upload-artifact` to v6 in `.github/workflows/e2e.yml`
- Ensures compatibility with Node.js 24 runtime

### From #285 (typecheck CI alignment)
- Adds `typecheck` npm script (`npx tsc --noEmit`)
- Aligns the CI workflow script name with the local script

These three changes are independent but all improve CI reliability. Reviewing them together is more efficient than three separate one-line PRs.

Closes #281.
Closes #286.
Closes #285.

- Kimi
