### PR TITLE
Compute Vite/Playwright ports from an env var to support parallel worktrees

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { PREVIEW_PORT } from "./worktree-ports.ts";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -8,7 +9,7 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: [["html"], ["github"]],
   use: {
-    baseURL: "http://localhost:4173",
+    baseURL: `http://localhost:${PREVIEW_PORT}`,
     trace: "on-first-retry",
   },
   projects: [
@@ -27,7 +28,14 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm run preview",
-    port: 4173,
+    // If `vite preview` cannot bind PREVIEW_PORT (e.g. a parallel
+    // worktree already on the same offset, or any other process on
+    // the port), it exits with EADDRINUSE — Playwright then times
+    // out waiting for this port and reports "server did not start".
+    // The underlying EADDRINUSE typically surfaces in the spawned
+    // `npm run preview` output rather than in Playwright's own
+    // timeout message; check both when this fails.
+    port: PREVIEW_PORT,
     reuseExistingServer: false,
   },
 });

--- a/src/test/worktree-ports.test.ts
+++ b/src/test/worktree-ports.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { portOffset, DEV_PORT, PREVIEW_PORT } from "../../worktree-ports.ts";
+
+describe("worktree-ports", () => {
+  it("DEV_PORT is exactly 1000 above PREVIEW_PORT (single shared offset)", () => {
+    // The module-load constants depend on the process env at import, so
+    // we assert the invariant between them rather than absolute values.
+    expect(DEV_PORT - PREVIEW_PORT).toBe(1000);
+  });
+
+  it("DEV_PORT / PREVIEW_PORT apply the resolved offset to the base ports", () => {
+    expect(DEV_PORT).toBe(5173 + portOffset());
+    expect(PREVIEW_PORT).toBe(4173 + portOffset());
+  });
+
+  it("returns 0 when SPEM_PORT_OFFSET is unset", () => {
+    expect(portOffset(undefined)).toBe(0);
+  });
+
+  it("returns 0 for an empty or whitespace value", () => {
+    expect(portOffset("")).toBe(0);
+    expect(portOffset("   ")).toBe(0);
+  });
+
+  it("parses a valid non-negative integer offset", () => {
+    expect(portOffset("0")).toBe(0);
+    expect(portOffset("100")).toBe(100);
+    expect(portOffset("400")).toBe(400);
+  });
+
+  it("falls back to 0 for malformed, negative, or non-integer values (never throws)", () => {
+    // A mistyped offset must degrade to the default port rather than
+    // throw at config-eval — a worktree's own setup error cannot then
+    // break the build for CI, forks, or anyone else. A real collision
+    // surfaces as EADDRINUSE at preview bind (strictPort) instead.
+    expect(portOffset("abc")).toBe(0);
+    expect(portOffset("1OO")).toBe(0); // letter O, not zeros
+    expect(portOffset("-100")).toBe(0);
+    expect(portOffset("10.5")).toBe(0);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,11 @@ import commonjs from "vite-plugin-commonjs";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { execSync } from "child_process";
+// Per-worktree dev/preview ports. The offset comes from the
+// SPEM_PORT_OFFSET env var (default 0); see `worktree-ports.ts`. This
+// import never throws — an unset or invalid value falls back to the
+// default ports, so config-eval is safe in CI, forks, and clones.
+import { DEV_PORT, PREVIEW_PORT } from "./worktree-ports.ts";
 
 const pkg = JSON.parse(
   readFileSync(resolve(__dirname, "package.json"), "utf-8")
@@ -24,6 +29,22 @@ const versionWithBranch =
 
 export default defineConfig({
   assetsInclude: ["**/*.ohm", "**/*.ly"],
+  server: {
+    // Dev tolerates port collisions: `strictPort: false` lets Vite
+    // auto-increment from DEV_PORT when running `npm run dev` —
+    // human ergonomics, not a test contract.
+    port: DEV_PORT,
+    strictPort: false,
+  },
+  preview: {
+    // Preview hard-fails on collision. `strictPort: true` is
+    // load-bearing: Playwright's `webServer.port` polls the exact
+    // PREVIEW_PORT (see playwright.config.ts), so silent
+    // auto-increment would test the wrong server. Do NOT relax this
+    // to match the dev block — the asymmetry is intentional.
+    port: PREVIEW_PORT,
+    strictPort: true,
+  },
   test: {
     globals: true,
     environment: "jsdom",

--- a/worktree-ports.ts
+++ b/worktree-ports.ts
@@ -1,0 +1,44 @@
+// Per-worktree dev/preview port offset, so multiple agent worktrees can
+// run their dev/preview servers at once without colliding.
+//
+// Each worktree declares its own offset via the SPEM_PORT_OFFSET
+// environment variable, set once in that worktree (its launch script or
+// a gitignored .env.local). Anything that does NOT set it — CI, forks, a
+// fresh clone, the main checkout — gets offset 0 and the default ports,
+// so config evaluation can never fail on an unrecognised checkout
+// directory. The offset is the worktree's own fact to declare; we do not
+// infer it from the directory name (CI checks out into `spem-player`, a
+// fork could be named anything — the name is an unreliable proxy).
+//
+// Suggested per-worktree values (offset -> dev / preview):
+//   main / claude  0   -> 5173 / 4173
+//   vera           100 -> 5273 / 4273
+//   kimi           200 -> 5373 / 4373
+//   copilot        300 -> 5473 / 4473
+//   tele           400 -> 5573 / 4573
+//
+// vite.config.ts and playwright.config.ts read DEV_PORT / PREVIEW_PORT at
+// config-eval time; the offset is resolved once here at module load.
+
+/**
+ * Resolve the per-worktree port offset from `SPEM_PORT_OFFSET`.
+ *
+ * @param raw - the raw env value (defaults to
+ *   `process.env.SPEM_PORT_OFFSET`).
+ * @returns the offset as a non-negative integer, or `0` when the
+ *   variable is unset, empty, or not a valid non-negative integer.
+ *
+ * Never throws: a mistyped offset degrades to the default ports rather
+ * than breaking config-eval for every command (test, build, lint). A
+ * genuine collision between two worktrees surfaces instead as
+ * EADDRINUSE at preview bind, where Playwright uses `strictPort`.
+ */
+export const portOffset = (
+  raw: string | undefined = process.env.SPEM_PORT_OFFSET,
+): number => {
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : 0;
+};
+
+export const DEV_PORT = 5173 + portOffset();
+export const PREVIEW_PORT = 4173 + portOffset();


### PR DESCRIPTION
## What

Lets multiple agent worktrees run `npm run dev` / `npm run preview` /
`npm run e2e` at the same time without port collisions, by giving each
worktree its own dev/preview port offset.

## How

- `worktree-ports.ts` (new) resolves a per-worktree offset from the
  `SPEM_PORT_OFFSET` environment variable, defaulting to `0` when unset,
  empty, or invalid. It never throws.
- `vite.config.ts`: `server.port = 5173 + offset` (`strictPort: false`, dev
  may auto-increment) and `preview.port = 4173 + offset`
  (`strictPort: true`, Playwright waits on the exact port).
- `playwright.config.ts`: `baseURL` and `webServer.port` use `PREVIEW_PORT`.

Each parallel worktree sets `SPEM_PORT_OFFSET` for itself (e.g. in its launch
script or a gitignored `.env.local`). Anything that does not set it (CI,
forks, a fresh clone, the main checkout) gets offset 0 and the default
`5173` / `4173`, so config evaluation is always safe.

## Note

An earlier revision derived the offset from the checkout directory name,
which threw in CI (the runner checks out into `spem-player/`); this revision
replaces that with the explicit env var. See the PR comment for detail.

Fixes #408
