### PR TITLE
fix: defer scrollSmooth via requestAnimationFrame to avoid forced reflow on initial load (#92)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -113,4 +113,26 @@ test.describe("Spem Player smoke tests", () => {
     await barInput.blur();
     await expect(controls).toHaveAttribute("bar", "0");
   });
+
+  test("initial scroll lands on the target bar (#92)", async ({ page }) => {
+    // Regression guard for #92: `MusicScore.#loadScore()` previously called
+    // `scrollSmooth()` synchronously after inserting the SVG, triggering a
+    // Chrome forced-reflow violation. The fix defers `scrollSmooth()` via
+    // `requestAnimationFrame`. This test guards the behavioural invariant
+    // — wherever the deferral lives, the score must end up scrolled to the
+    // target bar after the initial load. If a future change reverts the
+    // defer in a way that swallows the call (rAF callback never runs),
+    // the inner `.score-scroll-area` stays at scrollLeft 0 and this test
+    // fails.
+    await page.goto("/?bar=40");
+    const scrollArea = page.locator("music-score .score-scroll-area");
+    await expect(scrollArea).toBeVisible();
+    await expect
+      .poll(
+        async () =>
+          await scrollArea.evaluate((el) => (el as HTMLElement).scrollLeft),
+        { timeout: 2000 },
+      )
+      .toBeGreaterThan(0);
+  });
 });

--- a/src/ts/MusicScore.ts
+++ b/src/ts/MusicScore.ts
@@ -214,9 +214,13 @@ export class MusicScore extends MusicElement {
       String(indicatorWidth)
     );
 
-    // Highlight and scroll to the current bar
+    // Highlight and scroll to the current bar. Defer scrollSmooth() via
+    // requestAnimationFrame so the layout reads inside it (offsetWidth,
+    // getBoundingClientRect) happen against clean post-paint layout
+    // rather than forcing a synchronous reflow on the freshly inserted
+    // SVG — see #92.
     this.highlight();
-    this.scrollSmooth();
+    requestAnimationFrame(() => this.scrollSmooth());
   }
 
   async setChoir(c: string | number) {


### PR DESCRIPTION
## Summary

Defer `MusicScore.#loadScore()`'s call to `scrollSmooth()` by one
`requestAnimationFrame` tick so the layout reads inside `scrollSmooth`
(`offsetWidth`, `getBoundingClientRect`) run against clean post-paint
layout rather than dirty post-`innerHTML` layout. This eliminates the
Chrome `[Violation] Forced reflow while executing JavaScript took 36ms`
console warning on initial page load.

Diagnosed via the respec on #92: the warning was triggered by
`scrollSmooth()` running synchronously immediately after `innerHTML`
insertion and the four `prepend` calls in `#loadScore`, with the SVG's
layout still dirty.

Behaviour is preserved — the score still scrolls to the URL-specified
bar after load, just one paint cycle later.

## Changes

- `src/ts/MusicScore.ts:218-219` — wrap `scrollSmooth()` in
  `requestAnimationFrame`.
- `e2e/smoke.spec.ts` — add a regression guard that loads `/?bar=40`
  and asserts `.score-scroll-area` ends up with `scrollLeft > 0`. If a
  future change reverts the defer in a way that swallows the call (e.g.
  the rAF callback never runs), the guard fails.

## Test plan

- [x] `npm run ci` passes locally.
- [x] `npm run e2e -- --project chromium` passes locally, including the
      new `initial scroll lands on the target bar (#92)` case.
- [x] Manual: loading `/?bar=40` lands the playhead near bar 40 in the
      same observable position as before the change.
- [ ] No `[Violation] Forced reflow` warning on initial load in
      DevTools Console — manual verification per respec section 6.1.

Fixes #92
