### PR TITLE
fix: correct bar clamp maximum from 137 to 139

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -107,7 +107,7 @@ test.describe("Spem Player smoke tests", () => {
 
     await barInput.fill("999");
     await barInput.blur();
-    await expect(controls).toHaveAttribute("bar", "137");
+    await expect(controls).toHaveAttribute("bar", "139");
 
     await barInput.fill("-5");
     await barInput.blur();

--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -421,7 +421,7 @@ describe("MusicControls custom element", () => {
   it("clamps out-of-range bar input to max on change (#184)", async () => {
     const elem = document.querySelector("music-controls") as MusicControls;
     const bar = document.getElementById("bar-field") as HTMLInputElement;
-    const maxBar = barCount > 0 ? barCount - 1 : 0;
+    const maxBar = barCount > 0 ? barCount : 0;
     bar.value = "999";
     bar.dispatchEvent(new Event("change", { bubbles: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/src/test/lily.test.ts
+++ b/src/test/lily.test.ts
@@ -2,6 +2,7 @@ import {
   processLilypond,
   ranges,
   dict,
+  barCount,
   exportedForTesting,
   frLocations,
   detectFalseRelations,
@@ -58,6 +59,7 @@ describe("lilypond parsing tests", () => {
     //assert on the response
     processLilypond();
     expect(dict.length).toBe(139); // bars including bar zero
+    expect(barCount).toBe(139);
     expect(ranges.length).toBe(8); // choirs
     for (var c = 0; c < 8; c++) {
       expect(ranges[c].length).toBe(5);

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -160,7 +160,7 @@ export class MusicControls extends MusicElement {
     } else {
       this.bar = Math.max(0, parsed);
       if (barCount > 0) {
-        this.bar = Math.min(this.bar, barCount - 1);
+        this.bar = Math.min(this.bar, barCount);
       }
     }
     this.barinput.value = String(this.bar);

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -337,7 +337,7 @@ export function processLilypond() {
       }
     }
   }
-  barCount = Math.floor(barCount) - 1;
+  barCount = Math.floor(barCount);
 
   detectFalseRelations(activeNotes);
 }


### PR DESCRIPTION
The bar input was clamping typed values to 137 even though the piece has 140 bars (0..139). Two off-by-one errors compounded:

- `lily.ts` subtracted 1 from `barCount` unnecessarily.
- `MusicControls.ts` clamped to `barCount - 1` instead of `barCount`.

Updated unit and e2e tests to expect max bar 139.

Fixes #315
