### PR TITLE
fix: part shortcuts fail on non-Latin keyboard layouts (#522)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -326,9 +326,11 @@ function keyboardTapped(e: KeyboardEvent) {
     case "KeyA":
     case "KeyT":
     case "KeyR":
-    case "KeyB":
-      setPart("satrb".indexOf(String(e.key).toLowerCase()));
+    case "KeyB": {
+      const partCodes = ["KeyS", "KeyA", "KeyT", "KeyR", "KeyB"];
+      setPart(partCodes.indexOf(e.code));
       break;
+    }
     case "KeyV":
       toggleRecording();
       break;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/src/test/keyboard.test.ts
+++ b/src/test/keyboard.test.ts
@@ -323,6 +323,29 @@ describe("Space bar play/pause", () => {
     });
   });
 
+  describe("Part shortcuts with non-Latin keyboard layouts (#522)", () => {
+    it.each([
+      ["KeyS", "ы", "0"],
+      ["KeyA", "ф", "1"],
+      ["KeyT", "е", "2"],
+      ["KeyR", "к", "3"],
+      ["KeyB", "и", "4"],
+    ])(
+      "%s with Cyrillic e.key selects part %s",
+      async (code, key, expectedPart) => {
+        const controls = document.querySelector(
+          "music-controls"
+        ) as MusicControls;
+        controls.setAttribute("part", "all");
+        document.body.dispatchEvent(
+          new KeyboardEvent("keydown", { code, key, bubbles: true })
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(controls.getAttribute("part")).toBe(expectedPart);
+      }
+    );
+  });
+
   describe("Auto-repeat (held-key) handling", () => {
     // Tests that exercise async setChoir need to yield to the
     // microtask queue (await new Promise + setTimeout 0) so the


### PR DESCRIPTION
Fixes #522

## Summary

Replace layout-dependent `e.key` lookup with physical `e.code` mapping for part-selection shortcuts (S/A/T/R/B). This ensures singers on Cyrillic, Greek, Arabic, and other non-Latin keyboard layouts can switch parts using the same physical keys.

## Changes

- `index.ts`: map `KeyS/KeyA/KeyT/KeyR/KeyB` directly to part indices via `e.code`
- `src/test/keyboard.test.ts`: add parameterized test simulating Cyrillic `e.key` values with Latin `e.code` values
- `package.json`: bump patch version 2.8.0 → 2.8.1

## Verification

- `pnpm test`: 296 passed
- `pnpm run check`: all clean (no new warnings vs. main baseline)

## Doc changes

No doc changes required.