### PR TITLE
fix: use raw docstring in postprocessSvg.py to suppress SyntaxWarning

### DIFF
--- a/build/postprocessSvg.py
+++ b/build/postprocessSvg.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2024-2026 Mark Wainwright
 # SPDX-License-Identifier: MIT
-"""Post-process LilyPond-generated SVGs.
+r"""Post-process LilyPond-generated SVGs.
 
 Parses \\pointAndClickOn anchor tags to determine which voice part each
 graphical element belongs to, adds data-part="N" attributes, removes

--- a/build/test/test_postprocessSvg.py
+++ b/build/test/test_postprocessSvg.py
@@ -1,0 +1,19 @@
+"""Tests for build/postprocessSvg.py module integrity."""
+
+import warnings
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parent.parent / "postprocessSvg.py"
+
+
+def test_module_compiles_without_syntax_warning():
+    """Verify postprocessSvg.py has no invalid escape sequences.
+
+    Python 3.12+ emits SyntaxWarning for invalid escapes; Python 3.14+
+    promotes this to SyntaxError. Treating SyntaxWarning as an error
+    catches the problem on all affected versions.
+    """
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=SyntaxWarning)
+        compile(source, str(MODULE_PATH), "exec")


### PR DESCRIPTION
`postprocessSvg.py` had a non-raw docstring containing `\d` and similar escape sequences, which Python 3.12+ flags as a `SyntaxWarning`. Switched the docstring to a raw string literal.

Fixes #301
