### PR TITLE
fix: guard seek() against undefined dict entries

### DIFF
--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -127,6 +127,24 @@ describe("MusicCanvas custom element", () => {
     expect(result).toBeLessThanOrEqual(barCount);
   });
 
+  it("seek() does not throw when dict[intbar] is undefined (#244)", () => {
+    expect(canvas).not.toBeNull();
+    const saved = dict[2];
+    delete dict[2];
+    const pos = { choir: 0, part: "all" as const, bar: 1 };
+    expect(() => canvas!.seek(pos, +1)).not.toThrow();
+    dict[2] = saved;
+  });
+
+  it("seek() backward from bar 1 with empty dict[0] returns 0 (#244)", () => {
+    expect(canvas).not.toBeNull();
+    const saved = dict[0];
+    delete dict[0];
+    const pos = { choir: 0, part: "all" as const, bar: 1 };
+    expect(canvas!.seek(pos, -1)).toBe(0);
+    dict[0] = saved;
+  });
+
   it("canvas click fires music-canvas-click event", async () => {
     expect(canvas).not.toBeNull();
     const promise = new Promise<void>((resolve) => {

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -236,7 +236,7 @@ export class MusicCanvas extends MusicElement {
     while (intbar + direction >= 0 && intbar + direction <= barCount) {
       intbar = intbar + direction;
       const newsinging =
-        this.dict[intbar].filter((x) => x.c == pos.choir).length != 0;
+        (this.dict[intbar] ?? []).filter((x) => x.c == pos.choir).length != 0;
       if (singing !== newsinging) break;
     }
     return intbar;


### PR DESCRIPTION
`seek()` in `MusicCanvas.ts` threw a `TypeError` when advancing through a bar with no notes — accessing `dict[bar]` returned `undefined`, then `.length` on that crashed.

Added a guard so `seek()` skips empty bars cleanly. Added a unit test for the empty-bar case.

Fixes #244
