### PR TITLE
Add a11y to PWA update toast (#518)

### DIFF
--- a/e2e/pwa-update-toast.spec.ts
+++ b/e2e/pwa-update-toast.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("PWA update toast accessibility", () => {
+  test("focus moves to the refresh button when the toast appears", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      (window as typeof window & { __pwaShowUpdateToast?: () => void }).__pwaShowUpdateToast?.();
+    });
+
+    const refreshBtn = page.locator(".pwa-update-toast-refresh");
+    await expect(refreshBtn).toBeFocused();
+  });
+
+  test("Escape key dismisses the toast", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      (window as typeof window & { __pwaShowUpdateToast?: () => void }).__pwaShowUpdateToast?.();
+    });
+
+    const toast = page.locator(".pwa-update-toast");
+    await expect(toast).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(toast).toBeHidden();
+  });
+});

--- a/src/test/pwa-update-toast.test.ts
+++ b/src/test/pwa-update-toast.test.ts
@@ -65,4 +65,50 @@ describe("PWA update toast", () => {
     capturedOnNeedRefresh!();
     expect(document.querySelectorAll(".pwa-update-toast").length).toBe(1);
   });
+
+  it("has role=alert and aria-live=polite", async () => {
+    await import("../ts/pwa-update");
+    capturedOnNeedRefresh!();
+    const toast = getToast();
+    expect(toast).not.toBeNull();
+    expect(toast!.getAttribute("role")).toBe("alert");
+    expect(toast!.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("moves focus to the refresh button", async () => {
+    await import("../ts/pwa-update");
+    capturedOnNeedRefresh!();
+    const refreshBtn = document.querySelector(
+      ".pwa-update-toast-refresh"
+    ) as HTMLButtonElement;
+    expect(document.activeElement).toBe(refreshBtn);
+  });
+
+  it("removes the toast when Escape is pressed", async () => {
+    await import("../ts/pwa-update");
+    capturedOnNeedRefresh!();
+    expect(getToast()).not.toBeNull();
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+    expect(getToast()).toBeNull();
+  });
+
+  it("cleans up the Escape listener after dismissal", async () => {
+    await import("../ts/pwa-update");
+    capturedOnNeedRefresh!();
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+    expect(getToast()).toBeNull();
+
+    // Trigger a second toast — if the old listener leaked, it would still
+    // be registered, but the new toast should show and dismiss normally.
+    capturedOnNeedRefresh!();
+    expect(getToast()).not.toBeNull();
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+    expect(getToast()).toBeNull();
+  });
 });

--- a/src/ts/pwa-update.ts
+++ b/src/ts/pwa-update.ts
@@ -11,6 +11,9 @@ function showUpdateToast() {
 
   const toast = document.createElement("div");
   toast.className = "pwa-update-toast";
+  toast.setAttribute("role", "alert");
+  toast.setAttribute("aria-live", "polite");
+
   toast.innerHTML = `
     <span class="pwa-update-toast-message">Update available</span>
     <button class="pwa-update-toast-refresh">Refresh</button>
@@ -24,14 +27,34 @@ function showUpdateToast() {
     ".pwa-update-toast-dismiss"
   ) as HTMLButtonElement;
 
+  const removeToast = () => {
+    document.removeEventListener("keydown", handleKeydown);
+    toast.remove();
+  };
+
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      removeToast();
+    }
+  };
+
   refreshBtn.addEventListener("click", () => {
     updateSW(true);
-    toast.remove();
+    removeToast();
   });
 
   dismissBtn.addEventListener("click", () => {
-    toast.remove();
+    removeToast();
   });
 
+  document.addEventListener("keydown", handleKeydown);
+
   document.body.appendChild(toast);
+  refreshBtn.focus();
 }
+
+// Expose for e2e testing
+(
+  window as typeof window & { __pwaShowUpdateToast?: typeof showUpdateToast }
+).__pwaShowUpdateToast = showUpdateToast;


### PR DESCRIPTION
- Add `role=alert` and `aria-live=polite` to toast container
- Move focus to Refresh button when toast appears
- Add Escape key dismissal with proper listener cleanup
- Extend unit tests for ARIA attributes, focus, and Escape
- Add Playwright e2e tests for focus and keyboard dismissal

Closes #518