### PR TITLE
refactor: extract validated parseRepo() helper in monitor-resources.mjs (#497)

### DIFF
--- a/.github/scripts/monitor-resources.mjs
+++ b/.github/scripts/monitor-resources.mjs
@@ -53,8 +53,24 @@ async function getNetlifyUsage() {
   };
 }
 
+/**
+ * Parse `owner` and `repo` from the `GITHUB_REPOSITORY` environment variable.
+ *
+ * @returns {{owner: string, repo: string}} Both guaranteed non-empty.
+ * @throws {Error} If `GITHUB_REPOSITORY` is absent or not in `owner/repo` form.
+ */
+export function parseRepo() {
+  const [owner, repo] = process.env.GITHUB_REPOSITORY?.split("/") ?? [];
+  if (!owner || !repo) {
+    throw new Error(
+      `GITHUB_REPOSITORY must be owner/repo format, got: ${process.env.GITHUB_REPOSITORY}`
+    );
+  }
+  return { owner, repo };
+}
+
 async function getMergedPRCount(since) {
-  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  const { owner, repo } = parseRepo();
   const data = await api(
     `https://api.github.com/search/issues?q=repo:${owner}/${repo}+is:pr+is:merged+merged:>=${since}&per_page=1`,
     {
@@ -128,7 +144,7 @@ export function getReportingSince(nowMs = Date.now()) {
 }
 
 async function getGitHubUsage() {
-  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  const { owner, repo } = parseRepo();
   const now = new Date();
   const start = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
@@ -172,7 +188,7 @@ async function sendTelegram(text) {
 }
 
 async function openIssue(title, body) {
-  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  const { owner, repo } = parseRepo();
   const res = await fetch(
     `https://api.github.com/repos/${owner}/${repo}/issues`,
     {

--- a/.github/scripts/monitor-resources.test.mjs
+++ b/.github/scripts/monitor-resources.test.mjs
@@ -1,9 +1,10 @@
-import { test } from "node:test";
+import { test, after } from "node:test";
 import assert from "node:assert/strict";
 import {
   shouldSkipReport,
   formatMessage,
   getReportingSince,
+  parseRepo,
 } from "./monitor-resources.mjs";
 
 // shouldSkipReport: skip only when zero PRs AND below 50% (normal status)
@@ -58,4 +59,47 @@ test("getReportingSince returns YYYY-MM-DD format", () => {
   assert.equal(since, "2026-06-07");
   assert.doesNotMatch(since, /T/);
   assert.doesNotMatch(since, /Z/);
+});
+
+// parseRepo: parses and validates GITHUB_REPOSITORY environment variable.
+// These tests mutate the shared env var; restore it afterwards so they do not
+// leak global state to later tests or depend on execution order.
+const ORIG_GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+after(() => {
+  if (ORIG_GITHUB_REPOSITORY === undefined) {
+    delete process.env.GITHUB_REPOSITORY;
+  } else {
+    process.env.GITHUB_REPOSITORY = ORIG_GITHUB_REPOSITORY;
+  }
+});
+
+test("parseRepo returns owner and repo for valid input", () => {
+  process.env.GITHUB_REPOSITORY = "wainwmr/spem-player";
+  const result = parseRepo();
+  assert.equal(result.owner, "wainwmr");
+  assert.equal(result.repo, "spem-player");
+});
+
+test("parseRepo throws when GITHUB_REPOSITORY is undefined", () => {
+  delete process.env.GITHUB_REPOSITORY;
+  assert.throws(
+    () => parseRepo(),
+    /GITHUB_REPOSITORY must be owner\/repo format, got: undefined/
+  );
+});
+
+test("parseRepo throws when GITHUB_REPOSITORY has no slash", () => {
+  process.env.GITHUB_REPOSITORY = "badvalue";
+  assert.throws(
+    () => parseRepo(),
+    /GITHUB_REPOSITORY must be owner\/repo format, got: badvalue/
+  );
+});
+
+test("parseRepo throws when GITHUB_REPOSITORY is empty string", () => {
+  process.env.GITHUB_REPOSITORY = "";
+  assert.throws(
+    () => parseRepo(),
+    /GITHUB_REPOSITORY must be owner\/repo format, got: /
+  );
 });


### PR DESCRIPTION
Extracts a validated `parseRepo()` helper in
`.github/scripts/monitor-resources.mjs`, replacing three inline
`process.env.GITHUB_REPOSITORY.split("/")` sites.

- The old `.split("/")` silently yielded `undefined` owner/repo on a malformed
  `GITHUB_REPOSITORY`; `parseRepo()` throws a clear, named error instead.
- DRYs the three call sites (`getMergedPRCount`, `getGitHubUsage`, `openIssue`).
- Adds tests: valid input plus the undefined / no-slash / empty-string error
  cases.

Passed the Vera gate (five reviewers, no critical or important findings). Folded
the two convergent suggestions: a `@returns`/`@throws` JSDoc on `parseRepo` to
match the file's other exported helpers, and an `after()` hook so the new tests
restore `GITHUB_REPOSITORY` rather than leaking global state.

Fixes #497

- Vera
