### PR TITLE
fix: explicitly prevent default for Alt+Arrow seek shortcuts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -252,13 +252,14 @@ function keyboardTapped(e: KeyboardEvent) {
     return;
   }
 
-  // Swallow the browser-default for scroll-causing keys (iPad fix, #10),
-  // but only when no modifier is held — leave Cmd+S / Cmd+F / etc. alone.
-  // Cmd/Ctrl+ArrowLeft/Right is the one modifier combination the app
-  // owns (seek by section); preventDefault keeps the OS jump-word
-  // shortcut from racing the app handler.
+  // Swallow the browser-default for scroll-causing keys (iPad fix, #10).
+  // Plain arrows and Space scroll the page — the app owns those gestures.
+  // The app also owns these modifier+Left/Right combos for seeking:
+  //   Cmd/Ctrl+Left/Right → seek by section
+  //   Alt+Left/Right      → fine seek (1/16 bar)
+  // Leave non-seek modifier combinations (Cmd+S, Cmd+F, etc.) to the browser.
   const isModifierSeek =
-    (e.metaKey || e.ctrlKey) &&
+    (e.metaKey || e.ctrlKey || e.altKey) &&
     (e.code === "ArrowRight" || e.code === "ArrowLeft");
   const isPlainScrollKey =
     !e.metaKey && !e.ctrlKey && SCROLL_KEYS.has(e.code);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -225,6 +225,19 @@ describe("Space bar play/pause", () => {
       }
     );
 
+    // Alt+Left/Right is the fine seek (1/16 bar) — must preventDefault
+    // so the browser Back/Forward shortcut on Windows does not fire
+    // simultaneously.
+    it.each([["ArrowLeft"], ["ArrowRight"]])(
+      "preventDefaults Alt+%s (app handles 1/16-bar seek)",
+      (code) => {
+        expect(
+          dispatchKeydown(document.body, { code, altKey: true })
+            .defaultPrevented
+        ).toBe(true);
+      }
+    );
+
     // -- negative cases: browser shortcuts and non-scroll keys pass through --
     // Cmd+S, Cmd+F, Cmd+A etc. must NOT be swallowed; the user expects
     // browser/OS shortcuts to keep working when focus is on the body.
@@ -401,6 +414,42 @@ describe("Space bar play/pause", () => {
       );
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(Number(controls.getAttribute("bar"))).toBe(6);
+    });
+
+    // Alt+Left/Right is the fine seek (1/16 bar). These assert the bar
+    // actually moves by the fractional step — not just that preventDefault
+    // ran — so a regression that swallowed the default but broke the seek
+    // (or vice versa) would fail loudly. Mirrors the held-Arrow tests above.
+    it("Alt+ArrowRight fine-seeks forward by 1/16 bar", async () => {
+      const controls = document.querySelector(
+        "music-controls"
+      ) as MusicControls;
+      controls.setAttribute("bar", "5");
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ArrowRight",
+          bubbles: true,
+          altKey: true,
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(Number(controls.getAttribute("bar"))).toBeCloseTo(5.0625, 4);
+    });
+
+    it("Alt+ArrowLeft fine-seeks backward by 1/16 bar", async () => {
+      const controls = document.querySelector(
+        "music-controls"
+      ) as MusicControls;
+      controls.setAttribute("bar", "5");
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ArrowLeft",
+          bubbles: true,
+          altKey: true,
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(Number(controls.getAttribute("bar"))).toBeCloseTo(4.9375, 4);
     });
 
     // The Cmd/Ctrl+Arrow seek branch returns BEFORE the e.repeat


### PR DESCRIPTION
Fixes #420

Re-applies the #420 Alt+Arrow hardening — #481 was reverted pending the Vera gate; now gated.

**Vera gate (cycle 1) — passed.** The change is sound: the Alt+Arrow fine seek is actually dispatched, not just suppressed (preventDefault stops the browser Back/Forward shortcut from racing the handler). In scope, two findings were addressed: a seek-unit comment was corrected (the rework had mislabelled the `0.0625` step as a "1/64th note"; the codebase calls it "1/16 bar"), and coverage was added asserting Alt+Arrow moves `bar` by ±0.0625 (not just that the default was prevented). One pre-existing finding — `isPlainScrollKey` not excluding `altKey` (so Alt+Space / Alt+ArrowUp-Down are also swallowed) — was deferred as out of scope to a separate tracking item. Full Vera reports are on #420.

- Claude
