### PR TITLE
fix: parse fraction denominators in lily.ts (#321)

### DIFF
--- a/src/test/lily.test.ts
+++ b/src/test/lily.test.ts
@@ -5,7 +5,8 @@ import {
   detectFalseRelations,
 } from "../ts/lily";
 import type { ActiveNote } from "../ts/lily";
-const { romanise, setupLilypondParser, noteToPitchClass } = exportedForTesting;
+const { romanise, setupLilypondParser, noteToPitchClass, semantics } =
+  exportedForTesting;
 import { Note, Duration } from "../ts/music-classes";
 import * as ohm from "ohm-js";
 import lyGrammar from "../ohmjs/ly-grammar.ohm-bundle";
@@ -48,6 +49,18 @@ describe("lilypond parsing tests", () => {
   it("setupLilypondParser", () => {
     var s = setupLilypondParser();
     expect(s).toBeTruthy();
+  });
+
+  it("fraction multiplier parses with denominator (#321)", () => {
+    const match = lyGrammar.match("3/4", "fraction");
+    expect(match.succeeded()).toBe(true);
+    expect(semantics(match).parse()).toBe(0.75);
+  });
+
+  it("fraction multiplier parses without denominator (#321 regression)", () => {
+    const match = lyGrammar.match("3", "fraction");
+    expect(match.succeeded()).toBe(true);
+    expect(semantics(match).parse()).toBe(3);
   });
 
   it("processLilypond", () => {

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -234,9 +234,13 @@ function setupLilypondParser(): ohm.Semantics {
 
       return new Duration(x.duration, x.dotted, m);
     },
-    fraction(a, _, _2) {
-      // HACK: we're ignoring the denominator altogether.  Let's hope it's not there
-      return parseInt(a.sourceString);
+    fraction(_a, _b, _c) {
+      const text = (this as unknown as ohm.Node).sourceString;
+      if (text.includes("/")) {
+        const [numStr, denStr] = text.split("/");
+        return parseInt(numStr) / parseInt(denStr);
+      }
+      return parseInt(text);
     },
     variable(v) {
       return v.sourceString;


### PR DESCRIPTION
## What

Restore the `fraction()` semantic rule in `src/ts/lily.ts` so that
fractional duration multipliers (e.g. `c4*3/4`) parse to the correct
floating-point value (0.75) instead of just the numerator (3).

## Why

Commit `05e3d0b` (2026-05-15) added this fix. It was accidentally
reverted by PR #175 (commit `451ee0e`) when its feature branch carried
forward an older `lily.ts`. No fractional durations exist in the
current `src/lilypond/Hugh Keyte/*.ly` source, so the bug is **latent**
— but the parser silently produces wrong durations if a fraction is
ever added.

Sibling of #322 (also reverted by PR #175 and just restored in #345).

## Changes

`src/ts/lily.ts:237-244`:

```typescript
fraction(_a, _b, _c) {
  const text = (this as unknown as ohm.Node).sourceString;
  if (text.includes("/")) {
    const [numStr, denStr] = text.split("/");
    return parseInt(numStr) / parseInt(denStr);
  }
  return parseInt(text);
}
```

Removes the `HACK: ignoring the denominator` comment.

## Tests

Two tests in `src/test/lily.test.ts`:

- `fraction multiplier parses with denominator (#321)` — `3/4 → 0.75`.
  Verified failing before the fix, passing after.
- `fraction multiplier parses without denominator (#321 regression)`
  — `3 → 3`. Guards the integer path the new code also touches.

Both use `lyGrammar.match(input, "fraction")` for a focused unit test
of the fraction rule, bypassing the higher-level grammar.

## CI

`npm run ci` passes (152 tests). The one remaining test-file load
failure is `postprocessSvg.test.ts` with a pre-existing Rolldown parse
error, unrelated to this PR and present on main.

Fixes #321

- Claude
