### PR TITLE
fix: preserve URL parameter values containing '='

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import "./src/scss/style.scss";
 import config from "./src/ts/config";
 
 import { PartType, State, colors, toNum, toRecordingIndex } from "./src/ts/common";
+import { parseURLSearch } from "./src/ts/url";
 
 import { MusicCanvas } from "./src/ts/MusicCanvas";
 import { MusicCanvasWatcher } from "./src/ts/MusicCanvasWatcher";
@@ -164,43 +165,15 @@ function setBar(b: number) {
 }
 
 function parseURL() {
-  const url = window.location.search.substring(1);
-  const parms = url.split("&");
-
-  var recording = 0; // ALC
-  var choir = 0; // choir 1 because it is zero indexed
-  var part: PartType = "all";
-  var bar = 1 - config.intro_beats[recording] / 4;
-  var dark = true; // dark mode by default
-  var early = false;
-  var r = 0; // ALC
-
-  for (let i = 0; i < parms.length; i++) {
-    const parm = parms[i].split("=");
-    if (parm[0] == "choir") {
-      choir = Number(parm[1]);
-    } else if (parm[0] == "part") {
-      const n: number = Number(parm[1]);
-      if (n >= 0 && n < config.parts.length) part = n;
-    } else if (parm[0] == "bar") {
-      bar = Number(parm[1]);
-    } else if (parm[0] == "dark") {
-      dark = true;
-    } else if (parm[0] == "recording") {
-      if (parm[1] == "alc") r = 0;
-      else r = 1;
-    } else if (parm[0] == "score") {
-      early = parm[1] == "early";
-    }
-  }
-  setRecording(r);
-  setChoir(choir, true);
-  setPart(part);
-  setBar(bar);
-  if (early) {
+  const parsed = parseURLSearch(window.location.search);
+  setRecording(parsed.recording);
+  setChoir(parsed.choir, true);
+  setPart(parsed.part);
+  setBar(parsed.bar);
+  if (parsed.early) {
     toggleScore();
   }
-  if (!dark) {
+  if (!parsed.dark) {
     document.body.classList.add("light-theme");
     current.viewmode = "light";
   } else {

--- a/src/test/url.test.ts
+++ b/src/test/url.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { parseURLSearch } from "../ts/url";
+
+describe("parseURLSearch", () => {
+  it("preserves a value containing '=' instead of truncating at the first '='", () => {
+    // The bug was split("="): "recording=alc=extra" -> ["recording","alc",
+    // "extra"], so parm[1] === "alc" and recording wrongly resolved to 0.
+    // The fix (indexOf/slice) keeps val === "alc=extra".
+    expect(parseURLSearch("?recording=alc=extra").recording).toBe(1);
+    // Tighter proof that the WHOLE value survives, not merely "not alc":
+    // score only sets early when the value is exactly "early". Truncation
+    // would read "early" (true); preservation reads "early=x" (false). So
+    // this fails against the old split() bug AND pins full-value handling.
+    expect(parseURLSearch("?score=early=x").early).toBe(false);
+    expect(parseURLSearch("?score=early").early).toBe(true);
+  });
+
+  it("handles normal parameters without '=' in the value", () => {
+    const result = parseURLSearch("?recording=alc&choir=3&bar=10");
+    expect(result.recording).toBe(0);
+    expect(result.choir).toBe(3);
+    expect(result.bar).toBe(10);
+  });
+
+  it("returns the documented defaults for an empty search string", () => {
+    const result = parseURLSearch("");
+    expect(result.recording).toBe(0);
+    expect(result.choir).toBe(0);
+    expect(result.part).toBe("all");
+    expect(result.dark).toBe(true);
+    expect(result.early).toBe(false);
+  });
+
+  it("treats a key with no '=' as having no value (NaN for numeric keys)", () => {
+    // New indexOf/slice branch: eq === -1 -> val === undefined, so a
+    // numeric key yields Number(undefined) === NaN. Pinned as current
+    // behaviour; a guard against NaN is tracked in the follow-up ticket.
+    expect(Number.isNaN(parseURLSearch("?choir").choir)).toBe(true);
+  });
+});

--- a/src/ts/url.ts
+++ b/src/ts/url.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2024-2026 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
+import config from "./config";
+import { PartType } from "./common";
+
+export interface ParsedURL {
+  recording: number;
+  choir: number;
+  part: PartType;
+  bar: number;
+  dark: boolean;
+  early: boolean;
+}
+
+export function parseURLSearch(search: string): ParsedURL {
+  const url = search.substring(1);
+  const parms = url.split("&");
+
+  var recording = 0; // ALC
+  var choir = 0; // choir 1 because it is zero indexed
+  var part: PartType = "all";
+  var bar = 1 - config.intro_beats[recording] / 4;
+  var dark = true; // dark mode by default
+  var early = false;
+  var r = 0; // ALC
+
+  for (let i = 0; i < parms.length; i++) {
+    const eq = parms[i].indexOf("=");
+    const key = eq === -1 ? parms[i] : parms[i].slice(0, eq);
+    const val = eq === -1 ? undefined : parms[i].slice(eq + 1);
+    if (key == "choir") {
+      choir = Number(val);
+    } else if (key == "part") {
+      const n: number = Number(val);
+      if (n >= 0 && n < config.parts.length) part = n;
+    } else if (key == "bar") {
+      bar = Number(val);
+    } else if (key == "dark") {
+      dark = true;
+    } else if (key == "recording") {
+      if (val == "alc") r = 0;
+      else r = 1;
+    } else if (key == "score") {
+      early = val == "early";
+    }
+  }
+
+  return { recording: r, choir, part, bar, dark, early };
+}


### PR DESCRIPTION
## Problem

`parseURL` split each `key=value` URL parameter on `"="` and took `parm[1]`
as the value, so any value containing `"="` was truncated at the first one.
For example `?recording=alc=extra` parsed the value as `"alc"` rather than
`"alc=extra"`.

## Fix

Extract the parsing into a pure, exported `parseURLSearch(search)` in
`src/ts/url.ts`, and parse each pair with `indexOf("=")` + `slice` so the
whole value (including any further `"="`) is preserved. `index.ts`'s
`parseURL()` now delegates to it; behaviour is otherwise identical to the
previous inline parser.

## Tests

`src/test/url.test.ts` covers the `"="`-preservation fix (with a tight
`?score=early=x` assertion that fails against the old `split()`), normal
parameters, the empty-search defaults, and the no-`=` (flag) branch.

Fixes #410
