### PR TITLE
fix: use realpathSync for isMain check on macOS

### DIFF
--- a/build/buildScores.mjs
+++ b/build/buildScores.mjs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 import { execSync } from "child_process";
-import { existsSync, globSync, mkdirSync, rmSync, statSync } from "fs";
+import { existsSync, globSync, mkdirSync, realpathSync, rmSync, statSync } from "fs";
 import { basename, resolve } from "path";
 import { fileURLToPath } from "url";
 import { postprocessSvg } from "./postprocessSvg.mjs";
@@ -236,7 +236,7 @@ function main() {
 // imported by tests. `process.argv[1]` is undefined under some embed contexts;
 // treat that as "not main".
 const __filename = fileURLToPath(import.meta.url);
-const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(__filename);
+const isMain = process.argv[1] && realpathSync(process.argv[1]) === realpathSync(__filename);
 if (isMain) {
   main();
 }


### PR DESCRIPTION
Fixes #442

## Problem

On macOS,  is a symlink to . The  check in  used  which does not follow symlinks, so  and  never matched. The script exited silently without building anything.

## Fix

Replace  with  in the  comparison. This follows symlinks and normalises both paths to the same physical location.

## Verification

- 
> spem-player@2.5.0 test
> vitest run


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.6 [39m[90m/Users/mark/github/spem-player[39m

[90mstdout[2m | src/test/canvas.test.ts[2m > [22m[2mMusicCanvas custom element[2m > [22m[2mCheck that the canvasent contains a canvas
[22m[39m<canvas width="4000" height="1000" style="width: 100%; height: 100%;"></canvas>

 [32m✓[39m src/test/lily.test.ts [2m([22m[2m16 tests[22m[2m)[22m[33m 1075[2mms[22m[39m
     [33m[2m✓[22m[39m processLilypond() throws on parse failure [33m 338[2mms[22m[39m
     [33m[2m✓[22m[39m processLilypond() is idempotent over the parse — repeated cold calls produce equal data [33m 472[2mms[22m[39m
 [32m✓[39m src/test/canvas.test.ts [2m([22m[2m24 tests[22m[2m)[22m[33m 1381[2mms[22m[39m
 [32m✓[39m src/test/keyboard.test.ts [2m([22m[2m38 tests[22m[2m)[22m[33m 2368[2mms[22m[39m
 [32m✓[39m src/test/darkmode.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 774[2mms[22m[39m
 [32m✓[39m src/test/setbar.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 746[2mms[22m[39m
 [32m✓[39m src/test/score.test.ts [2m([22m[2m24 tests[22m[2m)[22m[33m 648[2mms[22m[39m
 [32m✓[39m src/test/controls.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 293[2mms[22m[39m
 [32m✓[39m src/test/feedback.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 711[2mms[22m[39m
 [32m✓[39m src/test/common.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 51[2mms[22m[39m
[90mstdout[2m | src/test/main.test.ts[2m > [22m[2mindex.js[2m > [22m[2mCheck that the score, canvas and controls are all there
[22m[39m

 [32m✓[39m src/test/main.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 63[2mms[22m[39m
 [32m✓[39m src/test/scoreCacheKey.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 153[2mms[22m[39m
 [32m✓[39m src/test/postprocessSvgDedup.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/test/canvaswatcher.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m src/test/postprocessSvg.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/test/music-classes.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/musicelement.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/test/spem.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/test/worktree-ports.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/buildScores.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/config.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/docs.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/url.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/helpers.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/integration/buildScores.test.ts [2m([22m[2m12 tests[22m[2m)[22m[33m 7618[2mms[22m[39m
     [33m[2m✓[22m[39m builds all notations [33m 1206[2mms[22m[39m
     [33m[2m✓[22m[39m creates missing score output directories on a clean checkout (#318) [33m 728[2mms[22m[39m
     [33m[2m✓[22m[39m caches by mtime [33m 847[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds all scores when a version-root include is newer (Vera 353-01) [33m 1511[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds the touched choir's notation when its own .ly is newer (Vera 353-11) [33m 1173[2mms[22m[39m
     [33m[2m✓[22m[39m does NOT rebuild a sibling notation when only one notation changes (Vera 353-07) [33m 1149[2mms[22m[39m
     [33m[2m✓[22m[39m does not build OUP [33m 617[2mms[22m[39m

[2m Test Files [22m [1m[32m24 passed[39m[22m[90m (24)[39m
[2m      Tests [22m [1m[32m252 passed[39m[22m[90m (252)[39m
[2m   Start at [22m 17:16:14
[2m   Duration [22m 8.32s[2m (transform 567ms, setup 188ms, import 792ms, tests 15.93s, environment 10.76s)[22m passes locally (252/252 tests, including all 12 integration tests in ).