### PR TITLE
fix: guard parseURLSearch against NaN for bar and choir (#235)

### DIFF
--- a/src/test/url.test.ts
+++ b/src/test/url.test.ts
@@ -31,11 +31,23 @@ describe("parseURLSearch", () => {
     expect(result.early).toBe(false);
   });
 
-  it("treats a key with no '=' as having no value (NaN for numeric keys)", () => {
-    // New indexOf/slice branch: eq === -1 -> val === undefined, so a
-    // numeric key yields Number(undefined) === NaN. Pinned as current
-    // behaviour; a guard against NaN is tracked in the follow-up ticket.
-    expect(Number.isNaN(parseURLSearch("?choir").choir)).toBe(true);
+  it("treats a key with no '=' as having the default value", () => {
+    // A key with no '=' has val === undefined, and Number(undefined)
+    // is NaN. The NaN guard should fall back to the default.
+    expect(parseURLSearch("?choir").choir).toBe(0);
+  });
+
+  it("ignores an invalid bar parameter (#235)", () => {
+    expect(parseURLSearch("?bar=abc").bar).toBe(1 - 2 / 4); // default for ALC recording
+  });
+
+  it("ignores an invalid choir parameter (#235)", () => {
+    expect(parseURLSearch("?choir=xyz").choir).toBe(0);
+  });
+
+  it("accepts valid bar and choir parameters (#235)", () => {
+    expect(parseURLSearch("?bar=50").bar).toBe(50);
+    expect(parseURLSearch("?choir=3").choir).toBe(3);
   });
 
   it("parses ?dark=0 as light mode (#236)", () => {

--- a/src/ts/url.ts
+++ b/src/ts/url.ts
@@ -30,12 +30,14 @@ export function parseURLSearch(search: string): ParsedURL {
     const key = eq === -1 ? parms[i] : parms[i].slice(0, eq);
     const val = eq === -1 ? undefined : parms[i].slice(eq + 1);
     if (key == "choir") {
-      choir = Number(val);
+      const n = Number(val);
+      if (!Number.isNaN(n)) choir = n;
     } else if (key == "part") {
       const n: number = Number(val);
       if (n >= 0 && n < config.parts.length) part = n;
     } else if (key == "bar") {
-      bar = Number(val);
+      const n = Number(val);
+      if (!Number.isNaN(n)) bar = n;
     } else if (key == "dark") {
       dark = val !== "false" && val !== "0";
     } else if (key == "recording") {


### PR DESCRIPTION
Fixes #235

## Summary
Invalid URL parameters like  or  previously propagated NaN through the app, breaking the bar indicator, audio position, and score highlight.

## Changes
- Added  guards in  for both  and  parsing
- Invalid values now fall back to defaults (bar = intro bar offset, choir = 0)
- Updated existing test that documented NaN behavior to expect the new safe default
- Added tests for invalid bar, invalid choir, and valid bar/choir parameters

## Verification
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/Users/mark/github/spem-player[39m

 [32m✓[39m src/test/url.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 2[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m10 passed[39m[22m[90m (10)[39m
[2m   Start at [22m 11:43:48
[2m   Duration [22m 511ms[2m (transform 26ms, setup 21ms, import 15ms, tests 2ms, environment 391ms)[22m: 10 tests pass
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/Users/mark/github/spem-player[39m

[90mstdout[2m | src/test/darkmode.test.ts[2m > [22m[2mDark/light mode toggle
[22m[39mSpem Player 2.7.0

[90mstdout[2m | src/test/keyboard.test.ts[2m > [22m[2mSpace bar play/pause
[22m[39mSpem Player 2.7.0

 [32m✓[39m src/test/darkmode.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 1017[2mms[22m[39m
[90mstdout[2m | src/test/canvas.test.ts[2m > [22m[2mMusicCanvas custom element[2m > [22m[2mCheck that the canvasent contains a canvas
[22m[39m<canvas width="4000" height="1000" style="width: 100%; height: 100%;"></canvas>

 [32m✓[39m src/test/keyboard.test.ts [2m([22m[2m43 tests[22m[2m)[22m[33m 2415[2mms[22m[39m
 [32m✓[39m src/test/pwa.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 977[2mms[22m[39m
     [33m[2m✓[22m[39m registers the service worker on load when supported [33m 578[2mms[22m[39m
 [32m✓[39m src/test/canvas.test.ts [2m([22m[2m28 tests[22m[2m)[22m[33m 2636[2mms[22m[39m
     [33m[2m✓[22m[39m disconnect and reconnect restarts the shimmer loop (#245) [33m 695[2mms[22m[39m
     [33m[2m✓[22m[39m removes all event listeners on disconnect and re-adds them on reconnect (#203) [33m 696[2mms[22m[39m
[90mstdout[2m | src/test/setbar.test.ts[2m > [22m[2msetBar boundary wrapping
[22m[39mSpem Player 2.7.0

[90mstdout[2m | src/test/feedback.test.ts[2m > [22m[2mFeedback modal
[22m[39mSpem Player 2.7.0

 [32m✓[39m src/test/setbar.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 767[2mms[22m[39m
 [32m✓[39m src/test/lily.test.ts [2m([22m[2m16 tests[22m[2m)[22m[33m 949[2mms[22m[39m
     [33m[2m✓[22m[39m processLilypond() is idempotent over the parse — repeated cold calls produce equal data [33m 444[2mms[22m[39m
 [32m✓[39m src/test/feedback.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 722[2mms[22m[39m
[90mstdout[2m | src/test/main.test.ts[2m > [22m[2mindex.js[2m > [22m[2mCheck that the score, canvas and controls are all there
[22m[39m

 [32m✓[39m src/test/main.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 81[2mms[22m[39m
 [32m✓[39m src/test/controls.test.ts [2m([22m[2m22 tests[22m[2m)[22m[33m 316[2mms[22m[39m
 [32m✓[39m src/test/score.test.ts [2m([22m[2m24 tests[22m[2m)[22m[33m 667[2mms[22m[39m
 [32m✓[39m src/test/common.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 51[2mms[22m[39m
 [32m✓[39m src/test/canvaswatcher.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m lilypond/test/postprocessSvg.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m lilypond/test/postprocessSvgDedup.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/test/worktree-ports.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/test/musicelement.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/test/music-classes.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/test/spem.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/test/url.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m lilypond/test/buildScores.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/escapeHtml.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/helpers.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/config.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/docs.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m lilypond/test/buildScores.integration.test.ts [2m([22m[2m15 tests[22m[2m)[22m[33m 10968[2mms[22m[39m
     [33m[2m✓[22m[39m builds all notations [33m 1152[2mms[22m[39m
     [33m[2m✓[22m[39m creates missing score output directories on a clean checkout (#318) [33m 827[2mms[22m[39m
     [33m[2m✓[22m[39m caches by mtime [33m 941[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds all scores when a version-root include is newer (Vera 353-01) [33m 1716[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds the touched choir's notation when its own .ly is newer (Vera 353-11) [33m 1266[2mms[22m[39m
     [33m[2m✓[22m[39m does NOT rebuild a sibling notation when only one notation changes (Vera 353-07) [33m 1279[2mms[22m[39m
     [33m[2m✓[22m[39m does not build OUP [33m 771[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds when postprocessSvg.mjs is newer (#393) [33m 1540[2mms[22m[39m
     [33m[2m✓[22m[39m deletes SVG on lilypond failure (#394) [33m 1014[2mms[22m[39m

[2m Test Files [22m [1m[32m25 passed[39m[22m[90m (25)[39m
[2m      Tests [22m [1m[32m276 passed[39m[22m[90m (276)[39m
[2m   Start at [22m 11:43:49
[2m   Duration [22m 11.58s[2m (transform 758ms, setup 218ms, import 732ms, tests 21.62s, environment 10.29s)[22m: 276 tests pass
- 
> spem-player@2.7.0 check
> npm run build:ohm && npm run check:unused && npm run check:format && npm run check:lint && npm run check:types && npm run check:deps


> spem-player@2.7.0 build:ohm
> npx ohm generateBundles --withTypes src/ohmjs/ly-grammar.ohm

src/ohmjs/ly-grammar.ohm-bundle.js
src/ohmjs/ly-grammar.ohm-bundle.d.ts

> spem-player@2.7.0 check:unused
> knip


> spem-player@2.7.0 check:format
> prettier --check src/

Checking formatting...
All matched files use Prettier code style!

> spem-player@2.7.0 check:lint
> eslint . --max-warnings 0


> spem-player@2.7.0 check:types
> tsc --noEmit


> spem-player@2.7.0 check:deps
> depcruise src/ts/*.ts index.ts


  warn no-orphans: src/ts/escapeHtml.ts

x 1 dependency violations (0 errors, 1 warnings). 25 modules, 39 dependencies cruised.: clean