### PR TITLE
docs: remove obsolete skip-worktree section from CONTRIBUTING.md

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -264,27 +264,6 @@ When creating or modifying a component:
 - **Local ignore rules** — personal patterns (IDE configs, local scripts) belong in
   `.git/info/exclude`, not `.gitignore`, to avoid polluting the shared ignore file.
 
-### Tracked Generated Files
-
-Two Ohm bundle files are committed to the repository (Mark's preference) but are
-regenerated locally during development:
-
-```text
-src/ohmjs/ly-grammar.ohm-bundle.js
-src/ohmjs/ly-grammar.ohm-bundle.d.ts
-```
-
-Set `--skip-worktree` on these files after cloning so local rebuilds do not appear
-in `git status`:
-
-```console
-git update-index --skip-worktree src/ohmjs/ly-grammar.ohm-bundle.js
-git update-index --skip-worktree src/ohmjs/ly-grammar.ohm-bundle.d.ts
-```
-
-Do not commit local versions of these files. If a rebase conflict touches them,
-accept the upstream version.
-
 ### Writing Tests
 
 Unit and integration tests use Vitest 3 with the jsdom environment. End-to-end

--- a/src/test/docs.test.ts
+++ b/src/test/docs.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, it, expect } from "vitest";
+
+const CONTRIBUTING_PATH = resolve(process.cwd(), "doc", "CONTRIBUTING.md");
+
+describe("CONTRIBUTING.md", () => {
+  it("does not contain the obsolete Tracked Generated Files section", () => {
+    const content = readFileSync(CONTRIBUTING_PATH, "utf-8");
+
+    expect(content).not.toContain("### Tracked Generated Files");
+    expect(content).not.toContain("git update-index --skip-worktree");
+    expect(content).not.toContain("src/ohmjs/ly-grammar.ohm-bundle.js");
+    expect(content).not.toContain("src/ohmjs/ly-grammar.ohm-bundle.d.ts");
+  });
+});


### PR DESCRIPTION
PR #313 (merged 2026-05-24) removed `src/ohmjs/ly-grammar.ohm-bundle.*` from git tracking and added them to `.gitignore`. The `### Tracked Generated Files` subsection in `doc/CONTRIBUTING.md` described an impossible operation (`--skip-worktree` on an untracked file).

Delete the obsolete subsection.

Fixes #337
