### PR TITLE
fix: surface evidence when the lilypond probe or version parse fails

### DIFF
--- a/lilypond/build/buildScores.mjs
+++ b/lilypond/build/buildScores.mjs
@@ -93,9 +93,13 @@ function checkLilypond(version) {
   let output;
   try {
     output = execSync("lilypond --version", { encoding: "utf-8", stdio: "pipe" });
-  } catch {
+  } catch (error) {
     console.error("Error: lilypond is not installed or not on PATH.");
     console.error("Please install LilyPond before building scores.");
+    console.error(String(error?.message ?? error));
+    console.error(
+      `(status: ${error?.status ?? "none"}, signal: ${error?.signal ?? "none"})`
+    );
     process.exit(1);
   }
 
@@ -106,6 +110,11 @@ function checkLilypond(version) {
       `Error: LilyPond ${lilypondVersion || "unknown"} is installed, but ${minVersion} or later is required.`
     );
     console.error("Please upgrade LilyPond before building scores.");
+    if (!lilypondVersion) {
+      console.error(
+        `'lilypond --version' stdout was:\n${output.trim() || "(empty)"}`
+      );
+    }
     process.exit(1);
   }
 }

--- a/lilypond/test/buildScores.integration.test.ts
+++ b/lilypond/test/buildScores.integration.test.ts
@@ -439,6 +439,44 @@ describe("buildScores.mjs integration", () => {
     expect(result.status).not.toBe(0);
     const output = (result.stdout + result.stderr).toLowerCase();
     expect(output).toContain("lilypond");
+    // Node's checkExecSyncError prefix is platform-stable; shell wordings
+    // are not (cmd "not recognized", bash "command not found", dash plain
+    // "not found" or — via the empty-PATH-element cwd trap — "Permission
+    // denied"). Both branches reach stderr only through the evidence line
+    // #549 added, so this still pins that line. ENOENT covers the one
+    // remaining class: the shell binary itself failing to spawn.
+    expect(result.stderr).toMatch(/Command failed: lilypond --version|ENOENT/);
+    expect(result.stderr).toMatch(/\(status: (?:\d+|none), signal: none\)/);
+  });
+
+  it("reports the raw --version output when the version cannot be parsed (#549)", () => {
+    // createWorkspace() containment: if the guarded regression ever occurs
+    // (parse failure not detected), the build proceeds and the fake would
+    // overwrite real gitignored src/scores SVGs with stubs. Contain it.
+    const ws = createWorkspace();
+    try {
+      const envWeird = {
+        ...env,
+        FAKE_LILYPOND_VERSION: "weird-build",
+      };
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ws, "build", "buildScores.mjs")],
+        {
+          cwd: ws,
+          env: envWeird,
+          encoding: "utf-8",
+        }
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("LilyPond unknown is installed");
+      expect(result.stderr).toContain("'lilypond --version' stdout was");
+      expect(result.stderr).toContain("weird-build");
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
   });
 
   it("fails when lilypond version is too old", () => {


### PR DESCRIPTION
Fixes #549

## What

`checkLilypond()` caught every failure of the `lilypond --version` probe with a bare `catch {}` and reported it as "not installed or not on PATH", discarding the actual evidence. Per the spec, the friendly first line stays; the diagnostics now follow:

- The catch logs `String(error?.message ?? error)` — with `stdio: "pipe"`, Node folds the probe's captured stderr into `error.message`, so the underlying cause (missing binary, permission failure, crashing wrapper) reaches the user — plus a `(status: ..., signal: ...)` line for the silent-crash class.
- The unknown-version path (parse failure on the `--version` banner) now echoes the raw stdout instead of discarding it — the same discard-the-evidence pattern one screen down.
- Tests: the no-lilypond test asserts the evidence line via Node's platform-stable `Command failed:` prefix rather than shell wordings (cmd "not recognized" / bash "command not found" / dash "not found" — and on the ubuntu runner the real outcome is "Permission denied", because the empty `PATH` element resolves `lilypond` against the repo root's `lilypond/` directory). A new test pins the unknown-version evidence, contained in a temp workspace.

## Test plan

- `pnpm run ci` green (281 unit tests), before and after rebasing onto current `main`.
- `lilypond/test/buildScores.integration.test.ts`: 15/16 green on Windows — the one failure is the pre-existing #539 fixture gap, fixed in open PR #550, untouched here.
- CI: this PR triggers the Regenerate SVGs workflow (`buildScores.mjs` is in its paths filter), which runs the integration suite on ubuntu.

Vera gate: cycle 1, two passes plus a prescribed-fix loop — [Original Report](https://github.com/wainwmr/spem-player/issues/549#issuecomment-4678055264), [Final Synthesis](https://github.com/wainwmr/spem-player/issues/549#issuecomment-4678180050). The gate's headline catch: the branch's original test assertion passed on Windows but could not pass on the ubuntu CI shell.
