### PR TITLE
fix: use YYYY-MM-DD for GitHub Search API merged date query (#491)

### DIFF
--- a/.github/scripts/monitor-resources.mjs
+++ b/.github/scripts/monitor-resources.mjs
@@ -113,6 +113,20 @@ export function formatMessage(
   return `${base} · ${mergedCount} ${noun} merged`;
 }
 
+/**
+ * Returns the start of the 24-hour reporting window as a `YYYY-MM-DD` string.
+ *
+ * GitHub's Search API `merged:` qualifier requires `YYYY-MM-DD`; passing an
+ * ISO timestamp causes it to return `total_count: 0` even when matching PRs
+ * exist. See #491.
+ *
+ * @param {number} nowMs - Current time in milliseconds since Unix epoch.
+ * @returns {string}
+ */
+export function getReportingSince(nowMs = Date.now()) {
+  return new Date(nowMs - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
 async function getGitHubUsage() {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
   const now = new Date();
@@ -223,8 +237,7 @@ async function main() {
     status = "watch";
   }
 
-  const since =
-    new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 19) + "Z";
+  const since = getReportingSince();
   let mergedCount;
   try {
     mergedCount = await getMergedPRCount(since);

--- a/.github/scripts/monitor-resources.test.mjs
+++ b/.github/scripts/monitor-resources.test.mjs
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { shouldSkipReport, formatMessage } from "./monitor-resources.mjs";
+import {
+  shouldSkipReport,
+  formatMessage,
+  getReportingSince,
+} from "./monitor-resources.mjs";
 
 // shouldSkipReport: skip only when zero PRs AND below 50% (normal status)
 test("shouldSkipReport skips when zero PRs and normal usage", () => {
@@ -46,4 +50,12 @@ test("formatMessage uses plural when multiple PRs merged", () => {
     formatMessage("🟡", 51, 30, "watch", 3),
     "🟡 Netlify 51% · GitHub 30% — watch · 3 PRs merged"
   );
+});
+
+// getReportingSince: must produce YYYY-MM-DD for GitHub Search API
+test("getReportingSince returns YYYY-MM-DD format", () => {
+  const since = getReportingSince(Date.UTC(2026, 5, 8, 7, 13, 8));
+  assert.equal(since, "2026-06-07");
+  assert.doesNotMatch(since, /T/);
+  assert.doesNotMatch(since, /Z/);
 });


### PR DESCRIPTION
Fixes #491