### PR TITLE
build: harden the required CI test job to cover all test suites (#558, #564)

### DIFF
--- a/.github/scripts/run-node-tests.mjs
+++ b/.github/scripts/run-node-tests.mjs
@@ -1,0 +1,26 @@
+// Runs the .github/scripts `node:test` suites, failing loudly if the glob
+// matches nothing. `node --test "<glob>"` on a zero-match glob exits 0 (Node 24),
+// which would let the required `test` job pass having run no script tests — the
+// exact false-green #564 was created to close (a required check that tested
+// nothing). Guard the zero-match here, then delegate to the runner.
+import { globSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const PATTERN = ".github/scripts/*.test.mjs";
+
+const files = globSync(PATTERN);
+if (files.length === 0) {
+  console.error(
+    `test:scripts: no files matched ${PATTERN} — refusing to pass vacuously (#564).`,
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, ["--test", ...files], {
+  stdio: "inherit",
+});
+if (result.error) {
+  console.error(`test:scripts: failed to launch node --test: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,36 @@ on:
     branches: [main]
     paths-ignore:
       - "*.md"
+      # Mirror lilypond.yml's `paths` so the two workflows are complementary:
+      # source and build-script changes regenerate SVGs there; everything
+      # else under lilypond/ (tests, type declarations) runs the test job
+      # here. A blanket lilypond/** ignore left test-only PRs with no
+      # required check at all (#558). Edit both files together —
+      # lilypond/test/workflowPathsMirror.test.ts enforces the mirror, and
+      # lilypond.yml is deliberately NOT ignored here so that editing it
+      # runs that test at PR time.
       - "lilypond/src/**"
-      - "lilypond/build/**"
-      - ".github/workflows/lilypond.yml"
+      - "lilypond/build/buildScores.mjs"
+      - "lilypond/build/postprocessSvg.mjs"
+      - "lilypond/build/install-lilypond.sh"
       - ".github/workflows/e2e.yml"
       - ".github/workflows/monitor-resources.yml"
   pull_request:
     branches: [main]
     paths-ignore:
       - "*.md"
+      # Mirror lilypond.yml's `paths` so the two workflows are complementary:
+      # source and build-script changes regenerate SVGs there; everything
+      # else under lilypond/ (tests, type declarations) runs the test job
+      # here. A blanket lilypond/** ignore left test-only PRs with no
+      # required check at all (#558). Edit both files together —
+      # lilypond/test/workflowPathsMirror.test.ts enforces the mirror, and
+      # lilypond.yml is deliberately NOT ignored here so that editing it
+      # runs that test at PR time.
       - "lilypond/src/**"
-      - "lilypond/build/**"
-      - ".github/workflows/lilypond.yml"
+      - "lilypond/build/buildScores.mjs"
+      - "lilypond/build/postprocessSvg.mjs"
+      - "lilypond/build/install-lilypond.sh"
       - ".github/workflows/e2e.yml"
       - ".github/workflows/monitor-resources.yml"
   # Daily at 00:00 UTC — catches drift in the test suite on days when no PR
@@ -42,4 +60,16 @@ jobs:
 
       - name: Run unit tests
         run: pnpm run test:unit
+
+      # The integration suite fakes LilyPond (no install needed). For changes
+      # confined to lilypond/test/** this is the only workflow that runs any
+      # test (#558); lilypond.yml also runs the suite when it triggers.
+      - name: Run lilypond integration tests
+        run: pnpm run test:lilypond
+
+      # The .github/scripts node:test suites (e.g. monitor-resources) run
+      # nowhere else — without this a PR to those scripts passes the required
+      # check without exercising their tests (#564).
+      - name: Run script tests
+        run: pnpm run test:scripts
 

--- a/.github/workflows/lilypond.yml
+++ b/.github/workflows/lilypond.yml
@@ -4,15 +4,21 @@ on:
   push:
     branches: [main]
     paths:
+      # Mirrored by ci.yml's paths-ignore: paths listed here are excluded
+      # there, so each lilypond path triggers exactly one of the two
+      # workflows. Edit both files together —
+      # lilypond/test/workflowPathsMirror.test.ts enforces the mirror (#558).
       - "lilypond/src/**"
-      - "lilypond/test/**"
       - "lilypond/build/buildScores.mjs"
       - "lilypond/build/postprocessSvg.mjs"
       - "lilypond/build/install-lilypond.sh"
   pull_request:
     paths:
+      # Mirrored by ci.yml's paths-ignore: paths listed here are excluded
+      # there, so each lilypond path triggers exactly one of the two
+      # workflows. Edit both files together —
+      # lilypond/test/workflowPathsMirror.test.ts enforces the mirror (#558).
       - "lilypond/src/**"
-      - "lilypond/test/**"
       - "lilypond/build/buildScores.mjs"
       - "lilypond/build/postprocessSvg.mjs"
       - "lilypond/build/install-lilypond.sh"

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -4,20 +4,20 @@ The repository uses GitHub Actions for automated testing and dependency updates.
 
 ## Philosophy
 
-- **Fast PR gate:** Only unit tests, lint, and type checks block merges. The full browser-based end-to-end suite runs separately.
+- **Fast PR gate:** Unit and integration tests, lint, and type checks block merges — the integration suite fakes LilyPond, so it stays fast. The full browser-based end-to-end suite runs separately.
 - **Nightly regression:** Playwright e2e tests run on a schedule to catch browser-level regressions without adding friction to the pull request workflow.
 
 ## Workflows
 
 ### `ci.yml`
 
-Triggers on push and pull request to `main`, nightly at 00:00 UTC via a `schedule` cron, and path-filtered to skip changes that do not affect the application build or unit tests (for example, `lilypond/src/**` and `lilypond/build/**` are ignored).
+Triggers on push and pull requests to `main` — except changes confined to its `paths-ignore` list — and nightly at 00:00 UTC via a `schedule` cron. The ignore list mirrors `lilypond.yml`'s `paths` (LilyPond sources and the three build scripts) so the two workflows are complementary: those paths regenerate SVGs in `lilypond.yml`, while everything else under `lilypond/` — tests, type declarations — runs the `test` job here (#558). Root-level `*.md` files and two of its sibling workflow files (`e2e.yml`, `monitor-resources.yml`) are also ignored; `lilypond.yml` deliberately is not, so edits to it run the mirror-enforcing `lilypond/test/workflowPathsMirror.test.ts` (part of the unit suite) at PR time. Note the consequence of any full match: the required `test` check never reports, so a PR confined to ignored paths (including LilyPond source-only PRs, whose only test-running trigger is the non-required Regenerate SVGs workflow) cannot merge without the owner's ruleset bypass (#558 fixed this for non-mirrored `lilypond/` paths; the residue is tracked in #563).
 
 Defines one job.
 
 #### `test` job
 
-Runs on every trigger. Executes `pnpm run check` (lint, format, type check, unused, deps) and `pnpm run build`, then `pnpm run test:unit`. This is the required status check for the `main` branch ruleset; pull requests cannot merge until it passes. The LilyPond integration suite (`pnpm run test:lilypond`) does not run here — it runs in the Regenerate SVGs workflow below. Changes confined to `lilypond/test/**` trigger neither workflow, so the required check never reports and such PRs cannot merge without a ruleset bypass (#558).
+Runs on every trigger. Executes `pnpm run check` (lint, format, type check, unused, deps) and `pnpm run build`, then `pnpm run test:unit` (the Vitest suite), then `pnpm run test:lilypond` (the integration suite fakes LilyPond, so no install is needed), then `pnpm run test:scripts` (the `node:test` suites in `.github/scripts/`). This is the required status check for the `main` branch ruleset; pull requests cannot merge until it passes.
 
 ### `e2e.yml`
 
@@ -36,7 +36,7 @@ This workflow is intentionally excluded from the PR gate. Playwright tests are s
 
 ### `lilypond.yml`
 
-Triggers on push to `main` and on `pull_request`, both path-filtered to `lilypond/src/**`, `lilypond/test/**`, `lilypond/build/buildScores.mjs`, `lilypond/build/postprocessSvg.mjs`, and `lilypond/build/install-lilypond.sh`.
+Triggers on push to `main` and on `pull_request`, both path-filtered to `lilypond/src/**`, `lilypond/build/buildScores.mjs`, `lilypond/build/postprocessSvg.mjs`, and `lilypond/build/install-lilypond.sh` — mirroring `ci.yml`'s `paths-ignore` (enforced by `lilypond/test/workflowPathsMirror.test.ts`), so `lilypond/test/**` changes run the required `test` job in `ci.yml` rather than regenerating SVGs here (#558).
 
 Permissions: `contents: write`.
 
@@ -51,7 +51,7 @@ Steps:
 - `actions/checkout@v6` with `ref: ${{ github.head_ref || github.ref_name }}` — checkout the target branch so commits can be pushed back.
 - `actions/setup-node@v6` from `.nvmrc` — install Node.js.
 - `pnpm ci` — clean install from lockfile.
-- `pnpm run test:lilypond` — run the Lilypond-related test suite.
+- `pnpm run test:lilypond` — run the LilyPond integration suite (fakes LilyPond; the same script the `test` job runs).
 - `bash lilypond/build/install-lilypond.sh` — install LilyPond.
 - Set `PATH` to include LilyPond 2.26.0, then `pnpm run build:scores` — regenerate SVGs.
 - Commit updated SVGs in `src/scores/` if changes exist, with message `chore: regenerate SVGs [skip ci]`, then push.

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -57,7 +57,7 @@ pnpm run test:coverage
 
 Unit tests live under `src/test/` and `lilypond/test/` (excluding `*.integration.test.ts`) and follow the naming convention `*.test.ts`. They run in-process under jsdom and should complete in under a few seconds each. In-process tests against `lilypond/build/` code (for example `postprocessSvg.test.ts`) live in `lilypond/test/` alongside the integration suite.
 
-Scripts in `.github/scripts/` that expose pure functions use the Node.js built-in test runner (`node:test`) rather than Vitest, and live alongside the script as `*.test.mjs`. Run them directly with `node --test .github/scripts/<name>.test.mjs`. These files are excluded from the Vitest config (`vite.config.ts`) and do not appear in `pnpm run test:unit` output.
+Scripts in `.github/scripts/` that expose pure functions use the Node.js built-in test runner (`node:test`) rather than Vitest, and live alongside the script as `*.test.mjs`. Run the whole set with `pnpm run test:scripts` (`node --test ".github/scripts/*.test.mjs"`), or a single file directly with `node --test .github/scripts/<name>.test.mjs`. They are excluded from the Vitest config (`vite.config.ts`), so they do not appear in `pnpm run test:unit` output; instead `pnpm run test:scripts` runs them in the `test` job of `ci.yml` (and as the final step of `pnpm run ci`), so a broken assertion blocks merge — see `doc/CI.md`.
 
 Integration tests live in `lilypond/test/*.integration.test.ts` and also follow `*.test.ts`. They typically spawn subprocesses (LilyPond, the build pipeline) and are substantially slower.
 
@@ -98,10 +98,10 @@ If a test needs any of the above, it belongs in the E2E layer.
 
 ## CI Behaviour
 
-The two suites run in separate workflows. See `doc/CI.md` for the canonical description; in summary:
+See `doc/CI.md` for the canonical description; in summary:
 
-- The `test` job (`.github/workflows/ci.yml`) runs `pnpm run check`, `pnpm run build`, and `pnpm run test:unit` on push to `main` and on pull requests targeting `main`, except changes confined to the workflow's `paths-ignore` list (see `ci.yml`; notably `lilypond/**`), plus a nightly cron. It is the required status check.
-- The integration suite (`pnpm run test:lilypond`) runs in the Regenerate SVGs workflow (`.github/workflows/lilypond.yml`) when `lilypond/src/**` or the build scripts listed in the workflow's paths filter change. Changes confined to `lilypond/test/**` trigger neither workflow, so the required `test` check never reports and the PR cannot merge without a ruleset bypass (#558); a local `pnpm run test:lilypond` is the only verification meanwhile.
+- The required `test` job (`.github/workflows/ci.yml`) runs `pnpm run check`, `pnpm run build`, `pnpm run test:unit`, `pnpm run test:lilypond`, and `pnpm run test:scripts` on push to `main` and on pull requests targeting `main`, except changes confined to the workflow's `paths-ignore` list (see `ci.yml`; the LilyPond sources and the three build scripts, mirroring `lilypond.yml`), plus a nightly cron. It is the required status check.
+- `lilypond/test/**` changes are not ignored by `ci.yml`, so they now run the required `test` job here (the #558 fix); the integration suite also runs in the Regenerate SVGs workflow (`.github/workflows/lilypond.yml`) when `lilypond/src/**` or the three build scripts change. LilyPond source-only PRs still report no required check (their only trigger is the non-required SVG workflow); that residue is tracked in #563.
 
 ## Key Dependencies
 

--- a/lilypond/test/workflowPathsMirror.test.ts
+++ b/lilypond/test/workflowPathsMirror.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { resolve, dirname } from "path";
+
+// Pins the cross-file invariant behind #558: ci.yml's lilypond-prefixed
+// `paths-ignore` entries must mirror lilypond.yml's `paths` exactly, so every
+// lilypond path triggers exactly one of the two workflows. Drift in the
+// dangerous direction (an entry ignored by ci.yml but absent from
+// lilypond.yml's paths) leaves files triggering neither workflow — the
+// required `test` check then never reports and such PRs cannot merge.
+//
+// GitHub Actions offers no cross-file single source for these lists (in-file
+// YAML anchors exist since 2025 but cannot span files), so the two files are
+// maintained by hand; each also duplicates its list across the push and
+// pull_request blocks. This test is the enforcement.
+//
+// The extraction is deliberately textual (no YAML dependency): it collects
+// quoted "- ..." entries under each `paths:` / `paths-ignore:` key, and
+// throws on any entry line it cannot parse, so a quoting-style change cannot
+// silently truncate a list. Restructures (a block added or removed, flow
+// style, anchors) fail the block-count assertions loudly.
+//
+// Known limit: the cross-file check compares literal "lilypond/"-prefixed
+// entries, so an ignore pattern covering lilypond files without that prefix
+// (e.g. "**") would pass unnoticed, and a non-lilypond entry ever added to
+// lilypond.yml's paths fails this test by design (extend the filter then).
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function extractBlocks(file: string, key: "paths" | "paths-ignore"): string[][] {
+  const text = readFileSync(resolve(root, file), "utf-8");
+  const blocks: string[][] = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== `${key}:`) continue;
+    const entries: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j].trim();
+      // Comments and blank lines may sit between entries.
+      if (line === "" || line.startsWith("#")) continue;
+      // A line that is not a sequence item genuinely ends the block.
+      if (!line.startsWith("- ")) break;
+      const m = line.match(/^- "(.+)"$/);
+      if (!m) {
+        // An entry-shaped line we cannot parse must fail loudly: silently
+        // breaking here would let an unquoted entry truncate the list and
+        // pass the suite while the #558 hole reopened.
+        throw new Error(
+          `Unparseable entry under "${key}:" at ${file}:${j + 1}: ${line} — entries must be double-quoted`
+        );
+      }
+      entries.push(m[1]);
+    }
+    blocks.push(entries);
+  }
+  return blocks;
+}
+
+describe("workflow path filters stay mirrored (#558)", () => {
+  const ciBlocks = extractBlocks(".github/workflows/ci.yml", "paths-ignore");
+  const lilyBlocks = extractBlocks(".github/workflows/lilypond.yml", "paths");
+
+  it("finds both blocks in each workflow file", () => {
+    // push + pull_request; a third block or a restructure must be looked at.
+    expect(ciBlocks.length).toBe(2);
+    expect(lilyBlocks.length).toBe(2);
+    for (const b of [...ciBlocks, ...lilyBlocks]) {
+      expect(b.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("ci.yml's push and pull_request ignore lists are identical", () => {
+    expect(ciBlocks[0]).toEqual(ciBlocks[1]);
+  });
+
+  it("lilypond.yml's push and pull_request paths are identical", () => {
+    expect(lilyBlocks[0]).toEqual(lilyBlocks[1]);
+  });
+
+  it("ci.yml ignores exactly the lilypond paths that lilypond.yml covers", () => {
+    const ciLilypondEntries = ciBlocks[0]
+      .filter((p) => p.startsWith("lilypond/"))
+      .sort();
+    const lilypondPaths = [...lilyBlocks[0]].sort();
+    expect(ciLilypondEntries).toEqual(lilypondPaths);
+  });
+
+  it("ci.yml does not ignore the files whose edits must run this test", () => {
+    // The "deliberately NOT ignored" choice is load-bearing: re-ignoring
+    // either workflow file would let its edits skip this test at PR time,
+    // guarded only by comments — the failure shape that opened #558.
+    for (const b of ciBlocks) {
+      expect(b).not.toContain(".github/workflows/lilypond.yml");
+      expect(b).not.toContain(".github/workflows/ci.yml");
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:lilypond": "vitest run lilypond/test/*.integration.test.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:scripts": "node .github/scripts/run-node-tests.mjs",
     "e2e": "playwright test",
     "check": "pnpm run build:ohm && pnpm run check:unused && pnpm run check:format && pnpm run check:lint && pnpm run check:types && pnpm run check:deps",
     "check:lint": "eslint . --max-warnings 0",
@@ -57,7 +58,7 @@
     "check:unused": "knip",
     "fix:lint": "eslint . --fix",
     "fix:format": "prettier --write src/",
-    "ci": "pnpm run check && pnpm run build && pnpm run test:unit",
+    "ci": "pnpm run check && pnpm run build && pnpm run test:unit && pnpm run test:scripts",
     "prepare": "husky"
   },
   "lint-staged": {


### PR DESCRIPTION
Combines #558 and #564: both harden the required `test` job in `ci.yml` by editing the same job and trigger config, so as separate PRs they would conflict with each other. One coherent change instead.

## #558 — lilypond test-only PRs hit no required check

`ci.yml` ignored all of `lilypond/**` and `lilypond.yml` triggered only on `src` + the three build scripts, so a PR touching only `lilypond/test/**` triggered **neither** workflow and could never satisfy the required `test` check (live instance: PR #550, BLOCKED). Now:

- `ci.yml`'s `paths-ignore` mirrors `lilypond.yml`'s `paths` (each lilypond path triggers exactly one workflow); `lilypond/test/**` is in neither, so it runs the `test` job here.
- a `test:lilypond` step runs the integration suite in the `test` job (it fakes LilyPond, no install).
- `lilypond/test/**` is removed from `lilypond.yml` (it was added by #550); this supersedes that interim with #558's option (a).
- `lilypond/test/workflowPathsMirror.test.ts` enforces the `ci.yml`↔`lilypond.yml` mirror so the two lists can't silently drift apart.

## #564 — script tests ran nowhere

`.github/scripts/*.test.mjs` (34 `node:test` cases incl. `monitor-resources`) were excluded from vitest and wired into no script or workflow, so a PR changing those scripts passed the required check without running their tests. Now a `test:scripts` step runs them in the `test` job and in the local `ci` script, via `.github/scripts/run-node-tests.mjs` — a runner that **fails loud if the glob matches nothing** (`node --test "<glob>"` exits 0 on a zero-match glob, which would reintroduce the exact vacuous-pass #564 exists to close).

## Notes

- `doc/CI.md` and `doc/TESTING.md` updated to match.
- LilyPond source-only PRs still report no required check (their only trigger is the non-required SVG workflow); that residue is tracked in #563.
- Took this through the Vera review gate (cycle 2). It caught that the #564 fix's own `test:scripts` step passed green on a zero-match glob — now guarded. Full synthesis on #558.

Fixes #558
Fixes #564

- Claude
