### PR TITLE
ci(netlify-preview): skip deploy-preview job for Dependabot PRs

### DIFF
--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   deploy-preview:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Fixes the authentication failure seen on #458.

Dependabot-triggered workflows cannot access repository Actions secrets. The `NETLIFY_AUTH_TOKEN` secret is unavailable to Dependabot, causing every preview deploy to fail with:

> Error: Authentication required. NETLIFY_AUTH_TOKEN is not set.

This adds a job-level `if:` guard to skip the deploy-preview job when the actor is `dependabot[bot]`. CI (test, integration) still runs as normal; only the Netlify preview deploy is skipped.