### PR TITLE
fix: center tooltip under header icon with translateX

### DIFF
--- a/e2e/tooltip.spec.ts
+++ b/e2e/tooltip.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Header tooltip positioning", () => {
+  test("tooltip is horizontally centred under its icon", async ({ page }) => {
+    await page.goto("/");
+
+    const header = page.locator("header");
+    await expect(header).toBeVisible();
+
+    const tooltips = header.locator(".tooltip");
+    const count = await tooltips.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const tooltip = tooltips.nth(i);
+      await tooltip.hover();
+      await page.waitForTimeout(300);
+
+      const tooltiptext = tooltip.locator(".tooltiptext").first();
+      await expect(tooltiptext).toBeVisible();
+
+      const tooltipBox = await tooltip.boundingBox();
+      const textBox = await tooltiptext.boundingBox();
+
+      expect(tooltipBox).not.toBeNull();
+      expect(textBox).not.toBeNull();
+
+      const tooltipCenter = tooltipBox!.x + tooltipBox!.width / 2;
+      const textCenter = textBox!.x + textBox!.width / 2;
+      const offset = Math.abs(tooltipCenter - textCenter);
+
+      expect(offset).toBeLessThanOrEqual(2);
+    }
+  });
+});

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -175,7 +175,7 @@ header {
     width: 120px;
     top: 100%;
     left: 50%;
-    margin-left: -120px;
+    transform: translateX(-50%);
     background-color: var(--color-background-lighter);
     border: 2px solid var(--color-border);
 


### PR DESCRIPTION
The `.tooltip .tooltiptext` rule used `left: 50%` with `margin-left: -120px` on a 120px-wide element. This shifted the tooltip's left edge to the icon's centre point rather than centring the tooltip underneath it.

Replace the brittle `margin-left` offset with `transform: translateX(-50%)`, which centres the tooltip correctly regardless of its width.

Includes a Playwright e2e test that verifies every header tooltip is horizontally centred under its icon across Chromium, Firefox, and WebKit.

Fixes #334
