### PR TITLE
test: add 30s timeout to buildScores integration tests

### DIFF
--- a/src/test/buildScores.test.ts
+++ b/src/test/buildScores.test.ts
@@ -223,7 +223,7 @@ describe("buildScores.mjs integration", () => {
     } finally {
       rmSync(ws, { recursive: true, force: true });
     }
-  });
+  }, 30000);
 
   it("caches by mtime", () => {
     const ws = createWorkspace();
@@ -256,7 +256,7 @@ describe("buildScores.mjs integration", () => {
     } finally {
       rmSync(ws, { recursive: true, force: true });
     }
-  });
+  }, 30000);
 
   it("rebuilds all scores when a version-root include is newer (Vera 353-01)", () => {
     const ws = createWorkspace();


### PR DESCRIPTION
Fixes #373

Add 30s per-test timeout to the two slowest `buildScores.mjs` integration tests:
- `builds all notations`
- `caches by mtime`

Both tests spawn the full build pipeline (16 fake lilypond invocations) and reliably exceed the default 10s timeout under Windows + `maxWorkers: 4` contention. 30s provides generous headroom without affecting the rest of the suite.
