### PR TITLE
test: stub virtual:pwa-register in Vitest setup

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,14 @@
+import { vi } from "vitest";
 import { makeFixtureSvg } from "./fixtureScore";
+
+// `virtual:pwa-register` is supplied by vite-plugin-pwa at build time only, not
+// under Vitest. Any suite that transitively imports index.ts (-> pwa-update.ts)
+// would otherwise fail at import: Node's path layer rejects the unresolved id
+// `file:///@vite-plugin-pwa/virtual:pwa-register` on Windows (POSIX tolerates
+// the drive-letter-less path, Windows does not). A global stub keeps every suite
+// importable; pwa-update-toast.test.ts hoists its own vi.mock, which takes
+// precedence where it needs the registration callback. See ticket #530.
+vi.mock("virtual:pwa-register", () => ({ registerSW: () => () => {} }));
 
 // MusicScore.#loadSvg() checks `MusicScore.testSvgLoader` (static,
 // preferred) first and falls back to `globalThis.__SPEM_TEST_SVG_LOADER`.


### PR DESCRIPTION
Fixes #530.

On Windows, four UI suites (`darkmode`, `feedback`, `keyboard`, `setbar`)
crashed at import because they transitively import `index.ts` →
`src/ts/pwa-update.ts`, which imports `registerSW` from `virtual:pwa-register`
— a module `vite-plugin-pwa` provides only at build time, not under Vitest.
Node rejects the unresolved id `file:///@vite-plugin-pwa/virtual:pwa-register`
on Windows (POSIX tolerates the drive-letter-less path), so CI (Linux) stayed
green and the breakage merged unseen; only Windows contributors hit it.

This adds a global `vi.mock("virtual:pwa-register", …)` stub to the shared
Vitest setup (`src/test/setup.ts`), keeping every suite importable. The
dedicated `pwa-update-toast.test.ts` keeps its own per-file `vi.mock`, which
Vitest hoists and which takes precedence where it needs the registration
callback.

Test-infrastructure only; no production behaviour change. Restores the 61
previously-skipped tests in the four suites; `pnpm run ci` green (281 tests).
