### PR TITLE
ci: add workflow to regenerate and commit SVGs on LilyPond changes (#462)

### DIFF
--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -1,0 +1,52 @@
+name: Regenerate SVGs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/lilypond/**"
+      - "build/buildScores.mjs"
+      - "build/postprocessSvg.mjs"
+      - "build/install-lilypond.sh"
+  pull_request:
+    paths:
+      - "src/lilypond/**"
+      - "build/buildScores.mjs"
+      - "build/postprocessSvg.mjs"
+      - "build/install-lilypond.sh"
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate-svgs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+
+      - run: npm ci
+
+      - run: bash build/install-lilypond.sh
+
+      - run: |
+          export PATH="$HOME/.local/lilypond/lilypond-2.26.0/bin:$PATH"
+          npm run build:scores
+
+      - name: Commit updated SVGs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/scores/
+          if git diff --cached --quiet; then
+            echo "No SVG changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: regenerate SVGs [skip ci]"
+          git push


### PR DESCRIPTION
Fixes #462

Creates `.github/workflows/lilypond.yml` with path-filtered triggers:
- Fires on push to `main` or `pull_request` when `src/lilypond/**`, `build/buildScores.mjs`, `build/postprocessSvg.mjs`, or `build/install-lilypond.sh` change
- Installs LilyPond, runs `npm run build:scores`
- Commits updated `src/scores/` back to the branch with skip-ci in the commit message
- Uses `ref: ${{ github.head_ref || github.ref_name }}` to handle both main pushes and PR branches

The workflow has `permissions: contents: write` so the bot can push the SVG commit.