### PR TITLE
docs: add tooling bug Type to CONTRIBUTING (#525)

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -64,7 +64,10 @@ Mark's kanban workflow with explicit entry and exit criteria:
 
 #### Type
 
-- `bug` — defect
+- `bug` — user-visible defect: a reproducible failure a user can hit in normal use
+- `tooling bug` — defect in repo-tracked build scripts, test harness, CI, or dev
+  tooling; not user-visible (for example, a broken build script). Distinct from
+  `tech debt`: a tooling bug is broken, whereas tech debt works but is suboptimal
 - `feature` — new capability
 - `tech debt` — structural or maintenance improvement
 


### PR DESCRIPTION
Adds `tooling bug` to the board Type taxonomy in `doc/CONTRIBUTING.md`,
completing the change begun by adding the Type option to the board itself.

- `tooling bug` = defect in repo-tracked build scripts, test harness, CI, or dev
  tooling; not user-visible (for example, a broken build script).
- Draws the boundary against `tech debt`: a tooling bug is broken, whereas tech
  debt works but is suboptimal.
- Sharpens `bug` to "user-visible defect" so the two defect categories are
  distinct on the defect axis.

The board Type option already exists; this lands the documentation half so the
docs match reality.

Fixes #525

- Vera
