### PR TITLE
fix: handle final boundary in getBarFromTime and getTimeFromBar (#176)

### DIFF
--- a/src/test/common.test.ts
+++ b/src/test/common.test.ts
@@ -50,7 +50,17 @@ describe("common", () => {
 
     result = getBarFromTime(1000, 0);
     expect(result).toBeTypeOf("number");
-    expect(result).toBe(0);
+    expect(result).toBeCloseTo(139);
+  });
+
+  it("getBarFromTime() returns final bar at ALC boundary", () => {
+    const result = getBarFromTime(512, 0);
+    expect(result).toBeCloseTo(139);
+  });
+
+  it("getBarFromTime() returns final bar at CotE boundary", () => {
+    const result = getBarFromTime(540, 1);
+    expect(result).toBeCloseTo(139);
   });
 
   it("getBarFromTime() converts time to bar as expected for CotE audio", () => {
@@ -67,7 +77,7 @@ describe("common", () => {
 
     result = getBarFromTime(1000, 1);
     expect(result).toBeTypeOf("number");
-    expect(result).toBe(0);
+    expect(result).toBeCloseTo(139);
   });
 
   it("getTimeFromBar() converts bar to time as expected for ALC", () => {
@@ -84,7 +94,17 @@ describe("common", () => {
     expect(result).toBeCloseTo(234.3); // ALC
 
     result = getTimeFromBar(140, 0);
-    expect(result).toBe(0);
+    expect(result).toBeCloseTo(512);
+  });
+
+  it("getTimeFromBar() returns final time at ALC boundary", () => {
+    const result = getTimeFromBar(139, 0);
+    expect(result).toBeCloseTo(512);
+  });
+
+  it("getTimeFromBar() returns final time at CotE boundary", () => {
+    const result = getTimeFromBar(139, 1);
+    expect(result).toBeCloseTo(540);
   });
 
   it("getTimeFromBar() converts bar to time as expected for CotE", () => {
@@ -101,7 +121,7 @@ describe("common", () => {
     expect(result).toBeCloseTo(251.631); // CotE
 
     result = getTimeFromBar(140, 1);
-    expect(result).toBe(0);
+    expect(result).toBeCloseTo(540);
   });
 
   it("colors() reads from CSS custom properties when available", () => {

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -92,7 +92,7 @@ export function toNum(
 }
 
 export function getBarFromTime(t: number, v: number = 0) {
-  for (let index = 0; index < config.bartime[v].length; index++) {
+  for (let index = 0; index < config.bartime[v].length - 1; index++) {
     if (t > config.bartime[v][index] && t < config.bartime[v][index + 1]) {
       // calculate temp (bars per second)
       const currenttempo =
@@ -103,11 +103,15 @@ export function getBarFromTime(t: number, v: number = 0) {
       return b;
     }
   }
+  const lastIdx = config.bartime[v].length - 1;
+  if (t >= config.bartime[v][lastIdx]) {
+    return config.barno[v][lastIdx];
+  }
   return 0;
 }
 
 export function getTimeFromBar(b: number, v: number = 0) {
-  for (let index = 0; index < config.bartime[v].length; index++) {
+  for (let index = 0; index < config.barno[v].length - 1; index++) {
     if (b >= config.barno[v][index] && b < config.barno[v][index + 1]) {
       // calculate temp (bars per second)
       const currenttempo =
@@ -118,6 +122,10 @@ export function getTimeFromBar(b: number, v: number = 0) {
         config.bartime[v][index] + (b - config.barno[v][index]) / currenttempo
       );
     }
+  }
+  const lastIdx = config.barno[v].length - 1;
+  if (b >= config.barno[v][lastIdx]) {
+    return config.bartime[v][lastIdx];
   }
   return 0;
 }


### PR DESCRIPTION
Fix boundary handling in `getBarFromTime()` and `getTimeFromBar()` so the final interval returns the correct value instead of `0`.

Changes:
- Loop bounds fixed to `length - 1` so `index + 1` is always valid
- Final boundary explicitly handled: values at or beyond the last entry return the final bar/time
- Out-of-bounds tests updated to expect clamped final values

Fixes #176
