### PR TITLE
fix: postprocessSvg.mjs CLI entry point unreachable on Windows and relative paths

### DIFF
--- a/doc/CI.md
+++ b/doc/CI.md
@@ -11,13 +11,13 @@ The repository uses GitHub Actions for automated testing and dependency updates.
 
 ### `ci.yml`
 
-Triggers on every push and pull request to `main`, and nightly at 00:00 UTC via a `schedule` cron.
+Triggers on push to `main` and on pull requests targeting `main` — except changes confined to the workflow's `paths-ignore` list (see `ci.yml`; it ignores root-level `*.md`, `lilypond/**`, and three sibling workflow files) — and nightly at 00:00 UTC via a `schedule` cron.
 
 Defines one job.
 
 #### `test` job
 
-Runs on every trigger. Executes `pnpm run check` (lint, format, type check, unused, deps) and `pnpm run build`, then `pnpm run test:unit`, then `pnpm run test:lilypond`. This is the required status check for the `main` branch ruleset; pull requests cannot merge until it passes.
+Runs on every trigger. Executes `pnpm run check` (lint, format, type check, unused, deps) and `pnpm run build`, then `pnpm run test:unit`. This is the required status check for the `main` branch ruleset; pull requests cannot merge until it passes. The LilyPond integration suite (`pnpm run test:lilypond`) does not run here — it runs in the Regenerate SVGs workflow below. Changes confined to `lilypond/test/**` trigger neither workflow, so the required check never reports and such PRs cannot merge without a ruleset bypass (#558).
 
 ### `e2e.yml`
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -61,7 +61,7 @@ Scripts in `.github/scripts/` that expose pure functions use the Node.js built-i
 
 Integration tests live in `lilypond/test/*.integration.test.ts` and also follow `*.test.ts`. They typically spawn subprocesses (LilyPond, the build pipeline) and are substantially slower.
 
-If a new shared fixture directory is introduced (e.g. `src/test/fixtures/`), add it to the `build-related` filter in `.github/workflows/ci.yml` so that PRs touching it exercise the integration suite.
+When changing integration tests, always run `pnpm run test:lilypond` locally — see § CI Behaviour below for which workflows run them in CI and the `lilypond/test/**` trigger gap (#558).
 
 ## Test Layer Decision Criteria
 
@@ -98,10 +98,10 @@ If a test needs any of the above, it belongs in the E2E layer.
 
 ## CI Behaviour
 
-The two suites run as separate jobs in `.github/workflows/ci.yml`. See `doc/CI.md` for the canonical description; in summary:
+The two suites run in separate workflows. See `doc/CI.md` for the canonical description; in summary:
 
-- The `test` job runs `pnpm run test:unit` on every push and pull request and is the required status check.
-- The `integration` job runs unconditionally on push to `main` and on a nightly cron. On pull requests it is gated by `dorny/paths-filter` and runs only when the PR touches build-related paths — see `doc/CI.md` for the canonical list.
+- The `test` job (`.github/workflows/ci.yml`) runs `pnpm run check`, `pnpm run build`, and `pnpm run test:unit` on push to `main` and on pull requests targeting `main`, except changes confined to the workflow's `paths-ignore` list (see `ci.yml`; notably `lilypond/**`), plus a nightly cron. It is the required status check.
+- The integration suite (`pnpm run test:lilypond`) runs in the Regenerate SVGs workflow (`.github/workflows/lilypond.yml`) when `lilypond/src/**` or the build scripts listed in the workflow's paths filter change. Changes confined to `lilypond/test/**` trigger neither workflow, so the required `test` check never reports and the PR cannot merge without a ruleset bypass (#558); a local `pnpm run test:lilypond` is the only verification meanwhile.
 
 ## Key Dependencies
 

--- a/lilypond/build/postprocessSvg.d.mts
+++ b/lilypond/build/postprocessSvg.d.mts
@@ -6,3 +6,7 @@ export function postprocessSvg(
   spemLyPath?: string,
   wordsLyPath?: string,
 ): void;
+export function isMainModule(
+  argv1: string | undefined,
+  importMetaUrl: string,
+): boolean;

--- a/lilypond/build/postprocessSvg.mjs
+++ b/lilypond/build/postprocessSvg.mjs
@@ -11,8 +11,9 @@
  * deduplicates repeated path shapes via <defs> and <use>.
  */
 
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, realpathSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
 
 const DEFAULT_SPEM_PATH = "lilypond/src/Hugh Keyte/spem.ly";
@@ -162,8 +163,8 @@ export function deduplicatePaths(doc) {
 
 /**
  * @param {string} svgPath
- * @param {string} spemLyPath
- * @param {string} wordsLyPath
+ * @param {string} [spemLyPath]
+ * @param {string | null} [wordsLyPath]
  */
 export function postprocessSvg(
   svgPath,
@@ -268,12 +269,26 @@ function main() {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg === "--spem") {
-      spemPath = args[++i];
-    } else if (arg === "--words") {
-      wordsPath = args[++i];
-    } else if (!svgPath && !arg.startsWith("-")) {
+    if (arg === "--spem" || arg === "--words") {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith("-")) {
+        console.error(`Error: ${arg} requires a value.`);
+        process.exit(1);
+      }
+      i++;
+      if (arg === "--spem") {
+        spemPath = value;
+      } else {
+        wordsPath = value;
+      }
+    } else if (arg.startsWith("-")) {
+      console.error(`Error: unknown option ${arg}.`);
+      process.exit(1);
+    } else if (svgPath === null) {
       svgPath = arg;
+    } else {
+      console.error(`Error: unexpected argument ${arg}.`);
+      process.exit(1);
     }
   }
 
@@ -286,6 +301,28 @@ function main() {
   postprocessSvg(svgPath, spemPath, wordsLyPath);
 }
 
-if (import.meta.url === new URL(process.argv[1], "file://").href) {
+/**
+ * True when the module at `importMetaUrl` is the script Node was invoked
+ * with. `argv1` may be missing (REPL, --eval, embedders) or name a path
+ * that no longer exists; both mean "not the entry point" — the guard must
+ * fail safe towards "imported", never crash the importer. Other fs errors
+ * stay loud.
+ * @param {string | undefined} argv1
+ * @param {string} importMetaUrl
+ * @returns {boolean}
+ */
+export function isMainModule(argv1, importMetaUrl) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(importMetaUrl));
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+    return false;
+  }
+}
+
+// Only run main() when this file is invoked directly from the CLI, not when
+// imported by buildScores.mjs or tests.
+if (isMainModule(process.argv[1], import.meta.url)) {
   main();
 }

--- a/lilypond/test/postprocessSvg.cli.integration.test.ts
+++ b/lilypond/test/postprocessSvg.cli.integration.test.ts
@@ -1,0 +1,163 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join, relative, resolve } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { spawnSync } from "child_process";
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { isMainModule } from "../build/postprocessSvg.mjs";
+
+// Module-relative, not process.cwd(): an IDE or non-root vitest invocation
+// must not point the script path at nothing.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const POSTPROCESS_SCRIPT = join(
+  REPO_ROOT,
+  "lilypond",
+  "build",
+  "postprocessSvg.mjs"
+);
+const POSTPROCESS_SCRIPT_RELATIVE = relative(REPO_ROOT, POSTPROCESS_SCRIPT);
+
+const SPEM_LY = `notesIASoprano = \\relative c' { c4 d e f }
+notesIAAlto = \\relative c' { c4 d e f }
+`;
+
+const WORDS_LY = `wordsIASoprano = \\lyricmode { Spem }
+wordsIAAlto = \\lyricmode { Spem }
+`;
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1000" height="500">
+  <a xlink:href="spem.ly:1:1:1">
+    <path d="M0,0 L1,1" transform="translate(10,10)"/>
+  </a>
+</svg>`;
+
+// Node absolutises process.argv[1] at bootstrap, so a spawned child can never
+// present the guard with a relative path — and the old broken guard
+// (`new URL(process.argv[1], "file://")`) actually matched absolute POSIX
+// paths. The inputs that discriminate the old guard from the working one
+// (relative argv[1] on any platform; drive-lettered argv[1] on Windows) are
+// therefore only reachable by calling the guard directly. These unit tests
+// are the #555 regression coverage that works on the Linux CI runner; the
+// spawn tests below are the end-to-end smoke.
+describe("isMainModule (#555)", () => {
+  const scriptUrl = pathToFileURL(POSTPROCESS_SCRIPT).href;
+
+  it("matches an absolute argv[1] naming the same file", () => {
+    expect(isMainModule(POSTPROCESS_SCRIPT, scriptUrl)).toBe(true);
+  });
+
+  it("matches a cwd-relative argv[1] — the #555 regression input", () => {
+    const rel = relative(process.cwd(), POSTPROCESS_SCRIPT);
+    expect(isMainModule(rel, scriptUrl)).toBe(true);
+  });
+
+  it("rejects a different file", () => {
+    expect(isMainModule(join(REPO_ROOT, "package.json"), scriptUrl)).toBe(
+      false
+    );
+  });
+
+  it("treats a missing argv[1] as not-main (REPL, --eval, embedders)", () => {
+    expect(isMainModule(undefined, scriptUrl)).toBe(false);
+  });
+
+  it("treats a nonexistent argv[1] path as not-main instead of throwing", () => {
+    expect(isMainModule(join(REPO_ROOT, "no-such-file.mjs"), scriptUrl)).toBe(
+      false
+    );
+  });
+});
+
+describe("postprocessSvg.mjs CLI (#555)", () => {
+  const tmpDir = mkdtempSync(join(tmpdir(), "spem-cli-test-"));
+  const tmpSvg = join(tmpDir, "Choir I A.svg");
+  const tmpSpem = join(tmpDir, "spem.ly");
+  const tmpWords = join(tmpDir, "spem words.ly");
+
+  beforeEach(() => {
+    writeFileSync(tmpSpem, SPEM_LY, "utf-8");
+    writeFileSync(tmpWords, WORDS_LY, "utf-8");
+    writeFileSync(tmpSvg, SVG, "utf-8");
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runCli(scriptPath: string, args: string[]) {
+    const result = spawnSync(process.execPath, [scriptPath, ...args], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    // A spawn failure leaves status null, which `not.toBe(0)` would accept.
+    expect(result.error).toBeUndefined();
+    return result;
+  }
+
+  it("processes the SVG when invoked via a relative script path (ticket repro)", () => {
+    const result = runCli(POSTPROCESS_SCRIPT_RELATIVE, [
+      tmpSvg,
+      "--spem",
+      tmpSpem,
+      "--words",
+      tmpWords,
+    ]);
+
+    expect(result.status).toBe(0);
+    const output = readFileSync(tmpSvg, "utf-8");
+    expect(output).not.toMatch(/<a\s/);
+    expect(output).toMatch(/data-part="0"/);
+  }, 15000);
+
+  it("prints usage and exits non-zero when no SVG path is given", () => {
+    const result = runCli(POSTPROCESS_SCRIPT, []);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Usage:");
+  });
+
+  it("rejects bare --spem without a value", () => {
+    const result = runCli(POSTPROCESS_SCRIPT, [tmpSvg, "--spem"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--spem requires a value");
+  });
+
+  it("rejects bare --words without a value", () => {
+    const result = runCli(POSTPROCESS_SCRIPT, [tmpSvg, "--words"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--words requires a value");
+  });
+
+  it("rejects a flag as the value of another flag", () => {
+    const result = runCli(POSTPROCESS_SCRIPT, [
+      tmpSvg,
+      "--spem",
+      "--words",
+      tmpWords,
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--spem requires a value");
+  });
+
+  it("rejects an unknown option instead of silently ignoring it", () => {
+    const result = runCli(POSTPROCESS_SCRIPT, [tmpSvg, "--word", tmpWords]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("unknown option --word");
+    // The SVG must not have been processed against default paths.
+    expect(readFileSync(tmpSvg, "utf-8")).toMatch(/<a\s/);
+  });
+
+  it("rejects a surplus positional argument", () => {
+    const second = join(tmpDir, "second.svg");
+    writeFileSync(second, SVG, "utf-8");
+    const result = runCli(POSTPROCESS_SCRIPT, [tmpSvg, second]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("unexpected argument");
+  });
+});


### PR DESCRIPTION
Fixes #555

## What

The CLI entry-point guard `import.meta.url === new URL(process.argv[1], "file://").href` never matched on Windows (drive letter parses as a URL scheme) and could not match relative invocations, so `main()` silently never ran — exit 0, no output, no SVG written.

- Replaced with an exported `isMainModule(argv1, importMetaUrl)` using the `realpathSync` comparison from the sibling `buildScores.mjs` (a deliberate deviation from the ticket's `pathToFileURL` suggestion, for consistency and symlink/case resilience), hardened so a missing or nonexistent `argv[1]` means "not the entry point" rather than a crash (ENOENT caught; other fs errors stay loud).
- The argument parser now fails loudly instead of silently misbehaving: bare `--spem`/`--words`, flag-shaped values, unknown options, and surplus positionals all error with exit 1 (the ticket's Notes flagged the `args[++i]` bounds gap; the rest fell out of review).
- 12 tests in `lilypond/test/postprocessSvg.cli.integration.test.ts`: five in-process `isMainModule` unit tests — including the relative-`argv[1]` input that discriminates the old guard from the new one on any platform (Node absolutises `argv[1]`, so spawn tests cannot reach it) — plus seven spawn tests (the ticket's repro invocation as the smoke, usage, and the five rejection paths).
- `doc/TESTING.md` and `doc/CI.md` corrected where they still described the pre-#474 CI layout (`integration` job, `dorny/paths-filter`, `test:lilypond` in the `test` job). The remaining `lilypond/test/**` trigger gap is tracked as #558.

## Test plan

- `pnpm run ci` green (check, build, 281 unit tests).
- Integration suite green on Windows except the pre-existing #539 fake-lilypond failure (fix already open in #550); the new file's 12 tests pass on Windows and are exercised on Linux by `pnpm run test:lilypond` in the Regenerate SVGs workflow, which this PR triggers via its `postprocessSvg.mjs` change.
- Acceptance criteria: `node lilypond/build/postprocessSvg.mjs <svg>` runs `main()`; `--spem` path honoured; module-import path unchanged (existing unit tests).

Vera gate: cycle 1, two passes, second pass clean — [Original Report](https://github.com/wainwmr/spem-player/issues/555#issuecomment-4676979901), [Final Synthesis](https://github.com/wainwmr/spem-player/issues/555#issuecomment-4677059161).
