### PR TITLE
build: exclude .husky/ from knip scan to unblock local npm run ci

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,5 +2,6 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "project": ["src/**/*.ts", "build/**/*.mjs", "*.ts"],
   "entry": ["src/**/*.ts", "build/**/*.mjs"],
-  "ignoreDependencies": ["autoprefixer", "lint-staged"]
+  "ignoreDependencies": ["autoprefixer", "lint-staged"],
+  "ignore": [".husky/**"]
 }


### PR DESCRIPTION
knip was failing on Windows (`Unlisted binaries (1): lint-staged .husky/pre-commit`), breaking local `npm run ci`.

Setting `lint-staged` in `ignoreBinaries` (the originally proposed fix) didn't suppress the warning in practice — knip simultaneously reported the binary as unlisted and hinted that the `ignoreBinaries` entry was redundant.

`ignore: [".husky/**"]` cleanly excludes the husky directory from knip's scan. Local `npm run ci` now exits 0.

Why CI on Linux was already passing while local on Windows wasn't is under separate investigation (Workbench #224); this PR unblocks the agent pre-publish gate regardless.

Fixes #338
