### PR TITLE
fix: move build-resource monitor cron off the top of the hour

### DIFF
--- a/.github/workflows/monitor-resources.yml
+++ b/.github/workflows/monitor-resources.yml
@@ -2,7 +2,9 @@ name: Monitor Build Resources
 
 on:
   schedule:
-    - cron: "0 8 * * *"
+    # 07:30 UTC (07:30 GMT / 08:30 BST). Off-hour to dodge GitHub
+    # top-of-hour scheduling throttling; see #454.
+    - cron: "30 7 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Moves the daily build-resource monitor's schedule off the top of the hour.

`0 8 * * *` (08:00 UTC = 09:00 BST) was prone to GitHub Actions' well-documented top-of-hour scheduling throttling — scheduled runs on the hour are delayed or silently dropped under platform-wide contention — and on 2026-06-02 the run did not fire. The new `30 7 * * *` (07:30 UTC = 08:30 BST) sits off the hour and closer to the intended 08:00 local time, with a comment documenting the UTC/local mapping.

No code is under test here (the value is consumed by GitHub's scheduler, not by application code), so verification is manual per the spec: a `workflow_dispatch` confirms the file is valid and the job runs, and the next scheduled run can be observed in the Actions tab.

Fixes #454
