### PR TITLE
build: bump actions/checkout and actions/setup-node to v6 (#438 #443)

### DIFF
--- a/.github/workflows/monitor-resources.yml
+++ b/.github/workflows/monitor-resources.yml
@@ -14,7 +14,7 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check usage and notify
         env:

--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -16,9 +16,9 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: npm


### PR DESCRIPTION
Fixes #438
Fixes #443

Bumps remaining Node.js 20 actions to v6:

- `.github/workflows/monitor-resources.yml` — `actions/checkout@v4` → `v6`
- `.github/workflows/netlify-preview.yml` — `actions/checkout@v4` → `v6`
- `.github/workflows/netlify-preview.yml` — `actions/setup-node@v4` → `v6`

`deploy-production.yml` was already on v6 from prior CI work (#434/#440).