### PR TITLE
fix: remove shebang and restore deduplicatePaths coverage (#355, #349)

### DIFF
--- a/build/postprocessSvg.d.mts
+++ b/build/postprocessSvg.d.mts
@@ -1,5 +1,8 @@
+import { Document } from "@xmldom/xmldom";
+
+export function deduplicatePaths(doc: Document): void;
 export function postprocessSvg(
   svgPath: string,
   spemLyPath?: string,
-  wordsLyPath?: string
+  wordsLyPath?: string,
 ): void;

--- a/build/postprocessSvg.mjs
+++ b/build/postprocessSvg.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /* eslint-env node */
 // Copyright (c) 2024-2026 Mark Wainwright
 // SPDX-License-Identifier: MIT

--- a/build/postprocessSvg.mjs
+++ b/build/postprocessSvg.mjs
@@ -92,7 +92,7 @@ function nonTransformAttrs(path) {
  * unchanged (defensive skip for attribute collision).
  * @param {Document} doc
  */
-function deduplicatePaths(doc) {
+export function deduplicatePaths(doc) {
   const allPaths = Array.from(doc.getElementsByTagName("path"));
 
   /** @type {Map<string, Element[]>} */

--- a/src/test/postprocessSvgDedup.test.ts
+++ b/src/test/postprocessSvgDedup.test.ts
@@ -1,0 +1,99 @@
+import { DOMParser } from "@xmldom/xmldom";
+import { deduplicatePaths } from "../../build/postprocessSvg.mjs";
+
+const DUPLICATE_PATHS_SVG = `<svg xmlns="http://www.w3.org/2000/svg">
+  <path d="M 0 0 L 10 10" transform="translate(10,20)" />
+  <path d="M 0 0 L 10 10" transform="translate(30,20)" />
+  <path d="M 0 0 L 10 10" transform="translate(50,20)" />
+  <path d="M 5 5 L 15 15" />
+</svg>`;
+
+const ATTR_COLLISION_SVG = `<svg xmlns="http://www.w3.org/2000/svg">
+  <path d="M 0 0 L 10 10" fill="red" />
+  <path d="M 0 0 L 10 10" fill="blue" />
+</svg>`;
+
+const NO_DUPLICATES_SVG = `<svg xmlns="http://www.w3.org/2000/svg">
+  <path d="M 0 0 L 10 10" />
+  <path d="M 5 5 L 15 15" />
+</svg>`;
+
+function parseSvg(xml: string) {
+  return new DOMParser().parseFromString(xml, "image/svg+xml");
+}
+
+describe("deduplicatePaths", () => {
+  it("creates defs block for duplicate paths", () => {
+    const doc = parseSvg(DUPLICATE_PATHS_SVG);
+    deduplicatePaths(doc);
+    const defs = doc.getElementsByTagName("defs");
+    expect(defs.length).toBe(1);
+  });
+
+  it("defs contains one path per unique shape", () => {
+    const doc = parseSvg(DUPLICATE_PATHS_SVG);
+    deduplicatePaths(doc);
+    const defsPaths = doc
+      .getElementsByTagName("defs")[0]
+      .getElementsByTagName("path");
+    expect(defsPaths.length).toBe(1);
+    expect(defsPaths[0].getAttribute("d")).toBe("M 0 0 L 10 10");
+  });
+
+  it("replaces duplicates with use elements", () => {
+    const doc = parseSvg(DUPLICATE_PATHS_SVG);
+    deduplicatePaths(doc);
+    const uses = doc.getElementsByTagName("use");
+    expect(uses.length).toBe(3);
+  });
+
+  it("use elements reference def id", () => {
+    const doc = parseSvg(DUPLICATE_PATHS_SVG);
+    deduplicatePaths(doc);
+    const defsPath = doc
+      .getElementsByTagName("defs")[0]
+      .getElementsByTagName("path")[0];
+    const defId = defsPath.getAttribute("id");
+    const uses = Array.from(doc.getElementsByTagName("use"));
+    expect(uses.every((u) => u.getAttribute("href") === `#${defId}`)).toBe(
+      true
+    );
+  });
+
+  it("use elements preserve transform", () => {
+    const doc = parseSvg(DUPLICATE_PATHS_SVG);
+    deduplicatePaths(doc);
+    const uses = Array.from(doc.getElementsByTagName("use"));
+    const transforms = uses.map((u) => u.getAttribute("transform"));
+    expect(transforms).toContain("translate(10,20)");
+    expect(transforms).toContain("translate(30,20)");
+    expect(transforms).toContain("translate(50,20)");
+  });
+
+  it("unique paths are not touched", () => {
+    const doc = parseSvg(DUPLICATE_PATHS_SVG);
+    deduplicatePaths(doc);
+    const paths = Array.from(doc.getElementsByTagName("path"));
+    const unique = paths.find((p) => p.getAttribute("d") === "M 5 5 L 15 15");
+    expect(unique).toBeDefined();
+    expect(unique!.parentNode!.nodeName).not.toBe("defs");
+  });
+
+  it("attr collision leaves paths unchanged", () => {
+    const doc = parseSvg(ATTR_COLLISION_SVG);
+    deduplicatePaths(doc);
+    expect(doc.getElementsByTagName("defs").length).toBe(0);
+    expect(doc.getElementsByTagName("use").length).toBe(0);
+    const paths = doc.getElementsByTagName("path");
+    expect(paths.length).toBe(2);
+  });
+
+  it("no duplicates leaves document unchanged", () => {
+    const doc = parseSvg(NO_DUPLICATES_SVG);
+    deduplicatePaths(doc);
+    expect(doc.getElementsByTagName("defs").length).toBe(0);
+    expect(doc.getElementsByTagName("use").length).toBe(0);
+    const paths = doc.getElementsByTagName("path");
+    expect(paths.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Fixes #355
Fixes #349

## #355: Remove shebang from postprocessSvg.mjs

The `#!/usr/bin/env node` shebang at line 1 caused Rolldown to fail when Vitest imported the module, blocking all tests for this file. The file is never executed directly without `node`; it is imported by `buildScores.mjs` and the test file.

## #349: Restore deduplicatePaths test coverage

PR #336 ported the build pipeline from Python to JavaScript but omitted the 8 unit tests that guarded `deduplicate_paths`. This PR:

- Exports `deduplicatePaths` from `build/postprocessSvg.mjs`
- Updates `build/postprocessSvg.d.mts` with the new export signature
- Adds `src/test/postprocessSvgDedup.test.ts` with 8 Vitest cases mirroring the original Python tests:
  - Creates defs block for duplicate paths
  - defs contains one path per unique shape
  - Replaces duplicates with use elements
  - use elements reference def id
  - use elements preserve transform
  - Unique paths are not touched
  - Attribute collision leaves paths unchanged
  - No duplicates leaves document unchanged

- Kimi
