### PR TITLE
refactor: type maskRect/maskLine fields, drop positional mask indexing

### DIFF
--- a/src/test/score.test.ts
+++ b/src/test/score.test.ts
@@ -127,9 +127,31 @@ describe("MusicScore custom element", () => {
     await waitingForLoaded;
 
     const indicatorWidth = elem.highlightPosition.getAttribute("width");
-    const maskRect = elem.highlightMask.children[0];
-    const maskWidth = maskRect.getAttribute("width");
+    const maskWidth = elem.maskRect!.getAttribute("width");
     expect(maskWidth).toBe(indicatorWidth);
+  });
+
+  it("exposes typed maskRect and maskLine fields as children of highlightMask", async () => {
+    const elem = document.querySelector("music-score") as MusicScore;
+    elem.scrollTo = vi.fn();
+
+    const waitingForLoaded = waitForEvent(
+      elem,
+      "music-score-loaded",
+      handleScoreLoaded,
+      0,
+      null,
+      0
+    );
+    elem?.setAttribute("choir", "0");
+    await waitingForLoaded;
+
+    expect(elem.maskRect).not.toBeNull();
+    expect(elem.maskLine).not.toBeNull();
+    expect(elem.maskRect!.tagName).toBe("rect");
+    expect(elem.maskLine!.tagName).toBe("line");
+    expect(elem.highlightMask.children).toContain(elem.maskRect);
+    expect(elem.highlightMask.children).toContain(elem.maskLine);
   });
 
   it("highlightPosition width changes with score type", async () => {

--- a/src/ts/MusicScore.ts
+++ b/src/ts/MusicScore.ts
@@ -40,6 +40,8 @@ export class MusicScore extends MusicElement {
     "http://www.w3.org/2000/svg",
     "mask"
   );
+  maskRect!: SVGRectElement;
+  maskLine!: SVGLineElement;
   scrollArea: HTMLDivElement | null = null;
   clefOverlay: HTMLDivElement | null = null;
 
@@ -61,24 +63,24 @@ export class MusicScore extends MusicElement {
 
     this.highlightMask.setAttribute("id", "hPosMask");
     this.highlightMask.setAttribute("maskUnits", "userSpaceOnUse");
-    const maskRect = document.createElementNS(
+    this.maskRect = document.createElementNS(
       "http://www.w3.org/2000/svg",
       "rect"
     );
-    maskRect.setAttribute("width", "7");
-    maskRect.setAttribute("height", "0");
-    maskRect.setAttribute("fill", "white");
-    const maskLine = document.createElementNS(
+    this.maskRect.setAttribute("width", "7");
+    this.maskRect.setAttribute("height", "0");
+    this.maskRect.setAttribute("fill", "white");
+    this.maskLine = document.createElementNS(
       "http://www.w3.org/2000/svg",
       "line"
     );
-    maskLine.setAttribute("y1", "0");
-    maskLine.setAttribute("y2", "0");
-    maskLine.setAttribute("stroke", "black");
-    maskLine.setAttribute("stroke-dasharray", "2 2");
-    maskLine.setAttribute("stroke-width", "0.75");
-    this.highlightMask.appendChild(maskRect);
-    this.highlightMask.appendChild(maskLine);
+    this.maskLine.setAttribute("y1", "0");
+    this.maskLine.setAttribute("y2", "0");
+    this.maskLine.setAttribute("stroke", "black");
+    this.maskLine.setAttribute("stroke-dasharray", "2 2");
+    this.maskLine.setAttribute("stroke-width", "0.75");
+    this.highlightMask.appendChild(this.maskRect);
+    this.highlightMask.appendChild(this.maskLine);
     this.highlightPosition.setAttribute("mask", "url(#hPosMask)");
 
     this.highlightBar.setAttribute("id", "hBar");
@@ -199,11 +201,8 @@ export class MusicScore extends MusicElement {
 
     this.highlightPosition.setAttribute("height", String(this.svgHeight));
     this.highlightBar.setAttribute("height", String(this.svgHeight));
-    this.highlightMask.children[0].setAttribute(
-      "height",
-      String(this.svgHeight)
-    );
-    this.highlightMask.children[1].setAttribute("y2", String(this.svgHeight));
+    this.maskRect.setAttribute("height", String(this.svgHeight));
+    this.maskLine.setAttribute("y2", String(this.svgHeight));
     this.svg.prepend(this.highlightPosition);
     this.svg.prepend(this.highlightBar);
     this.svg.prepend(this.highlightPart);
@@ -218,10 +217,7 @@ export class MusicScore extends MusicElement {
 
     const indicatorWidth = this.svgWidth / 600;
     this.highlightPosition.setAttribute("width", String(indicatorWidth));
-    this.highlightMask.children[0].setAttribute(
-      "width",
-      String(indicatorWidth)
-    );
+    this.maskRect.setAttribute("width", String(indicatorWidth));
 
     // Highlight and scroll to the current bar. Defer scrollSmooth() via
     // requestAnimationFrame so the layout reads inside it (offsetWidth,
@@ -289,15 +285,9 @@ export class MusicScore extends MusicElement {
       );
       const xPos = barcurrentpct * this.svgWidth - indicatorWidth / 2;
       this.highlightPosition.setAttribute("x", String(xPos));
-      this.highlightMask.children[0].setAttribute("x", String(xPos));
-      this.highlightMask.children[1].setAttribute(
-        "x1",
-        String(xPos + indicatorWidth / 2)
-      );
-      this.highlightMask.children[1].setAttribute(
-        "x2",
-        String(xPos + indicatorWidth / 2)
-      );
+      this.maskRect.setAttribute("x", String(xPos));
+      this.maskLine.setAttribute("x1", String(xPos + indicatorWidth / 2));
+      this.maskLine.setAttribute("x2", String(xPos + indicatorWidth / 2));
     }
 
     // set the highlight for the current bar


### PR DESCRIPTION
Replaces the positional `highlightMask.children[0]` / `[1]` access in
`MusicScore` with typed `maskRect` / `maskLine` fields (definite-assignment),
removing the fragile index assumption flagged in #298's Vera findings. Adds a
test asserting the typed fields are exposed as children of `highlightMask`.

Behaviour-preserving: the mask renders identically; the change is purely the
internal element references and their types.

The original branch also carried a `bar <= 0` → `bar < 1` change to the
`MusicCanvas` bar-highlight guard. Review showed that is **not** a no-op — it
would hide the playback cursor during the fractional first/intro bar, a
perceptual change that needs sign-off. It has been **split out** of this PR
into a separate item pending perceptual approval; this PR is the
behaviour-preserving mask-indexing refactor only.

Fixes #413
