### PR TITLE
docs: update BUILD.md and TESTING.md for accuracy

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -63,7 +63,7 @@ This iterates over matching `Choir*.ly` files under `src/lilypond/` and runs `li
 
 ## Quality Checks
 
-Run the full quality gate locally (formatting, lint, typecheck, dependency checks):
+Run the full quality gate locally (Ohm grammar bundle, unused-export check, formatting, lint, typecheck, dependency checks):
 
 ```console
 npm run check
@@ -102,6 +102,14 @@ Run end-to-end tests in a real browser:
 npm run e2e
 ```
 
+## CI Pipeline
+
+Run the full local CI pipeline (checks, build, and tests):
+
+```console
+npm run ci
+```
+
 ## Build Notes
 
 ### Version Injection
@@ -112,7 +120,7 @@ When releasing, update `package.json` only. The build will propagate the new ver
 
 ### Ohm Grammar
 
-`npm run build:ohm` regenerates `src/ohmjs/ly-grammar.ohm-bundle.js` from `src/ohmjs/ly-grammar.ohm` via `@ohm-js/cli`. If you modify the grammar, rebuild before testing or deploying.
+`npm run build:ohm` regenerates `src/ohmjs/ly-grammar.ohm-bundle.js` and `src/ohmjs/ly-grammar.ohm-bundle.d.ts` from `src/ohmjs/ly-grammar.ohm` via `@ohm-js/cli`. If you modify the grammar, rebuild before testing or deploying.
 
 ## Build Output
 
@@ -128,6 +136,7 @@ The project is configured for Netlify. `netlify.toml` specifies:
 
 - Build command: `npm run build`
 - Publish directory: `dist`
+- Functions directory: `netlify/functions`
 
 Deployment is automated: merging to `main` triggers a Netlify build and deploy.
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -2,7 +2,7 @@
 
 ## Framework and Configuration
 
-Tests use Vitest 3 with the jsdom environment. Configuration lives in `vite.config.ts`:
+Tests use Vitest 4 with the jsdom environment. Configuration lives in `vite.config.ts`:
 
 - `globals: true` (no need to import `describe`, `it`, `expect`)
 - `environment: 'jsdom'`
@@ -49,7 +49,6 @@ Tests live in `src/test/` and follow the naming convention `*.test.ts`.
 
 - `jsdom`: DOM implementation for Node.js
 - `canvas`: Node.js Canvas API implementation (required for `MusicCanvas` tests)
-- `vitest-fetch-mock`: Fetch mocking utility
 - `@vitest/coverage-v8`: Coverage reporting
 
 ## Coverage Output
@@ -79,5 +78,4 @@ npm run e2e
 ### E2E Key Dependencies
 
 - `@playwright/test`: test runner and browser automation
-- `chromium`: browser under test (installed via `npx playwright install chromium`)
-
+- `chromium`, `firefox`, `webkit`: browsers under test (installed via `npx playwright install chromium firefox webkit`)


### PR DESCRIPTION
## Summary

Updates `doc/BUILD.md` and `doc/TESTING.md` to reflect the current state of the project.

## Changes

### `doc/TESTING.md`

- Fixes Vitest version: 3 → 4
- Removes phantom dependency `vitist-fetch-mock` (not in `package.json`, unused)
- Documents all three Playwright browsers: chromium, firefox, webkit

### `doc/BUILD.md`

- Completes `npm run check` description (adds `build:ohm` and `check:unused`)
- Mentions `.d.ts` bundle in Ohm Grammar section
- Adds Netlify functions directory
- Adds new "CI Pipeline" section documenting `npm run ci`

## Checklist

- [x] `npm run check` passes (format, lint, types, deps)
- [x] `npm run build` passes
- Tests: no code changes; test failures are pre-existing (#355, flaky buildScores test)

Fixes #358
