### PR TITLE
fix: fail fast on unknown Duration; guard grammar/switch parity (#170)

### DIFF
--- a/src/test/grammar-consistency.test.ts
+++ b/src/test/grammar-consistency.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the implicit, manual coupling between the Ohm grammar's `duration`
+ * rule and the `switch` in the `Duration` constructor (see #170). If a
+ * developer adds a duration literal to one and forgets the other, the parser
+ * produces a string the switch does not handle, the constructor throws
+ * "Unknown duration" at runtime — and this test fails first, at CI, naming the
+ * offending literal so the divergence never reaches production.
+ *
+ * Both sides are extracted from source *text* (not by importing and exercising
+ * the code), so the comparison is between the literals as written. Backslash
+ * escaping matches: the grammar writes `"\\longa"` and the switch writes
+ * `case "\\longa":`, so each yields the same `\\longa` source string after the
+ * quotes are stripped (the test never resolves the escape to a single `\`).
+ *
+ * The text extraction makes two formatting assumptions, both true today and
+ * both fail-loud if broken except where noted:
+ *   - the grammar's `duration` rule stays on one line with no `)` inside the
+ *     alternation (the `[^)]+` capture stops at the first `)`);
+ *   - no `case` body in the Duration switch contains a `{` (the slice ends at
+ *     the first `}` after the switch head). A future braced case would
+ *     truncate the scan and silently drop later cases — the one drift this
+ *     guard would not catch — so keep the switch cases single-statement.
+ */
+describe("grammar / Duration switch consistency", () => {
+  it("the Duration switch handles exactly the grammar's duration literals", () => {
+    const grammar = readFileSync("src/ohmjs/ly-grammar.ohm", "utf-8");
+    const grammarMatch = grammar.match(/duration = \(([^)]+)\)/);
+    expect(
+      grammarMatch,
+      "could not locate the `duration = (...)` rule in ly-grammar.ohm"
+    ).not.toBeNull();
+    const grammarDurations = grammarMatch![1]
+      .split("|")
+      .map((s) => s.trim().replace(/"/g, ""))
+      .sort();
+
+    // Scope the case-label scan to the Duration switch block only, so a future
+    // unrelated `switch` elsewhere in the file cannot inject spurious labels.
+    const source = readFileSync("src/ts/music-classes.ts", "utf-8");
+    const switchStart = source.indexOf("switch (this.duration)");
+    expect(
+      switchStart,
+      "could not locate the Duration switch in music-classes.ts"
+    ).toBeGreaterThan(-1);
+    const switchBody = source.slice(
+      switchStart,
+      source.indexOf("}", switchStart)
+    );
+    const switchDurations = [...switchBody.matchAll(/case "([^"]+)":/g)]
+      .map((m) => m[1])
+      .sort();
+
+    const missingFromSwitch = grammarDurations.filter(
+      (d) => !switchDurations.includes(d)
+    );
+    const missingFromGrammar = switchDurations.filter(
+      (d) => !grammarDurations.includes(d)
+    );
+
+    expect(
+      missingFromSwitch,
+      "grammar durations with no matching case in the Duration switch"
+    ).toEqual([]);
+    expect(
+      missingFromGrammar,
+      "Duration switch cases with no matching literal in the grammar"
+    ).toEqual([]);
+  });
+});

--- a/src/test/music-classes.test.ts
+++ b/src/test/music-classes.test.ts
@@ -13,8 +13,14 @@ describe("Duration", () => {
     expect(new Duration("64").sfths).toBe(1);
   });
 
-  it("defaults to 0 for unknown duration", () => {
-    expect(new Duration("99").sfths).toBe(0);
+  it("throws on an unknown duration", () => {
+    expect(() => new Duration("99")).toThrow("Unknown duration: 99");
+    // The empty string is not a case label, so a duration-less construction
+    // throws too — the `duration` parameter is required for this reason.
+    expect(() => new Duration("")).toThrow("Unknown duration: ");
+    // The throw fires in the switch, before the dotted/multiplier arithmetic,
+    // so an unknown duration throws regardless of those arguments.
+    expect(() => new Duration("99", ".", 2)).toThrow("Unknown duration: 99");
   });
 
   it("handles dotted notes", () => {

--- a/src/ts/music-classes.ts
+++ b/src/ts/music-classes.ts
@@ -7,7 +7,7 @@ export class Duration {
   multiplier: number;
   sfths = 0; // sixtyfourth note
 
-  constructor(duration = "", dotted = "", multiplier = 1) {
+  constructor(duration: string, dotted = "", multiplier = 1) {
     this.duration = duration;
     this.dotted = dotted;
     this.multiplier = multiplier;
@@ -40,8 +40,13 @@ export class Duration {
         this.sfths = 1;
         break;
       default:
-        this.sfths = 0; // How did you get here??
-        break;
+        // Unreachable via the parser: the Ohm `duration` rule limits parsed
+        // strings to the cases above (grammar-consistency.test.ts enforces the
+        // parity). Only a direct call with an unknown string reaches here.
+        // Throw rather than silently set sfths = 0, which would stall
+        // bar-position advance in lily.ts and corrupt timing without error
+        // (#170).
+        throw new Error(`Unknown duration: ${this.duration}`);
     }
     if (dotted != undefined && this.dotted.length > 0) {
       this.sfths = this.sfths * (2 - 0.5 ** this.dotted.length);


### PR DESCRIPTION
Fixes #170.

The `Duration` constructor's `default` switch case silently set `sfths = 0` for
an unknown duration string. Because `lily.ts` advances bar position by
`comp.duration.sfths / barsize`, a zero-length duration stalls advance and
corrupts timing with no error — a silent failure reachable only if the Ohm
grammar and the switch drift apart.

This change:

- Throws `Unknown duration: <value>` from the `default` case instead of
  silently returning `0` (fail fast).
- Adds `src/test/grammar-consistency.test.ts`, a CI guard that extracts the
  grammar's `duration` literals and the switch's `case` labels from source and
  fails — naming the offending literal — if they ever diverge.
- Updates the existing test to expect the throw, and pins the empty-string and
  unknown-with-dot/multiplier cases.
- Makes the constructor's `duration` parameter required. The old `= ""` default,
  combined with the new throw, was a latent guaranteed throw and a misleading
  affordance. This tightens the signature slightly beyond the ticket's stated
  scope, so flagging it for review.

No user-facing behaviour changes for valid scores (the `default` case is
unreachable via the parser), so no version bump.

The Vera review gate ran (two passes, clean); the full synthesis is on the ticket.

- Vera
