### PR TITLE
fix: guard MusicCanvas.play() against duplicate rAF loops and restart shimmer on reconnect (#245)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -666,4 +666,46 @@ describe("MusicCanvas custom element", () => {
     expect(canvas!.voicePart).toBe(2);
     expect(canvas!.bar).toBe(50);
   });
+
+  it("calling play() while already playing cancels the previous rAF loop (#245)", () => {
+    expect(canvas).not.toBeNull();
+    const cancelSpy = vi.spyOn(window, "cancelAnimationFrame");
+    const rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockReturnValue(42);
+
+    canvas!.playing = true;
+    canvas!.play();
+    expect(cancelSpy).not.toHaveBeenCalled();
+
+    canvas!.play();
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(cancelSpy).toHaveBeenLastCalledWith(42);
+
+    cancelSpy.mockRestore();
+    rafSpy.mockRestore();
+    canvas!.playing = false;
+    canvas!.playLoopId = 0;
+  });
+
+  it("disconnect and reconnect restarts the shimmer loop (#245)", async () => {
+    const freshCanvas = document.createElement("music-canvas") as MusicCanvas;
+    document.body.appendChild(freshCanvas);
+    // Wait for connectedCallback -> #init -> processLilypond -> draw
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(freshCanvas.shimmerLoopId).not.toBe(0);
+    const oldShimmerId = freshCanvas.shimmerLoopId;
+
+    freshCanvas.remove();
+    expect(freshCanvas.shimmerLoopId).toBe(0);
+
+    document.body.appendChild(freshCanvas);
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(freshCanvas.shimmerLoopId).not.toBe(0);
+    expect(freshCanvas.shimmerLoopId).not.toBe(oldShimmerId);
+
+    freshCanvas.remove();
+  });
 });

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -34,6 +34,7 @@ export class MusicCanvas extends MusicElement {
   fpsLastTime = 0;
   fpsValue = 0;
   shimmerLoopId: number = 0;
+  playLoopId: number = 0;
   oldTimeStamp: number = 0;
 
   // Base lightness for unselected parts in light mode.
@@ -86,12 +87,18 @@ export class MusicCanvas extends MusicElement {
   async connectedCallback() {
     super.connectedCallback();
     await this.#init();
+    if (!this.playing && this.shimmerLoopId === 0) {
+      this.#startShimmerLoop();
+    }
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener("wheel", this.#preventVerticalScroll);
     cancelAnimationFrame(this.shimmerLoopId);
+    cancelAnimationFrame(this.playLoopId);
+    this.shimmerLoopId = 0;
+    this.playLoopId = 0;
   }
 
   #startShimmerLoop() {
@@ -239,17 +246,20 @@ export class MusicCanvas extends MusicElement {
   }
 
   play() {
+    if (this.playLoopId) {
+      cancelAnimationFrame(this.playLoopId);
+    }
     const self = this;
     function loop() {
       self.draw();
 
       if (self.playing) {
-        window.requestAnimationFrame(loop);
-        // setTimeout(frame, config.tempo / 10);
+        self.playLoopId = window.requestAnimationFrame(loop);
+      } else {
+        self.playLoopId = 0;
       }
     }
-    window.requestAnimationFrame(loop);
-    // setTimeout(frame, config.tempo / 10);
+    this.playLoopId = window.requestAnimationFrame(loop);
   }
 
   draw() {


### PR DESCRIPTION
Fixes #245