### PR TITLE
refactor: replace ranges triple-nested array with Map (#106)

### DIFF
--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -33,7 +33,7 @@ describe("MusicCanvas custom element", () => {
     // ranges.length === 0 guard. See refactor item 15 in wiki/refactor-lily.ts.md.
     const freshCanvas = document.createElement("music-canvas") as MusicCanvas;
     freshCanvas.notesByQuant = new Map();
-    freshCanvas.ranges = [];
+    freshCanvas.ranges = new Map();
     freshCanvas.draw();
   });
 

--- a/src/test/lily.test.ts
+++ b/src/test/lily.test.ts
@@ -72,11 +72,11 @@ describe("lilypond parsing tests", () => {
     const { notesByQuant, ranges } = processLilypond();
     expect(notesByQuant.size).toBeGreaterThan(0);
     expect(barCount).toBe(139);
-    expect(ranges.length).toBe(8); // choirs
+    expect(ranges.size).toBe(40); // 8 choirs * 5 parts
     for (var c = 0; c < 8; c++) {
-      expect(ranges[c].length).toBe(5);
       for (var p = 0; p < 1; p++) {
-        const last = ranges[c][p][ranges[c][p].length - 1];
+        const list = ranges.get(`${c}-${p}`)!;
+        const last = list[list.length - 1];
         expect(last.to).toBe(139);
       }
     }
@@ -86,7 +86,7 @@ describe("lilypond parsing tests", () => {
     const result = processLilypond();
     expect(result).toBeDefined();
     expect(result.notesByQuant.size).toBeGreaterThan(0);
-    expect(result.ranges.length).toBe(8);
+    expect(result.ranges.size).toBe(40);
     expect(result.barCount).toBeGreaterThan(0);
     expect(result.frLocations.length).toBeGreaterThan(0);
   });
@@ -123,7 +123,7 @@ describe("lilypond parsing tests", () => {
     resetLilypondCache();
     const result2 = processLilypond();
     expect(result2.notesByQuant.size).toBe(result1.notesByQuant.size);
-    expect(result2.ranges.length).toBe(result1.ranges.length);
+    expect(result2.ranges.size).toBe(result1.ranges.size);
     expect(result2.barCount).toBe(result1.barCount);
     expect(result2.frLocations.length).toBe(result1.frLocations.length);
   });

--- a/src/test/spem.test.ts
+++ b/src/test/spem.test.ts
@@ -4,17 +4,19 @@ describe("Check that spem notes looks good", () => {
   const { notesByQuant, ranges } = processLilypond();
 
   it("8 choir of 5 parts", async () => {
-    expect(ranges.length).toBe(8); // choirs
+    expect(ranges.size).toBe(40); // 8 choirs * 5 parts
     for (var c = 0; c < 8; c++) {
-      expect(ranges[c].length).toBe(5);
+      for (var p = 0; p < 5; p++) {
+        expect(ranges.get(`${c}-${p}`)).toBeDefined();
+      }
     }
   });
 
   it("Everyone finishes at the end of bar 138", async () => {
     for (var c = 0; c < 8; c++) {
-      expect(ranges[c].length).toBe(5);
       for (var p = 0; p < 1; p++) {
-        const last = ranges[c][p][ranges[c][p].length - 1];
+        const list = ranges.get(`${c}-${p}`)!;
+        const last = list[list.length - 1];
         expect(last.to).toBe(139);
       }
     }
@@ -24,7 +26,8 @@ describe("Check that spem notes looks good", () => {
   it("Everyone is singing respice at bar 122", () => {
     for (var c = 0; c < 8; c++) {
       for (var p = 0; p < 1; p++) {
-        const result = ranges[c][p].find((x) => (x.from = 122)) != null;
+        const result =
+          ranges.get(`${c}-${p}`)!.find((x) => (x.from = 122)) != null;
         expect(result, "choir/part " + c + "/" + p).toBe(true);
       }
     }
@@ -34,9 +37,9 @@ describe("Check that spem notes looks good", () => {
   it("Nobody is singing in the third beat of bar 74", () => {
     for (var c = 0; c < 8; c++) {
       for (var p = 0; p < 5; p++) {
-        const result = ranges[c][p].find(
-          (x) => x.from <= 74.5 && x.to >= 74.75
-        );
+        const result = ranges
+          .get(`${c}-${p}`)!
+          .find((x) => x.from <= 74.5 && x.to >= 74.75);
         expect(
           result,
           "choir/part " + c + "/" + p + " = " + result
@@ -49,9 +52,9 @@ describe("Check that spem notes looks good", () => {
   it("Nobody is singing in the third beat of bar 108", () => {
     for (var c = 0; c < 8; c++) {
       for (var p = 0; p < 5; p++) {
-        const result = ranges[c][p].find(
-          (x) => x.from <= 108.5 && x.to >= 108.75
-        );
+        const result = ranges
+          .get(`${c}-${p}`)!
+          .find((x) => x.from <= 108.5 && x.to >= 108.75);
         expect(
           result,
           "choir/part " + c + "/" + p + " = " + result
@@ -64,9 +67,9 @@ describe("Check that spem notes looks good", () => {
   it("Nobody is singing in the last minim of 121", () => {
     for (var c = 0; c < 8; c++) {
       for (var p = 0; p < 5; p++) {
-        const result = ranges[c][p].find(
-          (x) => x.from <= 121.75 && x.to >= 122
-        );
+        const result = ranges
+          .get(`${c}-${p}`)!
+          .find((x) => x.from <= 121.75 && x.to >= 122);
         expect(
           result,
           "choir/part " + c + "/" + p + " = " + result

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -22,7 +22,7 @@ export class MusicCanvas extends MusicElement {
   falseRelationPulses: number[] = [];
   shimmerPhases: number[] = [];
   notesByQuant: Map<number, NoteEntry[]> = new Map();
-  ranges: Range[][][] = []; // HACK: bad data type
+  ranges: Map<string, Range[]> = new Map();
   barCount: number = 0;
   frLocations: FRlocation[] = [];
   source: string | null = null;
@@ -301,7 +301,7 @@ export class MusicCanvas extends MusicElement {
 
   draw() {
     if (!this.canvas) return;
-    if (this.ranges.length === 0 || this.notesByQuant.size === 0) return;
+    if (this.ranges.size === 0 || this.notesByQuant.size === 0) return;
     if (!this.#shouldDraw()) return;
 
     this.#updatePulses();
@@ -443,7 +443,9 @@ export class MusicCanvas extends MusicElement {
         const startY =
           this.canvasPadding + c * this.choirHeight + p * this.partHeight;
 
-        const list: { from: number; to: number }[] = this.ranges[c][p];
+        const list: { from: number; to: number }[] = this.ranges.get(
+          `${c}-${p}`
+        )!;
         list.forEach((r) => {
           const from = r.from;
           const to = r.to;

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -274,7 +274,7 @@ export var barCount: number = 0;
 // and `frLocations` as immutable in non-test code.
 export type LilypondData = {
   readonly notesByQuant: Map<number, NoteEntry[]>;
-  readonly ranges: Range[][][];
+  readonly ranges: Map<string, Range[]>;
   readonly barCount: number;
   readonly frLocations: FRlocation[];
 };
@@ -289,8 +289,8 @@ let lilypondCache: LilypondData | null = null;
 
 // -----------------------------------------------------
 // Process the lilypond input file and return a LilypondData object:
-//   dict[position] = [ {choir, part, note}, ... ]
-//   ranges[choir (0 to 7)][part (0 to 4)] = [ {from, to}, ... ]
+//   notesByQuant.get(position) = [ {choir, part, note}, ... ]
+//   ranges.get("choir-part") = [ {from, to}, ... ]
 //   barCount — index of the last bar
 //   frLocations — false-relation positions for rendering
 // -----------------------------------------------------
@@ -314,15 +314,14 @@ export function processLilypond(): LilypondData {
   semantics(result).parse();
 
   const notesByQuant = new Map<number, NoteEntry[]>();
-  const ranges: Range[][][] = [];
+  const ranges = new Map<string, Range[]>();
   const activeNotes = new Map<number, ActiveNote[]>();
   let localBarCount = 0;
   for (let c = 0; c < config.choirs[0].length; c++) {
     const choir = config.choirs[0][c];
-    ranges[c] = [];
     for (let p = 0; p < config.parts.length; p++) {
       const part = config.parts[p];
-      ranges[c][p] = [];
+      ranges.set(`${c}-${p}`, []);
       var key = "notes" + choir.replace(/ /g, "") + part;
 
       // get the lilypond for this choir and part
@@ -364,7 +363,7 @@ export function processLilypond(): LilypondData {
           }
         } else if (comp instanceof Rest) {
           if (from != undefined) {
-            ranges[c][p].push({ from: from, to: pos });
+            ranges.get(`${c}-${p}`)!.push({ from, to: pos });
             from = undefined;
           }
 
@@ -373,7 +372,7 @@ export function processLilypond(): LilypondData {
       }
 
       if (from != undefined) {
-        ranges[c][p].push({ from: from, to: pos });
+        ranges.get(`${c}-${p}`)!.push({ from, to: pos });
       }
 
       if (pos > localBarCount) {


### PR DESCRIPTION
Fixes #106

## Summary
Replaces the opaque  triple-nested array with  in  and , completing the epic #508 data structure refactor.

## Changes
- **lily.ts**: Changed  to . Updated  to populate the Map with  keys (e.g., ).
- **MusicCanvas.ts**: Updated  field and  to use Map API.
- **Tests**: Updated , , and  to use , __TEXT	__DATA	__OBJC	others	dec	hex, and  instead of array indexing.

## Verification
- 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/Users/mark/github/spem-player[39m

[90mstdout[2m | src/test/keyboard.test.ts[2m > [22m[2mSpace bar play/pause
[22m[39mSpem Player 2.7.0

[90mstdout[2m | src/test/canvas.test.ts[2m > [22m[2mMusicCanvas custom element[2m > [22m[2mCheck that the canvasent contains a canvas
[22m[39m<canvas width="4000" height="1000" style="width: 100%; height: 100%;"></canvas>

 [32m✓[39m src/test/pwa.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 1261[2mms[22m[39m
     [33m[2m✓[22m[39m registers the service worker on load when supported [33m 869[2mms[22m[39m
 [32m✓[39m src/test/keyboard.test.ts [2m([22m[2m43 tests[22m[2m)[22m[33m 2472[2mms[22m[39m
 [32m✓[39m src/test/lily.test.ts [2m([22m[2m16 tests[22m[2m)[22m[33m 944[2mms[22m[39m
     [33m[2m✓[22m[39m processLilypond() is idempotent over the parse — repeated cold calls produce equal data [33m 432[2mms[22m[39m
 [32m✓[39m src/test/canvas.test.ts [2m([22m[2m28 tests[22m[2m)[22m[33m 2763[2mms[22m[39m
     [33m[2m✓[22m[39m disconnect and reconnect restarts the shimmer loop (#245) [33m 738[2mms[22m[39m
     [33m[2m✓[22m[39m removes all event listeners on disconnect and re-adds them on reconnect (#203) [33m 727[2mms[22m[39m
[90mstdout[2m | src/test/darkmode.test.ts[2m > [22m[2mDark/light mode toggle
[22m[39mSpem Player 2.7.0

[90mstdout[2m | src/test/setbar.test.ts[2m > [22m[2msetBar boundary wrapping
[22m[39mSpem Player 2.7.0

 [32m✓[39m src/test/darkmode.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 824[2mms[22m[39m
 [32m✓[39m src/test/setbar.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 780[2mms[22m[39m
[90mstdout[2m | src/test/feedback.test.ts[2m > [22m[2mFeedback modal
[22m[39mSpem Player 2.7.0

 [32m✓[39m src/test/feedback.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 725[2mms[22m[39m
[90mstdout[2m | src/test/main.test.ts[2m > [22m[2mindex.js[2m > [22m[2mCheck that the score, canvas and controls are all there
[22m[39m

 [32m✓[39m src/test/main.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 65[2mms[22m[39m
 [32m✓[39m src/test/controls.test.ts [2m([22m[2m22 tests[22m[2m)[22m[33m 302[2mms[22m[39m
 [32m✓[39m src/test/score.test.ts [2m([22m[2m24 tests[22m[2m)[22m[33m 645[2mms[22m[39m
 [32m✓[39m src/test/canvaswatcher.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/test/common.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 53[2mms[22m[39m
 [32m✓[39m lilypond/test/postprocessSvg.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m lilypond/test/postprocessSvgDedup.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/test/musicelement.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/test/worktree-ports.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/test/music-classes.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/test/config.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/spem.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/test/escapeHtml.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/url.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m lilypond/test/buildScores.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/docs.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/test/helpers.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m lilypond/test/buildScores.integration.test.ts [2m([22m[2m15 tests[22m[2m)[22m[33m 11310[2mms[22m[39m
     [33m[2m✓[22m[39m builds all notations [33m 1191[2mms[22m[39m
     [33m[2m✓[22m[39m creates missing score output directories on a clean checkout (#318) [33m 841[2mms[22m[39m
     [33m[2m✓[22m[39m caches by mtime [33m 994[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds all scores when a version-root include is newer (Vera 353-01) [33m 1706[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds the touched choir's notation when its own .ly is newer (Vera 353-11) [33m 1300[2mms[22m[39m
     [33m[2m✓[22m[39m does NOT rebuild a sibling notation when only one notation changes (Vera 353-07) [33m 1292[2mms[22m[39m
     [33m[2m✓[22m[39m does not build OUP [33m 796[2mms[22m[39m
     [33m[2m✓[22m[39m rebuilds when postprocessSvg.mjs is newer (#393) [33m 1587[2mms[22m[39m
     [33m[2m✓[22m[39m deletes SVG on lilypond failure (#394) [33m 1138[2mms[22m[39m

[2m Test Files [22m [1m[32m25 passed[39m[22m[90m (25)[39m
[2m      Tests [22m [1m[32m276 passed[39m[22m[90m (276)[39m
[2m   Start at [22m 14:41:46
[2m   Duration [22m 12.14s[2m (transform 692ms, setup 206ms, import 972ms, tests 22.20s, environment 11.29s)[22m: 276 tests pass
- 
> spem-player@2.7.0 check
> npm run build:ohm && npm run check:unused && npm run check:format && npm run check:lint && npm run check:types && npm run check:deps


> spem-player@2.7.0 build:ohm
> npx ohm generateBundles --withTypes src/ohmjs/ly-grammar.ohm

src/ohmjs/ly-grammar.ohm-bundle.js
src/ohmjs/ly-grammar.ohm-bundle.d.ts

> spem-player@2.7.0 check:unused
> knip


> spem-player@2.7.0 check:format
> prettier --check src/

Checking formatting...
All matched files use Prettier code style!

> spem-player@2.7.0 check:lint
> eslint . --max-warnings 0


> spem-player@2.7.0 check:types
> tsc --noEmit


> spem-player@2.7.0 check:deps
> depcruise src/ts/*.ts index.ts


  warn no-orphans: src/ts/escapeHtml.ts

x 1 dependency violations (0 errors, 1 warnings). 25 modules, 39 dependencies cruised.: clean (pre-existing escapeHtml orphan warning only)