### PR TITLE
fix: eliminate redundant build by passing dist artefact from CI to deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
           echo "Unit tests completed in ${duration}s (exit ${status})"
           exit "$status"
 
+      - name: Upload build artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
       # if: always() runs the report even when an upstream step failed —
       # the missing-duration case is handled below. Budgets are SOFT: a
       # breach emits a workflow warning annotation and a Budget-exceeded

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,47 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - uses: actions/setup-node@v6
+      - name: Download build artefact
+        uses: actions/download-artifact@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
-      # Cache the generated SVGs keyed on a hash of every input that affects
-      # them (build/scoreCacheKey.mjs). On an exact-key hit we restore the
-      # SVGs and skip the LilyPond install + regeneration entirely.
-      # There is deliberately NO restore-keys fallback: a partial-key match
-      # would restore stale SVGs and ship wrong scores. (#421)
-      - name: Compute score cache key
-        id: scorekey
-        run: |
-          key="$(node build/scoreCacheKey.mjs)"
-          if [[ ! "$key" =~ ^[0-9a-f]{64}$ ]]; then
-            echo "::error::scoreCacheKey.mjs produced an invalid key: '$key'" >&2
-            exit 1
-          fi
-          echo "key=$key" >> "$GITHUB_OUTPUT"
-
-      - name: Restore generated SVG cache
-        id: scores-cache
-        uses: actions/cache@v4
-        with:
-          path: src/scores
-          key: scores-v1-${{ steps.scorekey.outputs.key }}
-
-      # Install LilyPond only on a cache miss. On a hit the restored SVGs are
-      # used as-is and buildScores.mjs --skip-if-missing skips regeneration.
-      - name: Install LilyPond
-        if: steps.scores-cache.outputs.cache-hit != 'true'
-        run: |
-          bash build/install-lilypond.sh
-          echo "$HOME/.local/lilypond/lilypond-2.26.0/bin" >> "$GITHUB_PATH"
-
-      - run: npm ci
-
-      - name: Build
-        run: |
-          export PATH="$HOME/.local/lilypond/lilypond-2.26.0/bin:$PATH"
-          npm run build
+          name: dist
+          path: dist/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Install Netlify CLI
         run: npm install -g netlify-cli

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -72,16 +72,14 @@ Triggers via `workflow_run` when the `CI` workflow completes successfully on a p
 
 Steps:
 
-- `actions/checkout` — checks out the exact commit SHA that CI validated (`github.event.workflow_run.head_sha`).
-- `actions/setup-node` — installs Node.js from `.nvmrc`.
-- Compute score cache key and restore generated SVGs — skips LilyPond install when inputs are unchanged.
-- Install LilyPond — only on cache miss.
-- `npm ci` — install dependencies.
-- `npm run build` — production Vite build.
+- `actions/checkout` — checks out the exact commit SHA that CI validated (`github.event.workflow_run.head_sha`). Also ensures `netlify.toml` is present for the CLI.
+- `actions/download-artifact` — downloads the `dist` artefact produced by the CI `test` job.
 - Install Netlify CLI.
 - `netlify deploy --prod` — deploy to production.
 
-This workflow depends on the `CI` workflow passing first. It does not run on scheduled CI runs or PR CI runs.
+This workflow does not rebuild the site. The build output is produced once in CI and passed as an artefact. This avoids redundant builds and saves GitHub Actions minutes.
+
+This workflow does not run on scheduled CI runs or PR CI runs.
 
 ### `netlify-preview.yml`
 


### PR DESCRIPTION
Fixes #440

Also closes #437 (already applied).

## What changed

- **CI uploads:** The `test` job in `ci.yml` now uploads `dist/` as a workflow artefact after unit tests pass.
- **Deploy downloads:** `deploy-production.yml` downloads the `dist` artefact from the CI run instead of rebuilding from source.
- **Removed from deploy:** setup-node, score cache key, SVG cache, LilyPond install, `npm ci`, `npm run build`.
- **Deploy is now minimal:** checkout → download artefact → install Netlify CLI → deploy.
- **Docs:** `doc/CI.md` updated to describe the artefact-passing architecture.

## Savings

Per merge to `main`: ~2–3 minutes (cache hit) or 10+ minutes (cache miss) of redundant build time eliminated.
