### PR TITLE
fix: use the requested recording's intro_beats for the initial bar (#241)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/src/test/url.test.ts
+++ b/src/test/url.test.ts
@@ -61,4 +61,17 @@ describe("parseURLSearch", () => {
   it("parses ?dark=1 as dark mode (#236)", () => {
     expect(parseURLSearch("?dark=1").dark).toBe(true);
   });
+
+  it("uses the requested recording's intro_beats for the default bar (#241)", () => {
+    // intro_beats = [ALC 2, CotE 4]; the initial bar is 1 - intro_beats/4.
+    // The default bar must be keyed off the *parsed* recording, not the
+    // pre-parse default (ALC). CotE with no explicit ?bar= starts at bar 0.
+    expect(parseURLSearch("?recording=cote").bar).toBe(1 - 4 / 4); // 0
+    expect(parseURLSearch("?recording=alc").bar).toBe(1 - 2 / 4); // 0.5
+    // An explicit ?bar= still overrides the recording-derived default.
+    expect(parseURLSearch("?recording=cote&bar=10").bar).toBe(10);
+    // Explicit ?bar=0 is kept, not treated as "unset" — pins the `??` sentinel
+    // boundary against a future `||` regression (0 is falsy but not nullish).
+    expect(parseURLSearch("?recording=alc&bar=0").bar).toBe(0);
+  });
 });

--- a/src/ts/url.ts
+++ b/src/ts/url.ts
@@ -17,10 +17,9 @@ export function parseURLSearch(search: string): ParsedURL {
   const url = search.substring(1);
   const parms = url.split("&");
 
-  var recording = 0; // ALC
   var choir = 0; // choir 1 because it is zero indexed
   var part: PartType = "all";
-  var bar = 1 - config.intro_beats[recording] / 4;
+  var barParam: number | undefined; // explicit ?bar= override, if any
   var dark = true; // dark mode by default
   var early = false;
   var r = 0; // ALC
@@ -37,7 +36,7 @@ export function parseURLSearch(search: string): ParsedURL {
       if (n >= 0 && n < config.parts.length) part = n;
     } else if (key == "bar") {
       const n = Number(val);
-      if (!Number.isNaN(n)) bar = n;
+      if (!Number.isNaN(n)) barParam = n;
     } else if (key == "dark") {
       dark = val !== "false" && val !== "0";
     } else if (key == "recording") {
@@ -47,6 +46,11 @@ export function parseURLSearch(search: string): ParsedURL {
       early = val == "early";
     }
   }
+
+  // The default initial bar is keyed off the *parsed* recording (#241): the
+  // intro spans intro_beats/4 of a bar, so playback starts at
+  // 1 - intro_beats[r] / 4. An explicit ?bar= overrides it.
+  const bar = barParam ?? 1 - config.intro_beats[r] / 4;
 
   return { recording: r, choir, part, bar, dark, early };
 }


### PR DESCRIPTION
Fixes #241.

`parseURLSearch` computed the default initial bar from a pre-loop `recording = 0`
(ALC) **before** the URL loop parsed the recording into `r`, so `?recording=cote`
with no explicit `?bar=` started at ALC's `1 - 2/4 = 0.5` instead of CotE's
`1 - 4/4 = 0` — a slight but audible offset at the start of the piece.

The fix moves the default-bar computation to **after** the loop, keyed off the
parsed `r` (`1 - config.intro_beats[r] / 4`), with a `barParam: number | undefined`
sentinel so an explicit `?bar=` (including `?bar=0`) still overrides the default.
The now-dead pre-loop `recording` local is removed.

Note: the ticket's spec pointed at `index.ts:154`, but URL parsing was since
refactored into `parseURLSearch` (`src/ts/url.ts`); the identical bug and the fix
live there (a note is on the ticket).

Tests (`src/test/url.test.ts`): `?recording=cote` → bar 0, `?recording=alc` → 0.5,
explicit `?recording=cote&bar=10` → 10, and `?recording=alc&bar=0` → 0 (pinning the
`??` sentinel against a future `||` regression).

Patch version bump (user-facing fix). The Vera review gate ran (one pass, clean
fix); synthesis on the ticket.

- Vera
