### PR TITLE
refactor: make Range fields readonly in lily.ts (#551)

### DIFF
--- a/src/test/spem.test.ts
+++ b/src/test/spem.test.ts
@@ -1,4 +1,4 @@
-import { processLilypond } from "../ts/lily";
+import { processLilypond, type Range } from "../ts/lily";
 
 describe("Check that spem notes looks good", () => {
   const { notesByQuant, ranges } = processLilypond();
@@ -77,5 +77,20 @@ describe("Check that spem notes looks good", () => {
       }
     }
     expect(notesByQuant.get(121.75)).toBeUndefined();
+  });
+
+  it("Range fields are readonly at compile time (#551)", () => {
+    // Pins the readonly invariant in both directions: while it holds, the
+    // ts-expect-error directives below suppress the TS2540 these writes
+    // produce; if someone removes readonly, the directives become "unused
+    // directive" errors in check:types. Writes go to a fresh literal, never
+    // the cached fixture (readonly is compile-time only — the assignments
+    // execute at runtime).
+    const r: Range = { from: 1, to: 2 };
+    // @ts-expect-error -- Range.from is readonly (#551)
+    r.from = 0;
+    // @ts-expect-error -- Range.to is readonly (#551)
+    r.to = 0;
+    expect(r.from).toBe(0);
   });
 });

--- a/src/test/spem.test.ts
+++ b/src/test/spem.test.ts
@@ -27,7 +27,7 @@ describe("Check that spem notes looks good", () => {
     for (var c = 0; c < 8; c++) {
       for (var p = 0; p < 1; p++) {
         const result =
-          ranges.get(`${c}-${p}`)!.find((x) => (x.from = 122)) != null;
+          ranges.get(`${c}-${p}`)!.find((x) => x.from === 122) != null;
         expect(result, "choir/part " + c + "/" + p).toBe(true);
       }
     }

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -443,9 +443,7 @@ export class MusicCanvas extends MusicElement {
         const startY =
           this.canvasPadding + c * this.choirHeight + p * this.partHeight;
 
-        const list: { from: number; to: number }[] = this.ranges.get(
-          `${c}-${p}`
-        )!;
+        const list = this.ranges.get(`${c}-${p}`)!;
         list.forEach((r) => {
           const from = r.from;
           const to = r.to;

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -254,8 +254,8 @@ function setupLilypondParser(): ohm.Semantics {
 
 // A continuous singing interval for one part: bar positions from start to end.
 export type Range = {
-  from: number;
-  to: number;
+  readonly from: number;
+  readonly to: number;
 };
 
 // HACK: barCount is still exported as a module-level variable consumed by MusicControls.ts

--- a/src/ts/lily.ts
+++ b/src/ts/lily.ts
@@ -271,7 +271,8 @@ export var barCount: number = 0;
 // readonly because canvas.test.ts deliberately mutates `notesByQuant` to
 // exercise seek()'s defensive path (restoring at end-of-test); deep readonly
 // would force a wider refactor. Callers MUST treat `notesByQuant`, `ranges`,
-// and `frLocations` as immutable in non-test code.
+// and `frLocations` as immutable in non-test code (Range fields are
+// compiler-enforced readonly since #551; the Map and array levels are not).
 export type LilypondData = {
   readonly notesByQuant: Map<number, NoteEntry[]>;
   readonly ranges: Map<string, Range[]>;


### PR DESCRIPTION
Make `Range.from` and `Range.to` `readonly` to compiler-enforce the documented immutability invariant on `LilypondData.ranges`.

This prevents accidental mutation of cached parser state. The `spem.test.ts` assertion that used assignment (`=`) instead of comparison (`===`) is also fixed, since it now fails compilation as TS2540.

Fixes #551
