### PR TITLE
feat: skip daily monitor report when no PRs merged; include PR count

### DIFF
--- a/.github/scripts/monitor-resources.mjs
+++ b/.github/scripts/monitor-resources.mjs
@@ -9,6 +9,10 @@
  * posts a one-line summary to Telegram, and opens a critical issue if
  * either service exceeds 90% of quota.
  *
+ * Skips the Telegram message on days with no PR merges and normal usage
+ * (below 50%). Watch (≥ 50%), throttle (≥ 75%), and critical (≥ 90%) alerts
+ * always send regardless of PR activity.
+ *
  * Environment variables (all required):
  *   NETLIFY_AUTH_TOKEN
  *   NETLIFY_SITE_ID
@@ -18,8 +22,12 @@
  *   GITHUB_REPOSITORY  (owner/repo format)
  */
 
+import { fileURLToPath } from "url";
+import { realpathSync } from "fs";
+
 const NETLIFY_API = "https://api.netlify.com/api/v1";
 const TELEGRAM_API = "https://api.telegram.org/bot";
+const WATCH_THRESHOLD_PCT = 50;
 
 async function api(url, opts = {}) {
   const res = await fetch(url, opts);
@@ -45,10 +53,72 @@ async function getNetlifyUsage() {
   };
 }
 
+async function getMergedPRCount(since) {
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  const data = await api(
+    `https://api.github.com/search/issues?q=repo:${owner}/${repo}+is:pr+is:merged+merged:>=${since}&per_page=1`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    }
+  );
+  // total_count is reliable from the Search API even with per_page=1;
+  // we need the count, not the PR records, so fetching one record is enough.
+  if (!Number.isInteger(data.total_count) || data.total_count < 0) {
+    throw new Error(
+      `PR search API returned unexpected total_count: ${JSON.stringify(data.total_count)}`
+    );
+  }
+  return data.total_count;
+}
+
+/**
+ * Returns true if the daily Telegram report should be suppressed.
+ *
+ * Suppresses only when both conditions hold: no PRs merged in the reporting
+ * window (mergedCount === 0) and resource usage is below the watch threshold.
+ * Either condition alone is insufficient.
+ *
+ * @param {number} mergedCount - PR merge count for the reporting window.
+ * @param {number} maxPct - Maximum of Netlify and GitHub usage percentages (0–100).
+ * @returns {boolean}
+ */
+export function shouldSkipReport(mergedCount, maxPct) {
+  return mergedCount === 0 && maxPct < WATCH_THRESHOLD_PCT;
+}
+
+/**
+ * Builds the one-line Telegram summary message.
+ * Appends "· N PR(s) merged" only when mergedCount > 0.
+ *
+ * @param {string} emoji - Status emoji (🟢/🟡/🔴/🚨).
+ * @param {number} netlifyPct - Netlify usage percentage (0–100).
+ * @param {number} githubPct - GitHub Actions usage percentage (0–100).
+ * @param {string} status - Status label ("normal"/"watch"/"throttle"/"STOP").
+ * @param {number} mergedCount - Number of PRs merged in the reporting window.
+ * @returns {string}
+ */
+export function formatMessage(
+  emoji,
+  netlifyPct,
+  githubPct,
+  status,
+  mergedCount
+) {
+  const base = `${emoji} Netlify ${netlifyPct}% · GitHub ${githubPct}% — ${status}`;
+  if (mergedCount === 0) return base;
+  const noun = mergedCount === 1 ? "PR" : "PRs";
+  return `${base} · ${mergedCount} ${noun} merged`;
+}
+
 async function getGitHubUsage() {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
   const now = new Date();
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
+  ).toISOString();
 
   let totalMs = 0;
   let page = 1;
@@ -89,14 +159,17 @@ async function sendTelegram(text) {
 
 async function openIssue(title, body) {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ title, body }),
-  });
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/issues`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ title, body }),
+    }
+  );
   if (!res.ok) throw new Error(`Issues API HTTP ${res.status}`);
 }
 
@@ -106,35 +179,90 @@ async function main() {
   try {
     netlify = await getNetlifyUsage();
   } catch (e) {
-    await sendTelegram(`🚨 Monitor: Netlify API failed — ${e.message}`);
-    await openIssue("Monitor failure: Netlify API error", e.message);
+    try {
+      await sendTelegram(`🚨 Monitor: Netlify API failed — ${e.message}`);
+      await openIssue("Monitor failure: Netlify API error", e.message);
+    } catch (alertErr) {
+      console.error(
+        `Failed to send alert for Netlify failure: ${alertErr.message}`
+      );
+    }
     throw e;
   }
 
   try {
     github = await getGitHubUsage();
   } catch (e) {
-    await sendTelegram(`🚨 Monitor: GitHub API failed — ${e.message}`);
-    await openIssue("Monitor failure: GitHub API error", e.message);
+    try {
+      await sendTelegram(`🚨 Monitor: GitHub API failed — ${e.message}`);
+      await openIssue("Monitor failure: GitHub API error", e.message);
+    } catch (alertErr) {
+      console.error(
+        `Failed to send alert for GitHub failure: ${alertErr.message}`
+      );
+    }
     throw e;
   }
 
-  const netlifyPct = netlify.limit > 0 ? Math.round((netlify.current / netlify.limit) * 100) : 0;
-  const githubPct = github.limit > 0 ? Math.round((github.current / github.limit) * 100) : 0;
+  const netlifyPct =
+    netlify.limit > 0 ? Math.round((netlify.current / netlify.limit) * 100) : 0;
+  const githubPct =
+    github.limit > 0 ? Math.round((github.current / github.limit) * 100) : 0;
   const maxPct = Math.max(netlifyPct, githubPct);
 
   let emoji = "🟢";
   let status = "normal";
-  if (maxPct >= 90) { emoji = "🚨"; status = "STOP"; }
-  else if (maxPct >= 75) { emoji = "🔴"; status = "throttle"; }
-  else if (maxPct >= 50) { emoji = "🟡"; status = "watch"; }
+  if (maxPct >= 90) {
+    emoji = "🚨";
+    status = "STOP";
+  } else if (maxPct >= 75) {
+    emoji = "🔴";
+    status = "throttle";
+  } else if (maxPct >= WATCH_THRESHOLD_PCT) {
+    emoji = "🟡";
+    status = "watch";
+  }
 
-  const message = `${emoji} Netlify ${netlifyPct}% · GitHub ${githubPct}% — ${status}`;
+  const since =
+    new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 19) + "Z";
+  let mergedCount;
+  try {
+    mergedCount = await getMergedPRCount(since);
+  } catch (e) {
+    try {
+      await sendTelegram(`🚨 Monitor: PR search API failed — ${e.message}`);
+      await openIssue("Monitor failure: PR search API error", e.message);
+    } catch (alertErr) {
+      console.error(
+        `Failed to send alert for PR search failure: ${alertErr.message}`
+      );
+    }
+    throw e;
+  }
+
+  if (shouldSkipReport(mergedCount, maxPct)) {
+    console.log(`Skipping report: no PRs merged and usage normal (${maxPct}%)`);
+    return;
+  }
+
+  const message = formatMessage(
+    emoji,
+    netlifyPct,
+    githubPct,
+    status,
+    mergedCount
+  );
 
   try {
     await sendTelegram(message);
   } catch (e) {
-    await openIssue("Monitor failure: Telegram API error", e.message);
+    try {
+      await openIssue("Monitor failure: Telegram API error", e.message);
+    } catch (alertErr) {
+      console.error(
+        `Failed to open issue for Telegram failure: ${alertErr.message}`
+      );
+    }
     throw e;
   }
 
@@ -149,7 +277,15 @@ async function main() {
   console.log(message);
 }
 
-main().catch((err) => {
-  console.error(err.message);
-  process.exit(1);
-});
+// Only run main() when invoked directly, not when imported by tests.
+// realpathSync on both sides resolves symlinks so the comparison holds
+// when Node is launched via a symlinked path (macOS / nvm common case).
+const __filename = fileURLToPath(import.meta.url);
+const isMain =
+  process.argv[1] && realpathSync(process.argv[1]) === realpathSync(__filename);
+if (isMain) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/monitor-resources.test.mjs
+++ b/.github/scripts/monitor-resources.test.mjs
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shouldSkipReport, formatMessage } from "./monitor-resources.mjs";
+
+// shouldSkipReport: skip only when zero PRs AND below 50% (normal status)
+test("shouldSkipReport skips when zero PRs and normal usage", () => {
+  assert.equal(shouldSkipReport(0, 0), true);
+  assert.equal(shouldSkipReport(0, 49), true);
+});
+
+test("shouldSkipReport sends when zero PRs but watch threshold reached", () => {
+  assert.equal(shouldSkipReport(0, 50), false);
+});
+
+test("shouldSkipReport sends when zero PRs but throttle threshold reached", () => {
+  assert.equal(shouldSkipReport(0, 75), false);
+});
+
+test("shouldSkipReport sends when zero PRs but STOP threshold reached", () => {
+  assert.equal(shouldSkipReport(0, 90), false);
+});
+
+test("shouldSkipReport sends when PRs merged regardless of usage", () => {
+  assert.equal(shouldSkipReport(1, 0), false);
+  assert.equal(shouldSkipReport(3, 10), false);
+  assert.equal(shouldSkipReport(1, 95), false);
+});
+
+// formatMessage: append PR count only when > 0
+test("formatMessage omits PR suffix when no PRs", () => {
+  assert.equal(
+    formatMessage("🟢", 23, 45, "normal", 0),
+    "🟢 Netlify 23% · GitHub 45% — normal"
+  );
+});
+
+test("formatMessage uses singular when one PR merged", () => {
+  assert.equal(
+    formatMessage("🟢", 23, 45, "normal", 1),
+    "🟢 Netlify 23% · GitHub 45% — normal · 1 PR merged"
+  );
+});
+
+test("formatMessage uses plural when multiple PRs merged", () => {
+  assert.equal(
+    formatMessage("🟡", 51, 30, "watch", 3),
+    "🟡 Netlify 51% · GitHub 30% — watch · 3 PRs merged"
+  );
+});

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -90,14 +90,14 @@ automatically.
 
 ### `monitor-resources.yml`
 
-Triggers daily at 07:30 UTC (`cron: "30 7 * * *"`, deliberately off the top of the hour to avoid GitHub's schedule throttling) and on manual `workflow_dispatch`. Runs one job, `monitor`, on Ubuntu latest with `actions: read`, `issues: write`, and `contents: read` permissions.
+Triggers daily at 02:29 UTC (`cron: "29 2 * * *"`, deliberately off the top of the hour to avoid GitHub's schedule throttling; GitHub's ~5 h scheduling delay lands the Telegram post around breakfast) and on manual `workflow_dispatch`. Runs one job, `monitor`, on Ubuntu latest with `actions: read`, `issues: write`, and `contents: read` permissions.
 
 Steps:
 
 - `actions/checkout@v6` — checkout the repository.
 - `node .github/scripts/monitor-resources.mjs` — run the monitor, with `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `GITHUB_TOKEN` passed in the environment.
 
-The script queries the current period's Netlify build-minute usage and GitHub Actions usage, then posts a one-line summary to Telegram of the form `Netlify <n>% · GitHub <n>% — <status>`. If either service reaches **90%** of its quota, the status becomes `STOP` (with a 🚨 prefix) and the workflow opens a critical GitHub issue containing a runbook for reducing build-minute consumption.
+The script queries the current period's Netlify build-minute usage and GitHub Actions usage. On days with no PRs merged in the past 24 hours and normal resource usage (both services below 50%), the Telegram message is skipped to reduce noise. Watch (≥ 50%), throttle (≥ 75%), and critical (≥ 90%) alerts always send regardless of PR activity. When the message is sent, it takes the form `Netlify <n>% · GitHub <n>% — <status>`, appending `· N PR(s) merged` when at least one PR merged in the past 24 hours. If either service reaches **90%** of its quota, the status becomes `STOP` (with a 🚨 prefix) and the workflow opens a critical GitHub issue containing a runbook for reducing build-minute consumption.
 
 ## Node.js Version
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -57,6 +57,8 @@ npm run test:coverage
 
 Unit tests live under `src/test/` and `lilypond/test/` (excluding `*.integration.test.ts`) and follow the naming convention `*.test.ts`. They run in-process under jsdom and should complete in under a few seconds each. In-process tests against `lilypond/build/` code (for example `postprocessSvg.test.ts`) live in `lilypond/test/` alongside the integration suite.
 
+Scripts in `.github/scripts/` that expose pure functions use the Node.js built-in test runner (`node:test`) rather than Vitest, and live alongside the script as `*.test.mjs`. Run them directly with `node --test .github/scripts/<name>.test.mjs`. These files are excluded from the Vitest config (`vite.config.ts`) and do not appear in `npm run test:unit` output.
+
 Integration tests live in `lilypond/test/*.integration.test.ts` and also follow `*.test.ts`. They typically spawn subprocesses (LilyPond, the build pipeline) and are substantially slower.
 
 If a new shared fixture directory is introduced (e.g. `src/test/fixtures/`), add it to the `build-related` filter in `.github/workflows/ci.yml` so that PRs touching it exercise the integration suite.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.5.6",
+  "version": "2.6.0",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
-    exclude: ["e2e/**", "node_modules/**"],
+    exclude: [".github/**", "e2e/**", "node_modules/**"],
     maxWorkers: 4,
     testTimeout: 10000,
     coverage: {


### PR DESCRIPTION
## Summary

- On days with no PRs merged in the past 24 hours **and** resource usage below 50%, the daily Telegram message is suppressed to reduce noise. Watch (≥ 50%), throttle (≥ 75%), and critical (≥ 90%) alerts always send regardless of PR activity.
- When the message is sent, it appends `· N PR(s) merged` when at least one PR merged in the past 24 hours.
- Also corrects the `monitor-resources.yml` cron schedule in `doc/CI.md`: documented as `"30 7 * * *"` (07:30 UTC) but the workflow file has always used `"29 2 * * *"` (02:29 UTC). Item #362.

Vera gate ran (2 cycles, 4 findings resolved). Key fixes: `getMergedPRCount` wrapped in error-reporting try/catch; `WATCH_THRESHOLD_PCT` constant extracted; alert calls in catch blocks guarded against double-failure; `Number.isInteger` used for `total_count` validation.

Fixes #489
