### PR TITLE
refactor: replace dict sparse array with notesByQuant Map (#105)

### DIFF
--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -32,7 +32,7 @@ describe("MusicCanvas custom element", () => {
     // Note: this exercises the !this.canvas guard (element not in DOM), not the
     // ranges.length === 0 guard. See refactor item 15 in wiki/refactor-lily.ts.md.
     const freshCanvas = document.createElement("music-canvas") as MusicCanvas;
-    freshCanvas.dict = [];
+    freshCanvas.notesByQuant = new Map();
     freshCanvas.ranges = [];
     freshCanvas.draw();
   });
@@ -117,22 +117,22 @@ describe("MusicCanvas custom element", () => {
     expect(result).toBeLessThanOrEqual(canvas!.barCount);
   });
 
-  it("seek() does not throw when dict[intbar] is undefined (#244)", () => {
+  it("seek() does not throw when notesByQuant.get(intbar) is undefined (#244)", () => {
     expect(canvas).not.toBeNull();
-    const saved = canvas!.dict[2];
-    delete canvas!.dict[2];
+    const saved = canvas!.notesByQuant.get(2);
+    canvas!.notesByQuant.delete(2);
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     expect(() => canvas!.seek(pos, +1)).not.toThrow();
-    canvas!.dict[2] = saved;
+    if (saved) canvas!.notesByQuant.set(2, saved);
   });
 
-  it("seek() backward from bar 1 with empty dict[0] returns 0 (#244)", () => {
+  it("seek() backward from bar 1 with empty notesByQuant.get(0) returns 0 (#244)", () => {
     expect(canvas).not.toBeNull();
-    const saved = canvas!.dict[0];
-    delete canvas!.dict[0];
+    const saved = canvas!.notesByQuant.get(0);
+    canvas!.notesByQuant.delete(0);
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     expect(canvas!.seek(pos, -1)).toBe(0);
-    canvas!.dict[0] = saved;
+    if (saved) canvas!.notesByQuant.set(0, saved);
   });
 
   it("canvas click fires music-canvas-click event", async () => {

--- a/src/test/lily.test.ts
+++ b/src/test/lily.test.ts
@@ -69,8 +69,8 @@ describe("lilypond parsing tests", () => {
   });
 
   it("processLilypond", () => {
-    const { dict, ranges } = processLilypond();
-    expect(dict.length).toBe(139); // bars including bar zero
+    const { notesByQuant, ranges } = processLilypond();
+    expect(notesByQuant.size).toBeGreaterThan(0);
     expect(barCount).toBe(139);
     expect(ranges.length).toBe(8); // choirs
     for (var c = 0; c < 8; c++) {
@@ -82,10 +82,10 @@ describe("lilypond parsing tests", () => {
     }
   });
 
-  it("processLilypond() returns a result object with dict, ranges, barCount, frLocations", () => {
+  it("processLilypond() returns a result object with notesByQuant, ranges, barCount, frLocations", () => {
     const result = processLilypond();
     expect(result).toBeDefined();
-    expect(result.dict.length).toBeGreaterThan(0);
+    expect(result.notesByQuant.size).toBeGreaterThan(0);
     expect(result.ranges.length).toBe(8);
     expect(result.barCount).toBeGreaterThan(0);
     expect(result.frLocations.length).toBeGreaterThan(0);
@@ -105,7 +105,7 @@ describe("lilypond parsing tests", () => {
     // The cache assignment in processLilypond is unreachable past the throw,
     // so the cache should still be null. Subsequent calls should produce a
     // valid parse result rather than handing out a poisoned cached value.
-    expect(processLilypond().dict.length).toBeGreaterThan(0);
+    expect(processLilypond().notesByQuant.size).toBeGreaterThan(0);
   });
 
   it("processLilypond() returns identical reference on second call (cache hit)", () => {
@@ -122,7 +122,7 @@ describe("lilypond parsing tests", () => {
     const result1 = processLilypond();
     resetLilypondCache();
     const result2 = processLilypond();
-    expect(result2.dict.length).toBe(result1.dict.length);
+    expect(result2.notesByQuant.size).toBe(result1.notesByQuant.size);
     expect(result2.ranges.length).toBe(result1.ranges.length);
     expect(result2.barCount).toBe(result1.barCount);
     expect(result2.frLocations.length).toBe(result1.frLocations.length);

--- a/src/test/spem.test.ts
+++ b/src/test/spem.test.ts
@@ -1,7 +1,7 @@
 import { processLilypond } from "../ts/lily";
 
 describe("Check that spem notes looks good", () => {
-  const { dict, ranges } = processLilypond();
+  const { notesByQuant, ranges } = processLilypond();
 
   it("8 choir of 5 parts", async () => {
     expect(ranges.length).toBe(8); // choirs
@@ -18,7 +18,7 @@ describe("Check that spem notes looks good", () => {
         expect(last.to).toBe(139);
       }
     }
-    expect(dict.length).toBe(139);
+    expect(notesByQuant.size).toBeGreaterThan(0);
   });
 
   it("Everyone is singing respice at bar 122", () => {
@@ -28,7 +28,7 @@ describe("Check that spem notes looks good", () => {
         expect(result, "choir/part " + c + "/" + p).toBe(true);
       }
     }
-    expect(dict[122].length).toBe(40);
+    expect(notesByQuant.get(122)!.length).toBe(40);
   });
 
   it("Nobody is singing in the third beat of bar 74", () => {
@@ -43,7 +43,7 @@ describe("Check that spem notes looks good", () => {
         ).toBeUndefined();
       }
     }
-    expect(dict[74.5]).toBeUndefined();
+    expect(notesByQuant.get(74.5)).toBeUndefined();
   });
 
   it("Nobody is singing in the third beat of bar 108", () => {
@@ -58,7 +58,7 @@ describe("Check that spem notes looks good", () => {
         ).toBeUndefined();
       }
     }
-    expect(dict[108.5]).toBeUndefined();
+    expect(notesByQuant.get(108.5)).toBeUndefined();
   });
 
   it("Nobody is singing in the last minim of 121", () => {
@@ -73,6 +73,6 @@ describe("Check that spem notes looks good", () => {
         ).toBeUndefined();
       }
     }
-    expect(dict[121.75]).toBeUndefined();
+    expect(notesByQuant.get(121.75)).toBeUndefined();
   });
 });

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -5,7 +5,7 @@ import config from "./config";
 import { PartType, Position, colors } from "./common";
 import { MusicElement } from "./MusicElement";
 
-import { Dictionary, Range, FRlocation, processLilypond } from "./lily";
+import { NoteEntry, Range, FRlocation, processLilypond } from "./lily";
 
 export class MusicCanvas extends MusicElement {
   static observedAttributes = ["choir", "part", "bar", "playing"];
@@ -21,7 +21,7 @@ export class MusicCanvas extends MusicElement {
   lastNoteDuration: number[][] = [];
   falseRelationPulses: number[] = [];
   shimmerPhases: number[] = [];
-  dict: Dictionary[][] = []; // HACK: bad name and data type
+  notesByQuant: Map<number, NoteEntry[]> = new Map();
   ranges: Range[][][] = []; // HACK: bad data type
   barCount: number = 0;
   frLocations: FRlocation[] = [];
@@ -204,7 +204,7 @@ export class MusicCanvas extends MusicElement {
     this.#showLoadingOnCanvas();
 
     const lilyData = processLilypond();
-    this.dict = lilyData.dict;
+    this.notesByQuant = lilyData.notesByQuant;
     this.ranges = lilyData.ranges;
     this.barCount = lilyData.barCount;
     this.frLocations = lilyData.frLocations;
@@ -266,7 +266,7 @@ export class MusicCanvas extends MusicElement {
 
   seek(pos: Position, direction: 1 | -1) {
     var intbar = Math.floor(pos.bar);
-    const choirnotes = (this.dict[intbar] ?? []).filter(
+    const choirnotes = (this.notesByQuant.get(intbar) ?? []).filter(
       (x) => x.c == pos.choir
     );
     const singing = choirnotes.length != 0;
@@ -275,7 +275,8 @@ export class MusicCanvas extends MusicElement {
     while (intbar + direction >= 0 && intbar + direction <= this.barCount) {
       intbar = intbar + direction;
       const newsinging =
-        (this.dict[intbar] ?? []).filter((x) => x.c == pos.choir).length != 0;
+        (this.notesByQuant.get(intbar) ?? []).filter((x) => x.c == pos.choir)
+          .length != 0;
       if (singing !== newsinging) break;
     }
     return intbar;
@@ -300,7 +301,7 @@ export class MusicCanvas extends MusicElement {
 
   draw() {
     if (!this.canvas) return;
-    if (this.ranges.length === 0 || this.dict.length === 0) return;
+    if (this.ranges.length === 0 || this.notesByQuant.size === 0) return;
     if (!this.#shouldDraw()) return;
 
     this.#updatePulses();
@@ -331,7 +332,7 @@ export class MusicCanvas extends MusicElement {
 
     // If there are notes starting now, record their onset and duration
     const quant = Math.floor(this.bar * 16) / 16;
-    const notes = this.dict[quant];
+    const notes = this.notesByQuant.get(quant);
     if (notes != undefined && notes.length > 0) {
       for (var n of notes) {
         if (n.n.duration != null) {

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -7,8 +7,8 @@ import * as ohm from "ohm-js";
 import { Duration, BarLine, Note, Rest, Component } from "./music-classes";
 import spem from "../../lilypond/src/Hugh Keyte/spem.ly?raw";
 
-// Make an dictionary of music positions (hemidemisemiquavers/128) to array of notes {choir, part, note}
-export type Dictionary = {
+// A single note entry at a quantised bar position.
+export type NoteEntry = {
   c: number;
   p: number;
   n: Note;
@@ -266,14 +266,14 @@ export var barCount: number = 0;
 
 // Fields are `readonly` (field-level only) because processLilypond now hands
 // out the same cached reference on every call (see lilypondCache below).
-// `readonly` on the field catches `lilyData.dict = somethingElse`, the most
-// likely accidental reassignment. The arrays themselves are not marked
-// readonly because canvas.test.ts deliberately mutates `dict` to exercise
-// seek()'s defensive path (restoring at end-of-test); deep readonly would
-// force a wider refactor than this perf-ticket warrants. Callers MUST treat
-// `dict`, `ranges`, and `frLocations` as immutable in non-test code.
+// `readonly` on the field catches `lilyData.notesByQuant = somethingElse`,
+// the most likely accidental reassignment. The Map itself is not marked
+// readonly because canvas.test.ts deliberately mutates `notesByQuant` to
+// exercise seek()'s defensive path (restoring at end-of-test); deep readonly
+// would force a wider refactor. Callers MUST treat `notesByQuant`, `ranges`,
+// and `frLocations` as immutable in non-test code.
 export type LilypondData = {
-  readonly dict: Dictionary[][];
+  readonly notesByQuant: Map<number, NoteEntry[]>;
   readonly ranges: Range[][][];
   readonly barCount: number;
   readonly frLocations: FRlocation[];
@@ -313,7 +313,7 @@ export function processLilypond(): LilypondData {
 
   semantics(result).parse();
 
-  const dict: Dictionary[][] = [];
+  const notesByQuant = new Map<number, NoteEntry[]>();
   const ranges: Range[][][] = [];
   const activeNotes = new Map<number, ActiveNote[]>();
   let localBarCount = 0;
@@ -340,10 +340,12 @@ export function processLilypond(): LilypondData {
             from = pos;
           }
 
-          if (dict[pos] == undefined) {
-            dict[pos] = [];
+          const entry = notesByQuant.get(pos);
+          if (entry) {
+            entry.push({ c, p, n: comp });
+          } else {
+            notesByQuant.set(pos, [{ c, p, n: comp }]);
           }
-          dict[pos].push({ c: c, p: p, n: comp });
 
           if (comp.duration != null) pos += comp.duration.sfths / barsize;
 
@@ -383,7 +385,12 @@ export function processLilypond(): LilypondData {
 
   barCount = localBarCount; // side effect: keep global in sync for MusicControls.ts
   const frLocations = detectFalseRelations(activeNotes);
-  lilypondCache = { dict, ranges, barCount: localBarCount, frLocations };
+  lilypondCache = {
+    notesByQuant,
+    ranges,
+    barCount: localBarCount,
+    frLocations,
+  };
   return lilypondCache;
 }
 


### PR DESCRIPTION
Fixes #105

## Summary
Replaces the opaque  sparse array with a semantically named  in  and .

## Changes
- **lily.ts**: Renamed  → . Changed  to . Updated  to populate the Map using / instead of sparse array indexing.
- **MusicCanvas.ts**: Updated field, import, and all usages (, , ) to use Map API.
- **Tests**: Updated , , and  to use Map methods (__TEXT	__DATA	__OBJC	others	dec	hex, , ).

## Why not ranges too?
Epic #508 tracks both #105 () and #106 (). This PR covers #105 only.  remains as-is to keep the PR focused and reviewable. The  interface now has a mixed shape (Map + nested array) which is intentional and temporary — #106 will complete the refactor.

## Verification
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/Users/mark/github/spem-player[39m

[90mstdout[2m | src/test/keyboard.test.ts[2m > [22m[2mSpace bar play/pause
[22m[39mSpem Player 2.7.0

[90mstdout[2m | src/test/canvas.test.ts[2m > [22m[2mMusicCanvas custom element[2m > [22m[2mCheck that the canvasent contains a canvas
[22m[39m<canvas width="4000" height="1000" style="width: 100%; height: 100%;"></canvas>

 [32m✓[39m src/test/pwa.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 1223[2mms[22m[39m
     [33m[2m✓[22m[39m registers the service worker on load when supported [33m 826[2mms[22m[39m
 [32m✓[39m src/test/keyboard.test.ts [2m([22m[2m43 tests[22m[2m)[22m[33m 2419[2mms[22m[39m
 [32m✓[39m src/test/lily.test.ts [2m([22m[2m16 tests[22m[2m)[22m[33m 949[2mms[22m[39m
     [33m[2m✓[22m[39m processLilypond() is idempotent over the parse — repeated cold calls produce equal data [33m 445[2mms[22m[39m
 [32m✓[39m src/test/canvas.test.ts [2m([22m[2m28 tests[22m[2m)[22m[33m 2749[2mms[22m[39m
     [33m[2m✓[22m[39m disconnect and reconnect restarts the shimmer loop (#245) [33m 711[2mms[22m[39m
     [33m[2m✓[22m[39m removes all event listeners on disconnect and re-adds them on reconnect (#203) [33m 743[2mms[22m[39m
[90mstdout[2m | src/test/darkmode.test.ts[2m > [22m[2mDark/light mode toggle
[22m[39mSpem Player 2.7.0

[90mstdout[2m | src/test/setbar.test.ts[2m > [22m[2msetBar boundary wrapping
[22m[39mSpem Player 2.7.0

 [32m✓[39m src/test/darkmode.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 835[2mms[22m[39m
[90mstdout[2m | src/test/feedback.test.ts[2m > [22m[2mFeedback modal
[22m[39mSpem Player 2.7.0

 [32m✓[39m src/test/setbar.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 772[2mms[22m[39m
 [32m✓[39m src/test/feedback.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 712[2mms[22m[39m
[90mstdout[2m | src/test/main.test.ts[2m > [22m[2mindex.js[2m > [22m[2mCheck that the score, canvas and controls are all there
[22m[39m

 [32m✓[39m src/test/main.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 67[2mms[22m[39m
 [32m✓[39m src/test/controls.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 300[2mms[22m[39m
 [32m✓[39m src/test/score.test.ts [2m([22m[2m24 tests[22m[2m)[22m[33m 679[2mms[22m[39m
 [32m✓[39m src/test/common.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 53[2mms[22m[39m
 [32m✓[39m src/test/canvaswatcher.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m lilypond/test/postprocessSvg.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m lilypond/test/postprocessSvgDedup.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/test/musicelement.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/test/worktree-ports.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/test/music-classes.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/test/url.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/spem.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m lilypond/test/buildScores.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/escapeHtml.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/config.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/helpers.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/docs.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m lilypond/test/buildScores.integration.test.ts [2m([22m[2m15 tests[22m[2m)[22m[33m 11200[2mms[22m[39m
     [33m[2m✓[22m[39m builds all notations [33m 1228[2mms[22m[39m
     [33m[2m✓[22m[39m creates missing score output directories on a clean checkout (#318) [33m 842[2mms[22m[39m
     [33m[2m✓[22m[39m caches by mtime [33m 1032[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds all scores when a version-root include is newer (Vera 353-01) [33m 1769[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds the touched choir's notation when its own .ly is newer (Vera 353-11) [33m 1301[2mms[22m[39m
     [33m[2m✓[22m[39m does NOT rebuild a sibling notation when only one notation changes (Vera 353-07) [33m 1260[2mms[22m[39m
     [33m[2m✓[22m[39m does not build OUP [33m 781[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds when postprocessSvg.mjs is newer (#393) [33m 1557[2mms[22m[39m
     [33m[2m✓[22m[39m deletes SVG on lilypond failure (#394) [33m 977[2mms[22m[39m

[2m Test Files [22m [1m[32m25 passed[39m[22m[90m (25)[39m
[2m      Tests [22m [1m[32m276 passed[39m[22m[90m (276)[39m
[2m   Start at [22m 14:30:31
[2m   Duration [22m 11.78s[2m (transform 706ms, setup 190ms, import 853ms, tests 22.02s, environment 10.61s)[22m: 276 tests pass
- 
> spem-player@2.7.0 check
> npm run build:ohm && npm run check:unused && npm run check:format && npm run check:lint && npm run check:types && npm run check:deps


> spem-player@2.7.0 build:ohm
> npx ohm generateBundles --withTypes src/ohmjs/ly-grammar.ohm

src/ohmjs/ly-grammar.ohm-bundle.js
src/ohmjs/ly-grammar.ohm-bundle.d.ts

> spem-player@2.7.0 check:unused
> knip


> spem-player@2.7.0 check:format
> prettier --check src/

Checking formatting...
All matched files use Prettier code style!

> spem-player@2.7.0 check:lint
> eslint . --max-warnings 0


> spem-player@2.7.0 check:types
> tsc --noEmit


> spem-player@2.7.0 check:deps
> depcruise src/ts/*.ts index.ts


  warn no-orphans: src/ts/escapeHtml.ts

x 1 dependency violations (0 errors, 1 warnings). 25 modules, 39 dependencies cruised.: clean (pre-existing escapeHtml orphan warning only)