### PR TITLE
fix: rebuild choir dropdown when recording changes (#398)

### DIFF
--- a/e2e/playback-toggle.spec.ts
+++ b/e2e/playback-toggle.spec.ts
@@ -50,4 +50,27 @@ test.describe("Playback keyboard toggle", () => {
     await page.keyboard.press("Enter");
     await expect(pauseIcon).toBeHidden();
   });
+
+  test("play/pause button stays circular when the recording changes (#398)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const button = page.locator("#playpausebutton");
+    await expect(button).toBeVisible();
+
+    // The button is border-radius:50%, so it only reads as a circle while its
+    // width equals its height. Changing the recording rebuilds the choir
+    // dropdown to a different label width, reflowing the controls row; the
+    // button must not be resized by that reflow.
+    const isSquare = async () => {
+      const box = await button.boundingBox();
+      if (!box) throw new Error("button has no bounding box");
+      expect(Math.abs(box.width - box.height)).toBeLessThanOrEqual(1);
+    };
+
+    await isSquare();
+    await page.locator("#recordingswitch").click();
+    await isSquare();
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spem-player",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spem-player",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "ohm-js": "^17.2.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -375,6 +375,11 @@ kbd {
       padding: 3px;
       margin: 3px 5px;
 
+      // Pin the button so flexbox cannot resize it when the controls row
+      // reflows (e.g. when the choir dropdown rebuilds to a different
+      // recording's labels). Without this, a shrunk width against the fixed
+      // height renders the border-radius:50% circle as an oval (#398).
+      flex: none;
       height: 3rem;
       width: 3rem;
       background: white;

--- a/src/test/controls.test.ts
+++ b/src/test/controls.test.ts
@@ -56,6 +56,9 @@ describe("MusicControls custom element", () => {
     expect(choirs?.querySelectorAll("option").length).toBe(
       config.choirs[0].length
     );
+    expect(
+      Array.from(choirs!.querySelectorAll("option")).map((o) => o.textContent)
+    ).toEqual(config.choirs[0]);
 
     const parts = document.getElementById("part-select");
     expect(parts).not.toBeNull();
@@ -69,6 +72,57 @@ describe("MusicControls custom element", () => {
     expect(bar?.getAttribute("name")).toBe("bar");
     expect(bar?.getAttribute("value")).toBe("0");
     expect(bar?.getAttribute("min")).toBe("0");
+  });
+
+  it("setRecording updates choir dropdown labels", () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const choir = document.getElementById("choir-select") as HTMLSelectElement;
+
+    // Default recording is 0 (ALC)
+    const options0 = Array.from(choir.querySelectorAll("option"));
+    expect(options0.map((o) => o.textContent)).toEqual(config.choirs[0]);
+
+    // Switch to recording 1 (CotE)
+    elem.setRecording(1);
+
+    const options1 = Array.from(choir.querySelectorAll("option"));
+    expect(options1.map((o) => o.textContent)).toEqual(config.choirs[1]);
+  });
+
+  it("setRecording rebuilds choir dropdown labels when switching back (#398)", () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const choir = document.getElementById("choir-select") as HTMLSelectElement;
+
+    // Switch away to recording 1 (CotE), then back to recording 0 (ALC)
+    elem.setRecording(1);
+    expect(
+      Array.from(choir.querySelectorAll("option")).map((o) => o.textContent)
+    ).toEqual(config.choirs[1]);
+
+    elem.setRecording(0);
+
+    // Labels must return to recording 0, not stay stale on recording 1
+    expect(
+      Array.from(choir.querySelectorAll("option")).map((o) => o.textContent)
+    ).toEqual(config.choirs[0]);
+  });
+
+  it("setRecording preserves selected choir index", () => {
+    const elem = document.querySelector("music-controls") as MusicControls;
+    const choir = document.getElementById("choir-select") as HTMLSelectElement;
+
+    // Set choir to 3
+    elem.setAttribute("choir", "3");
+    expect(choir.value).toBe("3");
+
+    // Switch recording
+    elem.setRecording(1);
+
+    // Selection preserved
+    expect(choir.value).toBe("3");
+    // Label updated
+    const options = Array.from(choir.querySelectorAll("option"));
+    expect(options[3].textContent).toBe(config.choirs[1][3]);
   });
 
   it("MusicControls has the loading, play and pause SVGs", () => {

--- a/src/ts/MusicControls.ts
+++ b/src/ts/MusicControls.ts
@@ -70,12 +70,7 @@ export class MusicControls extends MusicElement {
     this.choirselect.setAttribute("name", "choir");
     this.choirselect.setAttribute("id", "choir-select");
     this.choirselect.setAttribute("class", "control");
-    for (var c in config.choirs[0]) {
-      const opt = document.createElement("option");
-      opt.setAttribute("value", c);
-      opt.appendChild(document.createTextNode(config.choirs[0][c]));
-      this.choirselect.append(opt);
-    }
+    this.#buildChoirDropdown();
     label.append(this.choirselect);
     this.append(label);
 
@@ -147,6 +142,25 @@ export class MusicControls extends MusicElement {
     if (this.playpausebutton)
       this.playpausebutton.addEventListener("click", this.playpause.bind(this));
     this.audio.addEventListener("ended", () => this.pause());
+  }
+
+  #buildChoirDropdown() {
+    if (!this.choirselect) return;
+    // Invariant: every recording's choir list is the same length, so the
+    // selected index (`this.choir`, restored below via `.value`) is always a
+    // valid option after a rebuild. All recordings have 8 choirs today; a
+    // future recording with a different count would make `.value` silently
+    // fail to select. A length-parity assertion is tracked in #504.
+    this.choirselect.innerHTML = "";
+    for (var c in config.choirs[this.recording]) {
+      const opt = document.createElement("option");
+      opt.setAttribute("value", c);
+      opt.appendChild(
+        document.createTextNode(config.choirs[this.recording][c])
+      );
+      this.choirselect.append(opt);
+    }
+    this.choirselect.value = String(this.choir);
   }
 
   async #handleControlsChanged() {
@@ -292,6 +306,7 @@ export class MusicControls extends MusicElement {
 
   setRecording(v: number | string): void {
     super.setRecording(v);
+    this.#buildChoirDropdown();
     this.audio.currentTime = getTimeFromBar(this.bar, this.recording);
     if (this.isPlaying()) this.play();
   }


### PR DESCRIPTION
## Summary

Fixes #398.

The choir dropdown was built once at init from `config.choirs[0]` and never
rebuilt, so selecting the CotE recording (recording = 1) left the dropdown
showing the ALC choir labels.

## Changes

- Extract the dropdown build into `MusicControls.#buildChoirDropdown()`, which
  clears and rebuilds the options from `config.choirs[this.recording]` and
  restores the selected choir. It is called at init and from `setRecording()`,
  so the labels track the active recording.
- Pin the play/pause button with `flex: none`. Rebuilding the dropdown changes
  its width per recording, which reflows the controls row; without the pin,
  flexbox shrank the button's width against its fixed height and the
  `border-radius: 50%` circle rendered as an oval. (Found during UI review; a
  pre-existing layout fragility that this fix would otherwise have exposed.)

## Tests

- Unit: a 1 → 0 recording switch-back test asserting the labels return to
  `config.choirs[0]` (verified red against a neutered fix, then green).
- e2e: the play/pause button stays square (circular) across a recording toggle.

## Notes

- The rebuild relies on every recording's choir list being the same length
  (all are 8 today). The invariant is commented in `#buildChoirDropdown`; a
  length-parity assertion is tracked separately in #504.

- Vera
