### PR TITLE
docs: explain SVG rebuild timing and non-byte-identical output in BUILD.md

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -61,6 +61,12 @@ npm run build:scores -- --version="Hugh Keyte" --notation=early --choir="II B"
 
 This iterates over matching `Choir*.ly` files under `src/lilypond/` and runs `lilypond --svg` for each, then post-processes the generated SVG with `build/postprocessSvg.mjs`.
 
+### Timing
+
+LilyPond is the slow part: roughly 60 seconds per choir, 16 choirs across early + modern notations. When `.ly` sources are current, `npm run build:scores` (and the `prebuild` step inside `npm run build`) completes in a few seconds because `needsRebuild` compares mtimes and skips unchanged files. After a batch edit of `.ly` files — particularly shared includes (`basic.ly`, `layout.ly`) — expect the next full `npm run ci` to take 10+ minutes as the affected SVGs regenerate. This is a one-off; the next build after that is fast again.
+
+Rebuilds are functionally equivalent to the committed SVGs but not byte-identical: LilyPond and the postprocessor reorder path definitions and dedup staff lines depending on input timing. If you see `src/scores/**/*.svg` files showing as modified after a rebuild on a clean branch, discard them (`git restore src/scores/`); the committed versions are canonical.
+
 ## Quality Checks
 
 Run the full quality gate locally (Ohm grammar bundle, unused-export check, formatting, lint, typecheck, dependency checks):


### PR DESCRIPTION
Small documentation-only addition to `doc/BUILD.md` under "Regenerate SVG Scores".

Adds a "Timing" subsection that:

- States the per-choir LilyPond cost (~60s) and the cold-rebuild total (16 choirs).
- Notes that batch edits of shared `.ly` includes (basic.ly, layout.ly) trigger a one-off ~10-min rebuild on the next `npm run ci`, and that subsequent runs are fast.
- Warns that rebuilds are functionally equivalent to the committed SVGs but not byte-identical (LilyPond reorders path definitions; the postprocessor varies staff-line dedup based on input timing). Tells developers seeing modified-SVG noise in `git status` after a rebuild on a clean branch to `git restore src/scores/`.

No code change. Preserves the surrounding `## Regenerate SVG Scores` and `## Quality Checks` sections.

The warning addresses a real surprise: a recent `npm run ci` took 12 min instead of the steady-state ~4–5 min because 9 SVGs needed rebuilding (consequence of an upstream batch edit at 18:57 on 2026-05-25). Nothing was wrong; the timing just wasn't documented anywhere. This entry is the prevention so the next person who hits it knows the pattern.

- Claude
