### PR TITLE
fix: explicitly prevent default for Alt+Arrow seek shortcuts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -252,13 +252,14 @@ function keyboardTapped(e: KeyboardEvent) {
     return;
   }
 
-  // Swallow the browser-default for scroll-causing keys (iPad fix, #10),
-  // but only when no modifier is held — leave Cmd+S / Cmd+F / etc. alone.
-  // Cmd/Ctrl+ArrowLeft/Right is the one modifier combination the app
-  // owns (seek by section); preventDefault keeps the OS jump-word
-  // shortcut from racing the app handler.
+  // Swallow the browser-default for scroll-causing keys (iPad fix, #10).
+  // Plain arrows and Space scroll the page — the app owns those gestures.
+  // The app also owns three modifier+Arrow combos for seeking:
+  //   Cmd/Ctrl+Arrow  → seek by section
+  //   Alt+Arrow       → fine seek (1/64th note)
+  // Leave all other modifier combinations (Cmd+S, Cmd+F, etc.) alone.
   const isModifierSeek =
-    (e.metaKey || e.ctrlKey) &&
+    (e.metaKey || e.ctrlKey || e.altKey) &&
     (e.code === "ArrowRight" || e.code === "ArrowLeft");
   const isPlainScrollKey =
     !e.metaKey && !e.ctrlKey && SCROLL_KEYS.has(e.code);

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -225,6 +225,19 @@ describe("Space bar play/pause", () => {
       }
     );
 
+    // Alt+Arrow is the fine-grained seek (hemidemisemiquaver) — must
+    // preventDefault so the browser Back/Forward shortcut on Windows
+    // does not fire simultaneously.
+    it.each([["ArrowLeft"], ["ArrowRight"]])(
+      "preventDefaults Alt+%s (app handles 1/64th-note seek)",
+      (code) => {
+        expect(
+          dispatchKeydown(document.body, { code, altKey: true })
+            .defaultPrevented
+        ).toBe(true);
+      }
+    );
+
     // -- negative cases: browser shortcuts and non-scroll keys pass through --
     // Cmd+S, Cmd+F, Cmd+A etc. must NOT be swallowed; the user expects
     // browser/OS shortcuts to keep working when focus is on the body.


### PR DESCRIPTION
Harden the Alt+Arrow keyboard shortcut handling so the browser Back/Forward navigation on Windows is explicitly prevented, rather than incidentally covered by the plain-scroll-key guard.

Changes:
- Add e.altKey to isModifierSeek so Alt+Arrow is an explicit app-owned combo
- Fix the misleading comment that claimed 
o modifier is held for plain keys
- Add regression tests for Alt+Arrow preventDefault behaviour

Fixes #420