### PR TITLE
build: Exclude escapeHtml.ts from depcruise no-orphans rule (#501)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -10,7 +10,7 @@ module.exports = {
     {
       name: "no-orphans",
       severity: "warn",
-      from: { orphan: true },
+      from: { orphan: true, pathNot: "src/ts/escapeHtml.ts" },
       to: {},
     },
     {


### PR DESCRIPTION
Fixes #501

## Summary

Applies Option B from the issue: adds a `pathNot` exception for `src/ts/escapeHtml.ts` in the `no-orphans` rule of `.dependency-cruiser.cjs`.

## Problem

`escapeHtml.ts` is imported by `vite.config.ts`, but `vite.config.ts` is not in the depcruise command (`depcruise src/ts/*.ts index.ts`). Dependency-cruiser therefore flags it as orphaned.

## Why Option B

- Option A (add `vite.config.ts` to the cruise set) trades one warning for five new `no-deprecated-core` warnings from Node built-ins.
- Option C (principled exclusion of build config from `no-deprecated-core`) is over-engineered for a single file.
- Option B is a one-line change with no side effects. If a pattern of build-only utilities emerges, revisit with Option C.

## Verification

- `npm run check` before: `warn no-orphans: src/ts/escapeHtml.ts`
- `npm run check` after: `✔ no dependency violations found`
- `npm test`: 280 tests pass
- Warning diff: orphan warning removed, zero new warnings introduced
- No version bump (build/config-only change per work method)