### PR TITLE
ci: simplify test job — remove LilyPond, SVG cache, merge integration tests (#463)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Daily at 00:00 UTC — catches drift in the integration suite on days
-  # when no build-related PR triggered the path-filtered integration job.
-  # GitHub may delay scheduled runs by up to ~15 min during peak load.
+  # Daily at 00:00 UTC — catches drift in the test suite on days when no PR
+  # triggered the job. GitHub may delay scheduled runs by up to ~15 min during
+  # peak load.
   schedule:
     - cron: "0 0 * * *"
 
@@ -22,47 +22,6 @@ jobs:
           cache: npm
       - run: npm ci
 
-      # Cache the generated SVGs keyed on a hash of every input that affects
-      # them (build/scoreCacheKey.mjs — the single source of truth, unit-tested
-      # in src/test/scoreCacheKey.test.ts). On an exact-key hit we restore the
-      # SVGs and skip the LilyPond install + regeneration entirely (~570s);
-      # buildScores.mjs's --skip-if-missing canary path then carries the build
-      # on the restored SVGs. There is deliberately NO restore-keys fallback: a
-      # partial-key match would restore stale SVGs and ship wrong scores. (#421)
-      - name: Compute score cache key
-        id: scorekey
-        run: |
-          # Assign first so `set -e` (on by default in Actions) catches a
-          # non-zero exit — a command substitution inside `echo "key=$(...)"`
-          # would NOT trip set -e, silently writing an empty key. Then assert
-          # the digest shape, so a script failure or empty key fails the build
-          # rather than collapsing the cache key to the constant "scores-v1-"
-          # and self-poisoning the cache. (#421)
-          key="$(node build/scoreCacheKey.mjs)"
-          if [[ ! "$key" =~ ^[0-9a-f]{64}$ ]]; then
-            echo "::error::scoreCacheKey.mjs produced an invalid key: '$key'" >&2
-            exit 1
-          fi
-          echo "key=$key" >> "$GITHUB_OUTPUT"
-
-      # actions/cache restores on an exact-key hit; it SAVES src/scores in an
-      # automatic post-job step only on a key miss (and only if the job
-      # succeeds). There is no explicit save step.
-      - name: Restore generated SVG cache
-        id: scores-cache
-        uses: actions/cache@v4
-        with:
-          path: src/scores
-          key: scores-v1-${{ steps.scorekey.outputs.key }}
-
-      # Install LilyPond only on a cache miss. On a hit the restored SVGs are
-      # used as-is. Mirrors the netlify.toml chain — same script, same explicit
-      # PATH export across the `&&` boundary in the build step below (the
-      # script's own export does not propagate).
-      - name: Install LilyPond
-        if: steps.scores-cache.outputs.cache-hit != 'true'
-        run: bash build/install-lilypond.sh
-
       # Timed-step pattern: capture command exit status separately so duration
       # is emitted even on failure (telemetry is most useful precisely when a
       # phase regresses), then re-exit with the captured status so the
@@ -70,7 +29,6 @@ jobs:
       - name: Run checks and build
         id: check-build
         run: |
-          export PATH="$HOME/.local/lilypond/lilypond-2.26.0/bin:$PATH"
           start=$(date +%s)
           status=0
           npm run check && npm run build || status=$?
@@ -92,12 +50,8 @@ jobs:
           echo "Unit tests completed in ${duration}s (exit ${status})"
           exit "$status"
 
-      - name: Upload build artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-          retention-days: 1
+      - name: Run integration tests
+        run: npm run test:integration
 
       # if: always() runs the report even when an upstream step failed —
       # the missing-duration case is handled below. Budgets are SOFT: a
@@ -150,65 +104,3 @@ jobs:
             report "**Budget exceeded:** measured phases took ${total}s (> ${TOTAL_BUDGET_SEC}s)."
           fi
 
-  integration:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # paths-filter falls back to the GitHub API to list a PR's changed files
-    # (the checkout is shallow), which needs pull-requests:read. With a
-    # restrictive default token (e.g. after the repo was made private) that
-    # call fails with "Resource not accessible by integration", skipping the
-    # tests and reddening the job. Grant the read scopes explicitly.
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dorny/paths-filter@v4
-        id: filter
-        if: github.event_name == 'pull_request'
-        with:
-          filters: |
-            build-related:
-              - "build/**"
-              - "src/lilypond/**"
-              - "src/test/integration/**"
-              - "package.json"
-              - "package-lock.json"
-              - "vite.config.ts"
-              - "tsconfig.json"
-              - ".nvmrc"
-              - ".github/workflows/ci.yml"
-
-      - name: Check if integration tests should run
-        id: should-run
-        run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.filter.outputs.build-related }}" == "true" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
-
-      - uses: actions/setup-node@v6
-        if: steps.should-run.outputs.run == 'true'
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-        if: steps.should-run.outputs.run == 'true'
-
-      - name: Run integration tests
-        run: npm run test:integration
-        if: steps.should-run.outputs.run == 'true'
-
-      - name: Report skip when no build-related changes
-        if: steps.should-run.outputs.run != 'true'
-        run: |
-          msg="Integration tests skipped — should-run='${{ steps.should-run.outputs.run }}' (PR did not touch build-related paths)."
-          echo "$msg"
-          echo "$msg" >> "$GITHUB_STEP_SUMMARY"

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -13,30 +13,11 @@ The repository uses GitHub Actions for automated testing, dependency updates, de
 
 Triggers on every push and pull request to `main`, and nightly at 00:00 UTC via a `schedule` cron.
 
-Defines two parallel jobs.
+Defines one job.
 
 #### `test` job
 
-Runs on every trigger. Executes `npm run check` (lint, format, type check, unused, deps) and `npm run build` as one timed phase, then `npm run test:unit` (the fast unit suite) as a second timed phase, both measured against a soft duration budget — see Duration Budget below. This is the required status check for the `main` branch ruleset; pull requests cannot merge until it passes.
-
-#### `integration` job
-
-Runs the subprocess-heavy integration suite (`src/test/integration/`). It runs unconditionally on push to `main` and on the nightly cron, but on pull requests it uses `dorny/paths-filter` to skip unless the PR touches one of:
-
-- `build/**`
-- `src/lilypond/**`
-- `src/scores/**`
-- `src/test/integration/**`
-- `package.json`
-- `package-lock.json`
-- `vite.config.ts`
-- `tsconfig.json`
-- `.nvmrc`
-- `.github/workflows/ci.yml`
-
-A skipped PR run is reported on the workflow summary page and in the job log with a message quoting the actual `should-run` output (e.g. `Integration tests skipped — should-run='false' (PR did not touch build-related paths).`), so the absence of test output is visible rather than appearing as a silent pass.
-
-The `integration` job is not currently a required check; failures surface but do not block merge. This is deliberate while the path-filter and skip-reporting behaviour bed in.
+Runs on every trigger. Executes `npm run check` (lint, format, type check, unused, deps) and `npm run build` as one timed phase, then `npm run test:unit` as a second timed phase, then `npm run test:integration`. All are measured against a soft duration budget — see Duration Budget below. This is the required status check for the `main` branch ruleset; pull requests cannot merge until it passes.
 
 ### `e2e.yml`
 


### PR DESCRIPTION
Fixes #463

- Removes score cache key, SVG cache restore, LilyPond install, and artefact upload steps from ci.yml test job
- Removes PATH export from build step (LilyPond no longer installed)
- Adds integration tests as a step in the test job
- Removes entire integration job (paths-filter, should-run, conditionals)
- Updates doc/CI.md to reflect single-job pipeline

**Note:** artefact upload removal temporarily breaks deploy-production.yml until #464 (Netlify native builds) is merged.