### PR TITLE
build: html-escape branch name and version in vite html-version plugin (#397)

### DIFF
--- a/src/test/escapeHtml.test.ts
+++ b/src/test/escapeHtml.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml } from "../ts/escapeHtml";
+
+describe("escapeHtml", () => {
+  it("escapes ampersand", () => {
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+  });
+
+  it("escapes less-than", () => {
+    expect(escapeHtml("a < b")).toBe("a &lt; b");
+  });
+
+  it("escapes greater-than", () => {
+    expect(escapeHtml("a > b")).toBe("a &gt; b");
+  });
+
+  it("escapes double quote", () => {
+    expect(escapeHtml('say "hello"')).toBe("say &quot;hello&quot;");
+  });
+
+  it("escapes single quote", () => {
+    expect(escapeHtml("it's")).toBe("it&#39;s");
+  });
+
+  it("escapes all dangerous characters together", () => {
+    expect(escapeHtml("test\"<>&'")).toBe("test&quot;&lt;&gt;&amp;&#39;");
+  });
+
+  it("prevents script injection in HTML context", () => {
+    const malicious = "<script>alert(1)</script>";
+    const escaped = escapeHtml(malicious);
+    expect(escaped).toBe("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(escaped).not.toContain("<script>");
+  });
+
+  it("prevents attribute breakout in double-quoted attribute", () => {
+    const branch = 'xss"><script>alert(1)</script>';
+    const escaped = escapeHtml(branch);
+    const attr = `data-branch="${escaped}"`;
+    expect(attr).toBe(
+      'data-branch="xss&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"'
+    );
+  });
+
+  it("leaves safe text unchanged", () => {
+    expect(escapeHtml("Spem Player v2.5.5")).toBe("Spem Player v2.5.5");
+  });
+});

--- a/src/ts/escapeHtml.ts
+++ b/src/ts/escapeHtml.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2024-2026 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import { execSync } from "child_process";
 // import never throws — an unset or invalid value falls back to the
 // default ports, so config-eval is safe in CI, forks, and clones.
 import { DEV_PORT, PREVIEW_PORT } from "./worktree-ports.ts";
+import { escapeHtml } from "./src/ts/escapeHtml";
 
 const pkg = JSON.parse(
   readFileSync(resolve(__dirname, "package.json"), "utf-8")
@@ -77,11 +78,13 @@ export default defineConfig({
       name: "html-version",
       transformIndexHtml(html) {
         return html
-          .replace(/%VERSION%/g, versionWithBranch)
+          .replace(/%VERSION%/g, escapeHtml(versionWithBranch))
           .replace(/%YEAR%/g, new Date().getFullYear().toString())
           .replace(
             /data-branch="%BRANCH%"/g,
-            branch && branch !== "main" ? `data-branch="${branch}"` : ""
+            branch && branch !== "main"
+              ? `data-branch="${escapeHtml(branch)}"`
+              : ""
           );
       },
     },


### PR DESCRIPTION
Fixes #397