### PR TITLE
Cancel stale score loads on rapid choir switching (#391)

### DIFF
--- a/src/test/score.test.ts
+++ b/src/test/score.test.ts
@@ -6,6 +6,7 @@ import {
   expectedPart,
   waitForEvent,
 } from "./helpers";
+import { makeFixtureSvg } from "./fixtureScore";
 
 // Polyfill DOMPoint for jsdom
 if (typeof DOMPoint === "undefined") {
@@ -687,5 +688,53 @@ describe("MusicScore custom element", () => {
     const overlay = elem.querySelector(".score-clef-overlay");
     expect(overlay).not.toBeNull();
     expect(overlay!.querySelector("#part-dim-style")).toBeNull();
+  });
+
+  it("aborts stale #loadScore when a newer choir request resolves first (#391)", async () => {
+    const elem = document.querySelector("music-score") as MusicScore;
+    elem.scrollTo = vi.fn();
+
+    let resolveChoir0: (svg: string) => void = () => {};
+    let resolveChoir1: (svg: string) => void = () => {};
+
+    const originalLoader = MusicScore.testSvgLoader;
+    MusicScore.testSvgLoader = (scoreType, choir) => {
+      if (choir === 0) {
+        return new Promise((resolve) => {
+          resolveChoir0 = resolve;
+        }) as unknown as string;
+      }
+      if (choir === 1) {
+        return new Promise((resolve) => {
+          resolveChoir1 = resolve;
+        }) as unknown as string;
+      }
+      return makeFixtureSvg(scoreType);
+    };
+
+    // Start two choir changes without awaiting between them
+    const p0 = elem.setChoir(0);
+    const p1 = elem.setChoir(1);
+
+    // Resolve choir 1 first (the newer request wins the race)
+    resolveChoir1(
+      makeFixtureSvg("modern").replace("<svg ", '<svg data-choir="1" ')
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Then resolve choir 0 (stale)
+    resolveChoir0(
+      makeFixtureSvg("modern").replace("<svg ", '<svg data-choir="0" ')
+    );
+
+    await Promise.all([p0, p1]);
+
+    // Final state must be consistent: svg, bars, and choir all agree
+    expect(elem.choir).toBe(1);
+    expect(elem.svg).not.toBeNull();
+    expect(elem.svg!.isConnected).toBe(true);
+    expect(elem.svg!.getAttribute("data-choir")).toBe("1");
+
+    MusicScore.testSvgLoader = originalLoader;
   });
 });

--- a/src/ts/MusicScore.ts
+++ b/src/ts/MusicScore.ts
@@ -56,6 +56,7 @@ export class MusicScore extends MusicElement {
   maskRect!: SVGRectElement;
   maskLine!: SVGLineElement;
   scrollArea: HTMLDivElement | null = null;
+  #loadGeneration = 0;
   clefOverlay: HTMLDivElement | null = null;
 
   constructor() {
@@ -188,7 +189,11 @@ export class MusicScore extends MusicElement {
       const loader =
         MusicScore.testSvgLoader || globalThis.__SPEM_TEST_SVG_LOADER;
       if (loader) {
-        const svg = loader(this.scoreType, this.choir, this.recording);
+        // Await Promise.resolve so tests can supply either sync strings
+        // or async Promises (e.g. to simulate network races, #391).
+        const svg = await Promise.resolve(
+          loader(this.scoreType, this.choir, this.recording)
+        );
         // `typeof svg === "string"` covers both null (documented "fall
         // through" sentinel) and undefined (a stricter shape than the
         // type guarantees, but defensive against an `any`-typed fixture).
@@ -213,7 +218,15 @@ export class MusicScore extends MusicElement {
   };
 
   async #loadScore() {
+    const generation = ++this.#loadGeneration;
     const svgComp = await this.#loadSvg();
+
+    // If a newer load has started since we began, abort this stale run
+    // before it mutates DOM or state (#391).
+    if (generation !== this.#loadGeneration) {
+      return;
+    }
+
     if (svgComp) {
       this.innerHTML = `<div class="score-scroll-area">${svgComp}</div>`;
     }


### PR DESCRIPTION
- Add `#loadGeneration` counter to `MusicScore`
- Increment counter at start of `#loadScore`; abort if a newer load has started when the await resolves
- Allow test SvgLoader to return Promises by awaiting `Promise.resolve()` so tests can simulate network races
- Add unit test verifying stale load aborts when newer request resolves first

Closes #391