### PR TITLE
fix: make worktree-ports offset test worktree-agnostic

### DIFF
--- a/src/test/worktree-ports.test.ts
+++ b/src/test/worktree-ports.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  parseOffset,
   portOffset,
   DEV_PORT,
   PREVIEW_PORT,
@@ -22,30 +23,35 @@ describe("worktree-ports", () => {
     expect(PREVIEW_PORT).toBe(4173 + portOffset());
   });
 
-  it("returns 0 when SPEM_PORT_OFFSET is unset", () => {
-    expect(portOffset(undefined)).toBe(0);
+  // The value-parse cases target the pure `parseOffset`, not `portOffset`:
+  // calling `portOffset(undefined)` triggers its default parameter, which
+  // reads the `.worktree-offset` file and makes the result worktree-dependent
+  // (green in CI, red wherever an offset file exists). `parseOffset` has no
+  // such default, so these stay deterministic in every worktree.
+  it("parseOffset returns 0 for an undefined raw value", () => {
+    expect(parseOffset(undefined)).toBe(0);
   });
 
-  it("returns 0 for an empty or whitespace value", () => {
-    expect(portOffset("")).toBe(0);
-    expect(portOffset("   ")).toBe(0);
+  it("parseOffset returns 0 for an empty or whitespace value", () => {
+    expect(parseOffset("")).toBe(0);
+    expect(parseOffset("   ")).toBe(0);
   });
 
-  it("parses a valid non-negative integer offset", () => {
-    expect(portOffset("0")).toBe(0);
-    expect(portOffset("100")).toBe(100);
-    expect(portOffset("400")).toBe(400);
+  it("parseOffset parses a valid non-negative integer offset", () => {
+    expect(parseOffset("0")).toBe(0);
+    expect(parseOffset("100")).toBe(100);
+    expect(parseOffset("400")).toBe(400);
   });
 
-  it("falls back to 0 for malformed, negative, or non-integer values (never throws)", () => {
+  it("parseOffset falls back to 0 for malformed, negative, or non-integer values (never throws)", () => {
     // A mistyped offset must degrade to the default port rather than
     // throw at config-eval — a worktree's own setup error cannot then
     // break the build for CI, forks, or anyone else. A real collision
     // surfaces as EADDRINUSE at preview bind (strictPort) instead.
-    expect(portOffset("abc")).toBe(0);
-    expect(portOffset("1OO")).toBe(0); // letter O, not zeros
-    expect(portOffset("-100")).toBe(0);
-    expect(portOffset("10.5")).toBe(0);
+    expect(parseOffset("abc")).toBe(0);
+    expect(parseOffset("1OO")).toBe(0); // letter O, not zeros
+    expect(parseOffset("-100")).toBe(0);
+    expect(parseOffset("10.5")).toBe(0);
   });
 });
 
@@ -69,5 +75,29 @@ describe("readWorktreeOffset", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("portOffset default-parameter composition", () => {
+  // portOffset()'s default parameter resolves
+  // `process.env.SPEM_PORT_OFFSET ?? readWorktreeOffset()` and parses it. These
+  // pin that wiring — env precedence, then file fallback — without asserting an
+  // absolute offset, so they hold in every worktree (the value-parse cases above
+  // moved to `parseOffset` precisely to stay worktree-agnostic; this restores
+  // coverage of the composition itself, which the move would otherwise drop).
+  const original = process.env.SPEM_PORT_OFFSET;
+  afterEach(() => {
+    if (original === undefined) delete process.env.SPEM_PORT_OFFSET;
+    else process.env.SPEM_PORT_OFFSET = original;
+  });
+
+  it("prefers SPEM_PORT_OFFSET over the .worktree-offset file", () => {
+    process.env.SPEM_PORT_OFFSET = "100";
+    expect(portOffset()).toBe(100);
+  });
+
+  it("falls back to the .worktree-offset file when SPEM_PORT_OFFSET is unset", () => {
+    delete process.env.SPEM_PORT_OFFSET;
+    expect(portOffset()).toBe(parseOffset(readWorktreeOffset()));
   });
 });

--- a/worktree-ports.ts
+++ b/worktree-ports.ts
@@ -18,12 +18,13 @@
 // the directory name (CI checks out into `spem-player`, a fork could be
 // named anything — the name is an unreliable proxy).
 //
-// Suggested per-worktree values (offset -> dev / preview):
-//   main / claude  0   -> 5173 / 4173
-//   vera           100 -> 5273 / 4273
-//   kimi           200 -> 5373 / 4373
-//   copilot        300 -> 5473 / 4473
-//   tele           400 -> 5573 / 4573
+// Per-worktree values in use (offset -> dev / preview):
+//   main / claude  0  -> 5173 / 4173
+//   copilot        10 -> 5183 / 4183
+//   kimi           20 -> 5193 / 4193
+//   tele           30 -> 5203 / 4203
+//   vera           40 -> 5213 / 4213
+//   zimi           50 -> 5223 / 4223
 //
 // vite.config.ts and playwright.config.ts read DEV_PORT / PREVIEW_PORT at
 // config-eval time; the offset is resolved once here at module load.
@@ -53,8 +54,20 @@ export function readWorktreeOffset(
 }
 
 /**
+ * Parse a raw offset value to a non-negative integer, returning `0` when it
+ * is undefined, empty, or not a valid non-negative integer. Pure — no
+ * environment or filesystem access — so it is deterministic in every
+ * worktree and is the unit the value-case tests target.
+ */
+export const parseOffset = (raw: string | undefined): number => {
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : 0;
+};
+
+/**
  * Resolve the per-worktree port offset from `SPEM_PORT_OFFSET`, falling
- * back to a `.worktree-offset` file beside this module.
+ * back to a `.worktree-offset` file beside this module, then parse it via
+ * {@link parseOffset}.
  *
  * @param raw - the raw offset value (defaults to
  *   `process.env.SPEM_PORT_OFFSET`, falling back to the `.worktree-offset`
@@ -70,10 +83,7 @@ export function readWorktreeOffset(
 export const portOffset = (
   raw: string | undefined = process.env.SPEM_PORT_OFFSET ??
     readWorktreeOffset(),
-): number => {
-  const n = Number(raw);
-  return Number.isInteger(n) && n >= 0 ? n : 0;
-};
+): number => parseOffset(raw);
 
 export const DEV_PORT = 5173 + portOffset();
 export const PREVIEW_PORT = 4173 + portOffset();


### PR DESCRIPTION
Fixes #496

`portOffset`'s default parameter resolves `process.env.SPEM_PORT_OFFSET ?? readWorktreeOffset()`, so `portOffset(undefined)` triggered the default and read the `.worktree-offset` file beside the module. The "returns 0 when unset" assertion therefore held only where no offset file exists (CI) and failed locally in any worktree that carries one — a CI-green / locally-red landmine.

**Change**

- Extract a pure `parseOffset(raw)` (no env, no filesystem) and have `portOffset` delegate to it.
- Repoint the value-parse tests at `parseOffset`, so they are deterministic in every worktree.
- Add a `portOffset default-parameter composition` test (env precedence + file fallback, asserted without an absolute offset) so the default-parameter wiring keeps coverage after the move.
- Correct the stale offset comment table to the values in use (0/10/20/30/40/50).

No production behaviour change; `worktree-ports.ts` is dev tooling (imported by `vite.config.ts` / `playwright.config.ts`), not shipped app code, so no version bump.

**Vera gate:** ran (cycle 1, two passes), passed. The gate caught a coverage regression the refactor itself introduced — the move had dropped all coverage of `portOffset()`'s default-parameter composition — which is addressed by the new test above (mutation-validated). One further quality note on the fallback test was rejected with defence. Full reports are on the ticket.
