### PR TITLE
fix: resolve port offset from a module-relative .worktree-offset file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+.worktree-offset
 node_modules
 dist
 *.ipynb

--- a/src/test/worktree-ports.test.ts
+++ b/src/test/worktree-ports.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { portOffset, DEV_PORT, PREVIEW_PORT } from "../../worktree-ports.ts";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  portOffset,
+  DEV_PORT,
+  PREVIEW_PORT,
+  readWorktreeOffset,
+} from "../../worktree-ports.ts";
 
 describe("worktree-ports", () => {
   it("DEV_PORT is exactly 1000 above PREVIEW_PORT (single shared offset)", () => {
@@ -37,5 +46,28 @@ describe("worktree-ports", () => {
     expect(portOffset("1OO")).toBe(0); // letter O, not zeros
     expect(portOffset("-100")).toBe(0);
     expect(portOffset("10.5")).toBe(0);
+  });
+});
+
+describe("readWorktreeOffset", () => {
+  it("reads the trimmed offset from a .worktree-offset file beside the module", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt-offset-"));
+    try {
+      writeFileSync(join(dir, ".worktree-offset"), "200\n");
+      const moduleUrl = pathToFileURL(join(dir, "worktree-ports.ts")).href;
+      expect(readWorktreeOffset(moduleUrl)).toBe("200");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when no .worktree-offset file sits beside the module", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wt-offset-"));
+    try {
+      const moduleUrl = pathToFileURL(join(dir, "worktree-ports.ts")).href;
+      expect(readWorktreeOffset(moduleUrl)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/worktree-ports.ts
+++ b/worktree-ports.ts
@@ -1,14 +1,22 @@
 // Per-worktree dev/preview port offset, so multiple agent worktrees can
 // run their dev/preview servers at once without colliding.
 //
-// Each worktree declares its own offset via the SPEM_PORT_OFFSET
-// environment variable, set once in that worktree (its launch script or
-// a gitignored .env.local). Anything that does NOT set it — CI, forks, a
-// fresh clone, the main checkout — gets offset 0 and the default ports,
-// so config evaluation can never fail on an unrecognised checkout
-// directory. The offset is the worktree's own fact to declare; we do not
-// infer it from the directory name (CI checks out into `spem-player`, a
-// fork could be named anything — the name is an unreliable proxy).
+// Each worktree declares its own offset, resolved in order from:
+//   1. the SPEM_PORT_OFFSET environment variable, if set; otherwise
+//   2. a gitignored `.worktree-offset` file beside this module, holding
+//      just the number.
+// Anything that declares neither — CI, forks, a fresh clone, the main
+// checkout — gets offset 0 and the default ports, so config evaluation
+// can never fail on an unrecognised checkout.
+//
+// The file fallback exists because the environment variable is not
+// reliably delivered to programmatically-spawned processes (IDE task
+// runners, test harnesses); a child may never see SPEM_PORT_OFFSET. The
+// file is resolved relative to this module's own location, not the
+// process cwd, so it is correct however the process was launched. The
+// offset is the worktree's own fact to declare; we do not infer it from
+// the directory name (CI checks out into `spem-player`, a fork could be
+// named anything — the name is an unreliable proxy).
 //
 // Suggested per-worktree values (offset -> dev / preview):
 //   main / claude  0   -> 5173 / 4173
@@ -20,13 +28,39 @@
 // vite.config.ts and playwright.config.ts read DEV_PORT / PREVIEW_PORT at
 // config-eval time; the offset is resolved once here at module load.
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 /**
- * Resolve the per-worktree port offset from `SPEM_PORT_OFFSET`.
+ * Read the raw offset from a `.worktree-offset` file beside this module.
  *
- * @param raw - the raw env value (defaults to
- *   `process.env.SPEM_PORT_OFFSET`).
- * @returns the offset as a non-negative integer, or `0` when the
- *   variable is unset, empty, or not a valid non-negative integer.
+ * @param metaUrl - module URL to resolve the file against (defaults to this
+ *   module's own `import.meta.url`). Resolving against the module location,
+ *   not `process.cwd()`, keeps it correct however the process was launched.
+ * @returns the trimmed file contents, or `undefined` when the file is
+ *   absent or unreadable. Never throws.
+ */
+export function readWorktreeOffset(
+  metaUrl: string = import.meta.url,
+): string | undefined {
+  try {
+    const dir = dirname(fileURLToPath(metaUrl));
+    return readFileSync(resolve(dir, ".worktree-offset"), "utf-8").trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the per-worktree port offset from `SPEM_PORT_OFFSET`, falling
+ * back to a `.worktree-offset` file beside this module.
+ *
+ * @param raw - the raw offset value (defaults to
+ *   `process.env.SPEM_PORT_OFFSET`, falling back to the `.worktree-offset`
+ *   file when the variable is unset).
+ * @returns the offset as a non-negative integer, or `0` when neither
+ *   source is set, empty, or a valid non-negative integer.
  *
  * Never throws: a mistyped offset degrades to the default ports rather
  * than breaking config-eval for every command (test, build, lint). A
@@ -34,7 +68,8 @@
  * EADDRINUSE at preview bind, where Playwright uses `strictPort`.
  */
 export const portOffset = (
-  raw: string | undefined = process.env.SPEM_PORT_OFFSET,
+  raw: string | undefined = process.env.SPEM_PORT_OFFSET ??
+    readWorktreeOffset(),
 ): number => {
   const n = Number(raw);
   return Number.isInteger(n) && n >= 0 ? n : 0;


### PR DESCRIPTION
## Summary

`worktree-ports.ts` resolved the per-worktree dev/preview port offset only
from `process.env.SPEM_PORT_OFFSET`. That variable is not reliably delivered
to programmatically-spawned processes (IDE task runners, test harnesses), so
parallel worktrees could collide on 5173/4173.

This adds a fallback: when `SPEM_PORT_OFFSET` is unset, read the offset from a
gitignored `.worktree-offset` file resolved **relative to the module's own
location** (`import.meta.url`), so it is correct regardless of where the
process was invoked from or how its shell was started.

Precedence: `SPEM_PORT_OFFSET` (if set) -> `.worktree-offset` file (if present)
-> `0`.

Name-agnostic and self-defaulting: a checkout with no `.worktree-offset` file
(a normal clone, a fork, CI, the main checkout) keeps today's behaviour exactly
(offset 0). The file is gitignored and holds only a number, so no
per-environment topology enters the repository.

## Changes

- `worktree-ports.ts`: add a `readWorktreeOffset()` helper (module-relative,
  never throws); `portOffset` uses it as the fallback after the env var.
- `src/test/worktree-ports.test.ts`: cover the helper (file present / absent).
- `.gitignore`: ignore `.worktree-offset`.

## Testing

- `npm test` (254 passed), `npm run check` (format / lint / types / deps clean),
  `npm run build` all green.
- e2e not run locally: without a `.worktree-offset` file the new path is
  inactive, so behaviour in CI is byte-identical (offset 0); CI runs e2e on this
  PR regardless.

Fixes #456

- Claude
