### PR TITLE
fix: disable reuseExistingServer in Playwright config to prevent stale build tests (#239)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,6 @@ export default defineConfig({
   webServer: {
     command: "npm run preview",
     port: 4173,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: false,
   },
 });


### PR DESCRIPTION
Disable `reuseExistingServer` in Playwright configuration to prevent e2e tests from passing against stale builds when a preview server is already running on port 4173.

Fixes #239
