### PR TITLE
fix: URL parameter split on '=' truncates values containing '=' (#410)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import "./src/scss/style.scss";
 import config from "./src/ts/config";
 
 import { PartType, State, colors, toNum, toRecordingIndex } from "./src/ts/common";
+import { parseURLSearch } from "./src/ts/url";
 
 import { MusicCanvas } from "./src/ts/MusicCanvas";
 import { MusicCanvasWatcher } from "./src/ts/MusicCanvasWatcher";
@@ -164,43 +165,15 @@ function setBar(b: number) {
 }
 
 function parseURL() {
-  const url = window.location.search.substring(1);
-  const parms = url.split("&");
-
-  var recording = 0; // ALC
-  var choir = 0; // choir 1 because it is zero indexed
-  var part: PartType = "all";
-  var bar = 1 - config.intro_beats[recording] / 4;
-  var dark = true; // dark mode by default
-  var early = false;
-  var r = 0; // ALC
-
-  for (let i = 0; i < parms.length; i++) {
-    const parm = parms[i].split("=");
-    if (parm[0] == "choir") {
-      choir = Number(parm[1]);
-    } else if (parm[0] == "part") {
-      const n: number = Number(parm[1]);
-      if (n >= 0 && n < config.parts.length) part = n;
-    } else if (parm[0] == "bar") {
-      bar = Number(parm[1]);
-    } else if (parm[0] == "dark") {
-      dark = true;
-    } else if (parm[0] == "recording") {
-      if (parm[1] == "alc") r = 0;
-      else r = 1;
-    } else if (parm[0] == "score") {
-      early = parm[1] == "early";
-    }
-  }
-  setRecording(r);
-  setChoir(choir, true);
-  setPart(part);
-  setBar(bar);
-  if (early) {
+  const parsed = parseURLSearch(window.location.search);
+  setRecording(parsed.recording);
+  setChoir(parsed.choir, true);
+  setPart(parsed.part);
+  setBar(parsed.bar);
+  if (parsed.early) {
     toggleScore();
   }
-  if (!dark) {
+  if (!parsed.dark) {
     document.body.classList.add("light-theme");
     current.viewmode = "light";
   } else {

--- a/src/test/url.test.ts
+++ b/src/test/url.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { parseURLSearch } from "../ts/url";
+
+describe("parseURLSearch", () => {
+  it("preserves values containing '=' instead of truncating", () => {
+    // With the bug (split("=")), "recording=alc=extra" would split into
+    // ["recording", "alc", "extra"] and parm[1] === "alc", giving recording=0.
+    // With the fix (indexOf/slice), val === "alc=extra", giving recording=1.
+    const result = parseURLSearch("?recording=alc=extra");
+    expect(result.recording).toBe(1);
+  });
+
+  it("handles normal parameters without '=' in value", () => {
+    const result = parseURLSearch("?recording=alc&choir=3&bar=10");
+    expect(result.recording).toBe(0);
+    expect(result.choir).toBe(3);
+    expect(result.bar).toBe(10);
+  });
+});

--- a/src/ts/url.ts
+++ b/src/ts/url.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2024-2026 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
+import config from "./config";
+import { PartType } from "./common";
+
+export interface ParsedURL {
+  recording: number;
+  choir: number;
+  part: PartType;
+  bar: number;
+  dark: boolean;
+  early: boolean;
+}
+
+export function parseURLSearch(search: string): ParsedURL {
+  const url = search.substring(1);
+  const parms = url.split("&");
+
+  var recording = 0; // ALC
+  var choir = 0; // choir 1 because it is zero indexed
+  var part: PartType = "all";
+  var bar = 1 - config.intro_beats[recording] / 4;
+  var dark = true; // dark mode by default
+  var early = false;
+  var r = 0; // ALC
+
+  for (let i = 0; i < parms.length; i++) {
+    const eq = parms[i].indexOf("=");
+    const key = eq === -1 ? parms[i] : parms[i].slice(0, eq);
+    const val = eq === -1 ? undefined : parms[i].slice(eq + 1);
+    if (key == "choir") {
+      choir = Number(val);
+    } else if (key == "part") {
+      const n: number = Number(val);
+      if (n >= 0 && n < config.parts.length) part = n;
+    } else if (key == "bar") {
+      bar = Number(val);
+    } else if (key == "dark") {
+      dark = true;
+    } else if (key == "recording") {
+      if (val == "alc") r = 0;
+      else r = 1;
+    } else if (key == "score") {
+      early = val == "early";
+    }
+  }
+
+  return { recording: r, choir, part, bar, dark, early };
+}


### PR DESCRIPTION
Fixes #410.

**Root cause:** parseURL() used String.prototype.split('=') without a limit. When a URL parameter value contained =, the split produced three or more array elements, and only the fragment before the first = was used as the value.

**Fix:** Extracted parseURLSearch() into a new pure module src/ts/url.ts (testable) and replaced split('=') with indexOf('=')/slice() to preserve the entire value after the first =.

**Tests:** Added src/test/url.test.ts with two Vitest cases:
1. Values containing = are preserved (fails with old code, passes with fix)
2. Normal parameters without = still work

Unit test suite: 313 passed, 48 skipped.