### PR TITLE
docs: add direct-push policy and worktree port documentation (#436)

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -21,6 +21,23 @@ npm run dev
 
 This serves the application locally with hot module replacement. The `--host` flag is set, so the server is accessible on the local network.
 
+### Parallel worktrees
+
+Multiple worktrees can run dev and preview servers simultaneously by setting
+`SPEM_PORT_OFFSET` in each worktree's environment (for example, in a
+`.env.local` file). The offset is added to the default ports:
+
+| Worktree | Offset | Dev port | Preview port |
+| --- | --- | --- | --- |
+| default | 0 | 5173 | 4173 |
+| vera | 100 | 5273 | 4273 |
+| kimi | 200 | 5373 | 4373 |
+| copilot | 300 | 5473 | 4473 |
+| tele | 400 | 5573 | 4573 |
+
+`vite.config.ts` and `playwright.config.ts` read the offset from
+`worktree-ports.ts` at config-eval time.
+
 ## Build for Production
 
 ```console

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -211,6 +211,10 @@ A well-formed ticket body contains:
   board item automatically. The difference is that `Fixes` also closes the issue
   on merge; `See` does not.
 
+#### Direct push policy
+
+The repository owner may push directly to `main` only for **non-code changes**: documentation updates, configuration comments, and metadata. All code changes — including build scripts, tooling, and test files — must go through a pull request.
+
 #### What you do when you receive a PR
 
 - **Approve and merge** - Submit `Approve` review, merge PR to `main` - Move ticket from `Review` to `Done`

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -123,6 +123,10 @@ The production build must exist before e2e tests run:
 npm run build
 ```
 
+When running e2e tests in a parallel worktree, ensure `SPEM_PORT_OFFSET` is set
+so that `vite preview` and Playwright target the same non-default port. See
+`doc/BUILD.md` § Parallel worktrees.
+
 ### Running E2E Tests
 
 Headless run:


### PR DESCRIPTION
docs: add direct-push policy and worktree port documentation (#436)

## Changes

- `doc/CONTRIBUTING.md` § "For the Maintainer": add Direct push policy restricting Mark's direct-push bypass to non-code changes only.
- `doc/BUILD.md` § Development: add Parallel worktrees table documenting `SPEM_PORT_OFFSET` and per-worktree port offsets.
- `doc/TESTING.md` § E2E Prerequisites: add cross-reference to parallel worktrees for e2e testing in non-default worktrees.

## Also closes Workbench items

- #265 — Post-merge doc for #369 (no change needed, type narrowing has no doc impact)
- #272 — Post-merge doc for #318 (already covered)
- #279 — Post-merge doc for #327 (ticket closed as NOT_PLANNED)
- #297 — Post-merge doc for #388 (bug fix, no doc impact)
- #329 — Post-merge doc for #421 (already covered in BUILD.md § Caching)
- #330 — Post-merge doc for #423 (ticket closed without merge)
- #303 — Post-merge doc for #408 (worktree ports now documented)

See #436
