### PR TITLE
ci(e2e): restore SVG cache and install LilyPond on cache miss (#452)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,30 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
       - run: npm ci
+
+      - name: Compute score cache key
+        id: scorekey
+        run: |
+          key="$(node build/scoreCacheKey.mjs)"
+          if [[ ! "$key" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::scoreCacheKey.mjs produced an invalid key: '$key'" >&2
+            exit 1
+          fi
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Restore generated SVG cache
+        id: scores-cache
+        uses: actions/cache@v4
+        with:
+          path: src/scores
+          key: scores-v1-${{ steps.scorekey.outputs.key }}
+
+      - name: Install LilyPond
+        if: steps.scores-cache.outputs.cache-hit != 'true'
+        run: |
+          bash build/install-lilypond.sh
+          echo "$HOME/.local/lilypond/lilypond-2.26.0/bin" >> "$GITHUB_PATH"
+
       - run: npm run build
       - run: npx playwright install --with-deps
       - run: npm run e2e


### PR DESCRIPTION
Fixes #452

The E2E workflow was not updated when `--skip-if-missing` was hardened in #318/#421. It now needs either cached SVGs or a LilyPond install to pass the canary check.

Changes:
- Compute score cache key (mirrors `ci.yml`)
- Restore generated SVG cache via `actions/cache@v4`
- Install LilyPond on cache miss, with PATH added to `GITHUB_PATH` for the build step

On a cache hit the restored SVGs are used as-is and LilyPond is skipped. On a miss LilyPond is installed and the build regenerates the SVGs.