### PR TITLE
fix: observe recording on MusicScore and fall back to ALC score when CotE SVG missing (#237)

### DIFF
--- a/e2e/recording-toggle.spec.ts
+++ b/e2e/recording-toggle.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+// #237: the recording switch must propagate to the score, and the score must
+// keep rendering when the (currently non-existent, #573) CotE SVG falls back to
+// the ALC file. This exercises the two paths jsdom cannot: the index.ts wiring
+// (setRecording -> score attribute) and the real Vite dynamic-import fallback.
+test.describe("Recording switch propagates to the score (#237)", () => {
+  test("toggling to CotE updates the score's recording and keeps it rendered", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const score = page.locator("music-score");
+
+    // The score renders at the default (ALC) recording.
+    await expect(score.locator("svg").first()).toBeVisible();
+    await expect(score).toHaveAttribute("recording", "0");
+
+    // Toggle the recording switch: ALC -> CotE.
+    await page.locator("#recordingswitch").click();
+
+    // The recording reaches the score (the wiring #237 adds), and the score is
+    // still rendered: CotE-named SVGs do not exist (#573), so #loadSvg falls
+    // back to the ALC file rather than leaving a blank panel.
+    await expect(score).toHaveAttribute("recording", "1");
+    await expect(score.locator("svg").first()).toBeVisible();
+
+    // #237 removed the recording propagation from setChoir, so a choir change
+    // must now leave the score's recording untouched (the score observes
+    // recording independently). Change choir via the keyboard (digit n -> choir
+    // n-1) and confirm CotE (recording 1) is retained.
+    await page.keyboard.press("3");
+    await expect(score).toHaveAttribute("choir", "2");
+    await expect(score).toHaveAttribute("recording", "1");
+    await expect(score.locator("svg").first()).toBeVisible();
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -125,9 +125,6 @@ async function setChoir(c: number, forceChange = false) {
   // Update the score for this choir
   score.setAttribute("choir", String(current.choir));
 
-  // Set the recording of the audio to use
-  score.setAttribute("recording", String(current.recording));
-
   // Update the canvas
   canvas.setAttribute("choir", String(current.choir));
 }
@@ -511,6 +508,11 @@ async function setRecording(r: number) {
 
   // Update the input field
   controls.setAttribute("recording", String(current.recording));
+
+  // Propagate to the score so it reloads with the selected recording's naming
+  // (#237). This is the only place recording reaches the score, so toggling
+  // recording without a choir change updates it.
+  score.setAttribute("recording", String(current.recording));
 }
 
 function toggleRecording() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/src/test/score.test.ts
+++ b/src/test/score.test.ts
@@ -737,4 +737,198 @@ describe("MusicScore custom element", () => {
 
     MusicScore.testSvgLoader = originalLoader;
   });
+
+  it("observes the recording attribute and updates the recording property (#237)", async () => {
+    const elem = document.querySelector("music-score") as MusicScore;
+    elem.scrollTo = vi.fn();
+
+    // Connect and load once so the element is live; recording defaults to 0.
+    const waitingForLoaded = waitForEvent(
+      elem,
+      "music-score-loaded",
+      handleScoreLoaded,
+      0,
+      null,
+      0
+    );
+    elem.setAttribute("choir", "0");
+    await waitingForLoaded;
+    expect(elem.recording).toBe(0);
+
+    // Observing "recording" must both update the property and trigger a reload.
+    // Awaiting the reload asserts the observed-attribute contract (the
+    // attributeChangedCallback oldValue==newValue guard does not suppress a
+    // genuine 0->1 change) and leaves no #loadScore() promise dangling past the
+    // test boundary.
+    const reloaded = waitForEvent(
+      elem,
+      "music-score-loaded",
+      handleScoreLoaded,
+      0,
+      null,
+      0
+    );
+    elem.setAttribute("recording", "1");
+    await reloaded;
+    expect(elem.recording).toBe(1);
+  });
+
+  it("reloads the score with the new recording when recording changes (#237)", async () => {
+    const elem = document.querySelector("music-score") as MusicScore;
+    elem.scrollTo = vi.fn();
+
+    const recordings: number[] = [];
+    const originalLoader = MusicScore.testSvgLoader;
+    MusicScore.testSvgLoader = (scoreType, _choir, recording) => {
+      recordings.push(recording);
+      return makeFixtureSvg(scoreType);
+    };
+
+    // Initial choir load happens at recording 0.
+    let loaded = waitForEvent(
+      elem,
+      "music-score-loaded",
+      handleScoreLoaded,
+      0,
+      null,
+      0
+    );
+    elem.setAttribute("choir", "0");
+    await loaded;
+    const countAfterChoir = recordings.length;
+
+    // Changing recording alone (no choir change) must trigger a fresh load
+    // carrying the new recording value.
+    loaded = waitForEvent(
+      elem,
+      "music-score-loaded",
+      handleScoreLoaded,
+      0,
+      null,
+      0
+    );
+    elem.setAttribute("recording", "1");
+    await loaded;
+
+    expect(recordings.length).toBeGreaterThan(countAfterChoir);
+    expect(recordings[recordings.length - 1]).toBe(1);
+
+    MusicScore.testSvgLoader = originalLoader;
+  });
+
+  it("resolves the CotE choir name with an ALC fallback (#237)", () => {
+    // CotE (recording 1): the primary filename uses the CotE name, the
+    // fallback is always the ALC name for the same choir, so the score can
+    // fall back to the ALC SVG while CotE SVGs do not exist (until #573).
+    expect(MusicScore.choirSvgNames(1, 0)).toEqual({
+      primary: "1",
+      fallback: "I A",
+    });
+    expect(MusicScore.choirSvgNames(1, 2)).toEqual({
+      primary: "3",
+      fallback: "II A",
+    });
+    // ALC (recording 0): primary and fallback are identical.
+    expect(MusicScore.choirSvgNames(0, 0)).toEqual({
+      primary: "I A",
+      fallback: "I A",
+    });
+  });
+
+  it("loadWithFallback returns the primary when it loads, without trying the fallback (#237)", async () => {
+    const calls: string[] = [];
+    const importer = async (stem: string) => {
+      calls.push(stem);
+      return `<svg data-stem="${stem}"/>`;
+    };
+    const svg = await MusicScore.loadWithFallback("1", "I A", importer);
+    expect(svg).toBe('<svg data-stem="1"/>');
+    expect(calls).toEqual(["1"]); // fallback never attempted
+  });
+
+  it("loadWithFallback falls back to the ALC name when the primary import fails (#237)", async () => {
+    const calls: string[] = [];
+    const importer = async (stem: string) => {
+      calls.push(stem);
+      if (stem === "1") throw new Error("missing CotE file");
+      return `<svg data-stem="${stem}"/>`;
+    };
+    const svg = await MusicScore.loadWithFallback("1", "I A", importer);
+    expect(svg).toBe('<svg data-stem="I A"/>');
+    expect(calls).toEqual(["1", "I A"]); // primary then fallback
+  });
+
+  it("loadWithFallback returns null when both primary and fallback fail (#237)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const importer = async () => {
+      throw new Error("nope");
+    };
+    const svg = await MusicScore.loadWithFallback("1", "I A", importer);
+    expect(svg).toBeNull();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
+  it("loadWithFallback does not re-import when primary === fallback (ALC) (#237)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const calls: string[] = [];
+    const importer = async (stem: string) => {
+      calls.push(stem);
+      throw new Error("missing");
+    };
+    const svg = await MusicScore.loadWithFallback("I A", "I A", importer);
+    expect(svg).toBeNull();
+    expect(calls).toEqual(["I A"]); // single attempt, no redundant retry
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
+  it("aborts a stale choir load when a newer recording load resolves first (#237)", async () => {
+    const elem = document.querySelector("music-score") as MusicScore;
+    elem.scrollTo = vi.fn();
+
+    let resolveChoir: (svg: string) => void = () => {};
+    let resolveRecording: (svg: string) => void = () => {};
+
+    const originalLoader = MusicScore.testSvgLoader;
+    // The two interleaved loads are told apart by the recording argument:
+    // setChoir(0) loads at recording 0, setRecording(1) loads at recording 1.
+    // Both drive the shared #loadGeneration guard (#391), so a recording change
+    // racing a choir change must resolve consistently.
+    MusicScore.testSvgLoader = (scoreType, _choir, recording) => {
+      if (recording === 0) {
+        return new Promise((resolve) => {
+          resolveChoir = resolve;
+        }) as unknown as string;
+      }
+      if (recording === 1) {
+        return new Promise((resolve) => {
+          resolveRecording = resolve;
+        }) as unknown as string;
+      }
+      return makeFixtureSvg(scoreType);
+    };
+
+    const pChoir = elem.setChoir(0); // generation 1, recording 0
+    const pRecording = elem.setRecording(1); // generation 2 (newer), recording 1
+
+    // The newer load (recording) resolves first and wins.
+    resolveRecording(
+      makeFixtureSvg("modern").replace("<svg ", '<svg data-rec="1" ')
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The stale choir load resolves last and must be discarded by the guard.
+    resolveChoir(
+      makeFixtureSvg("modern").replace("<svg ", '<svg data-rec="0" ')
+    );
+
+    await Promise.all([pChoir, pRecording]);
+
+    expect(elem.recording).toBe(1);
+    expect(elem.svg).not.toBeNull();
+    expect(elem.svg!.getAttribute("data-rec")).toBe("1"); // newer load won
+
+    MusicScore.testSvgLoader = originalLoader;
+  });
 });

--- a/src/ts/MusicElement.ts
+++ b/src/ts/MusicElement.ts
@@ -80,7 +80,7 @@ export class MusicElement extends HTMLElement {
     this.fireEvent("music-controls-changed");
   }
 
-  setRecording(v: number | string) {
+  setRecording(v: string | number) {
     this.recording = toRecordingIndex(v);
     this.fireEvent("music-controls-changed");
   }

--- a/src/ts/MusicScore.ts
+++ b/src/ts/MusicScore.ts
@@ -2,12 +2,94 @@
 // SPDX-License-Identifier: MIT
 
 import config from "./config";
-import { colors, toNum, TestSvgLoader } from "./common";
+import { colors, toNum, RecordingIndex, TestSvgLoader } from "./common";
 
 import { MusicElement } from "./MusicElement";
 
+/**
+ * The SVG filename stems for a choir under a given recording: `primary` is the
+ * selected recording's own naming, `fallback` is always the ALC name for the
+ * same choir. Both are stems of `config.choirs[*][choir]`, so for an in-range
+ * `choir` a `fallback` load always resolves a real file: the row-parity assert
+ * in `common.ts` guarantees the ALC name exists. (Clamping `choir` is the
+ * caller's responsibility — see `choirSvgNames`.)
+ */
+export interface ChoirSvgNames {
+  primary: string;
+  fallback: string;
+}
+
 export class MusicScore extends MusicElement {
-  static observedAttributes = ["choir", "part", "bar", "playing", "score-type"];
+  static observedAttributes = [
+    "choir",
+    "part",
+    "bar",
+    "playing",
+    "score-type",
+    "recording",
+  ];
+
+  /**
+   * Resolve the SVG filename stems for a recording and choir: the primary
+   * (the recording's own naming, `config.choirs[recording]`) and the ALC
+   * fallback (`config.choirs[0]`) for the same choir.
+   *
+   * CotE-named SVGs do not exist until #573, so a CotE selection resolves a
+   * primary that `#loadSvg()` cannot import and falls back to the ALC file
+   * rather than going blank; once #573 lands the primary loads directly.
+   *
+   * Precondition: `choir` must be in range (`0..config.choirs[0].length - 1`).
+   * The caller (`#loadScore` via the base `setChoir`) clamps it; this static
+   * helper does not, so an out-of-range `choir` yields an unusable stem.
+   */
+  static choirSvgNames(
+    recording: RecordingIndex,
+    choir: number
+  ): ChoirSvgNames {
+    return {
+      primary: config.choirs[recording][choir],
+      fallback: config.choirs[0][choir],
+    };
+  }
+
+  /**
+   * Load an SVG by choir-name stem, trying `primary` first and falling back to
+   * `fallback` when the primary cannot be loaded. `importer` performs the
+   * actual load (production passes a Vite `?raw` dynamic import; tests inject a
+   * stub), which keeps the try / fallback / null branching testable without
+   * the real bundler.
+   *
+   * The primary may legitimately be absent (e.g. CotE SVGs until #573), so a
+   * primary failure tries `fallback` rather than surfacing. When
+   * `primary === fallback` there is no alternative, so the single failure is
+   * logged and `null` returned with no redundant re-import. A both-failed load
+   * logs and returns `null`; the caller then renders nothing.
+   */
+  static async loadWithFallback(
+    primary: string,
+    fallback: string,
+    importer: (stem: string) => Promise<string>
+  ): Promise<string | null> {
+    try {
+      return await importer(primary);
+    } catch (primaryError) {
+      if (primary === fallback) {
+        console.error(`Error loading score SVG "${primary}": ${primaryError}`);
+        return null;
+      }
+      try {
+        return await importer(fallback);
+      } catch (fallbackError) {
+        // Both failed: log the primary error too — when the primary is a real
+        // file (not the expected-absent CotE case) its failure is the more
+        // diagnostic one.
+        console.error(
+          `Error loading score SVG "${primary}" (${primaryError}); fallback "${fallback}" also failed (${fallbackError})`
+        );
+        return null;
+      }
+    }
+  }
 
   /**
    * Test-only hook: when set, #loadSvg() bypasses the dynamic import and
@@ -204,17 +286,26 @@ export class MusicScore extends MusicElement {
       }
     }
 
-    try {
-      const choirName = config.choirs[this.recording][this.choir];
-      const svgModule = await import(
-        `../scores/Hugh Keyte/${this.scoreType}/Choir ${choirName}.svg?raw`
-      );
+    const { primary, fallback } = MusicScore.choirSvgNames(
+      this.recording,
+      this.choir
+    );
+    // The primary stem may name a file that does not exist (CotE SVGs until
+    // #573), so loadWithFallback tries the ALC fallback before giving up. This
+    // is a general "primary may be absent" guard, not a CotE-only workaround:
+    // it keeps the score rendering for any missing or renamed primary.
+    const svg = await MusicScore.loadWithFallback(primary, fallback, (stem) =>
+      import(
+        `../scores/Hugh Keyte/${this.scoreType}/Choir ${stem}.svg?raw`
+      ).then((svgModule) => svgModule.default as string)
+    );
+    // Guard on `typeof === "string"` (matching the test-seam branch above), not
+    // merely non-null, so a degenerate import resolving without a string
+    // `default` cannot fire a spurious loaded event.
+    if (typeof svg === "string") {
       this.fireEvent("music-score-loaded");
-      return svgModule.default;
-    } catch (error) {
-      console.error(`Error loading SVG: ${error}`);
-      return null;
     }
+    return svg;
   };
 
   async #loadScore() {
@@ -291,6 +382,16 @@ export class MusicScore extends MusicElement {
 
     // set the border color to match
     this.style.borderColor = `hsla(${colors().choir[this.choir]}, 80%, 55%, 1)`;
+  }
+
+  async setRecording(v: string | number) {
+    super.setRecording(v);
+
+    // The choir label is baked into the SVG file, which #loadSvg() selects
+    // from the recording, so a recording change must reload the score
+    // (mirrors setChoir and setScoreType). #loadScore()'s generation guard
+    // (#391) keeps a recording change racing a choir change consistent.
+    await this.#loadScore();
   }
 
   setBar(b: string | number) {

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -142,6 +142,26 @@ if (config.recording.length !== 2) {
   );
 }
 
+// Fail fast at import time: the score-SVG fallback (MusicScore.choirSvgNames)
+// resolves the ALC name `config.choirs[0][choir]` for any recording's choir,
+// which only holds if every recording row exists and all rows are of equal
+// length. Assert one row per recording, all of equal length, so a future edit
+// that makes a row short cannot silently break the "render rather than go
+// blank" fallback (it would resolve `undefined`). Mirrors the other fail-fast
+// config guards in this file.
+if (config.choirs.length !== config.recording.length) {
+  throw new Error(
+    `config.choirs must have one row per recording: got ${config.choirs.length} rows for ${config.recording.length} recordings`
+  );
+}
+for (let v = 0; v < config.choirs.length; v++) {
+  if (config.choirs[v].length !== config.choirs[0].length) {
+    throw new Error(
+      `config.choirs[${v}] must have the same length as config.choirs[0]`
+    );
+  }
+}
+
 // Fail fast at import time: mismatched lengths would silently corrupt
 // getBarFromTime/getTimeFromBar interval lookups. Throwing at module scope
 // breaks the whole app on bad config — intentional, since the alternative


### PR DESCRIPTION
Fixes #237. Fixes #504.

`MusicScore` now observes the `recording` attribute and reloads on change, and `index.ts setRecording()` propagates recording to the score (moved out of `setChoir`). When the CotE-named SVG is missing, `#loadSvg` falls back to the ALC file via a new pure `loadWithFallback`, so the score renders rather than going blank.

This is a **correctness + readiness** change. Because CotE-named SVGs do not exist yet, the score still visibly shows the ALC labels ("I A", "I B"…) — it loads the ALC file via the fallback. Visible CotE labels are blocked on generating CotE SVGs, filed as #573. The wiring is correct and safe, and lights up the moment #573 lands the SVGs.

## What changed

- `MusicScore.observedAttributes` now includes `recording`; `setRecording()` is overridden to reload (mirrors `setChoir`/`setScoreType`).
- `index.ts`: recording propagation moved from `setChoir` into `setRecording` (the sole site reaching the score), so toggling recording without a choir change updates the score.
- New pure `MusicScore.loadWithFallback(primary, fallback, importer)` + `ChoirSvgNames` type: tries the recording's own SVG, falls back to the ALC name, binds and logs errors, and short-circuits when there is no distinct fallback.
- `common.ts`: import-time assert that `config.choirs` has one row per recording, all equal length (backs the fallback invariant; mirrors the existing recording-length and bartime/barno guards). This is the standalone hardening specified as #504, folded in here because #237 depends on the same invariant.

## Tests

- Unit (`src/test/score.test.ts`): observes recording, reloads on recording change, `choirSvgNames` resolution, four `loadWithFallback` branch tests, and a recording-vs-choir race test.
- e2e (`e2e/recording-toggle.spec.ts`): toggling to CotE sets the score's `recording` and the score still renders (real Vite import fallback), and a choir change retains the recording.

## Notes

- Went through the Vera gate (two passes; findings resolved or deferred — see the #237 comments). One pre-existing fire-and-forget load-error pattern deferred to #575.
- Version bumped to 2.8.3. Heads-up: #241 (PR #576) also bumps to 2.8.3, so whichever merges second will need a trivial version rebase.

- Claude
