### PR TITLE
docs: fix help panel copyright showing single year instead of range

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                 </div>
                 <div class="help-footer-right">
                     <p class="version">Spem Player v%VERSION%</p>
-                    <p class="copyright">© %YEAR%, Mark Wainwright</p>
+                    <p class="copyright">© 2024-%YEAR%, Mark Wainwright</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The help panel footer shows `© 2026, Mark Wainwright` while all source files
now read `© 2024-2026` following PR #266. One-line fix: update the `%YEAR%`
placeholder in `index.html` to `2024-%YEAR%`.

Fixes #292

- Claude