### PR TITLE
fix: quote Helvetica Neue font name and add fallback stack

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -4,7 +4,7 @@ $duration: 1.4s;
 
 html {
   font-size: 14px;
-  font-family: Helvetica neue;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 /* Default colors (dark theme) */


### PR DESCRIPTION
Quotes the previously unquoted Helvetica neue font name and adds a sensible fallback stack (Helvetica, Arial, sans-serif).

Closes #316.