### PR TITLE
fix: hide MusicCanvas playhead during the intro bar (#419)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spem-player",
   "private": true,
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/src/test/canvas.test.ts
+++ b/src/test/canvas.test.ts
@@ -1,4 +1,4 @@
-import { MusicCanvas } from "../ts/MusicCanvas";
+import { MusicCanvas, exportedForTesting } from "../ts/MusicCanvas";
 import config from "../ts/config";
 import type { Position } from "../ts/common";
 MusicCanvas.define("music-canvas");
@@ -1220,5 +1220,80 @@ describe("MusicCanvas custom element", () => {
     addElemSpy.mockRestore();
     removeElemSpy.mockRestore();
     freshCanvas.remove();
+  });
+
+  it("draws the playhead through draw() only for whole, in-range bars (#419)", () => {
+    expect(canvas).not.toBeNull();
+    const ctx = canvas!.canvas!.getContext("2d")!;
+    // #drawBarHighlight is the only draw path that strokes with lineCap
+    // "square" (#drawSelectionHighlight and #drawVoiceParts use "round"), so a
+    // square-cap stroke is the signature that the playhead was painted. This
+    // exercises the guard wiring in #drawBarHighlight, which the pure
+    // shouldDrawBarHighlight tests cannot reach.
+    const countPlayheadStrokes = () => {
+      let n = 0;
+      const spy = vi.spyOn(ctx, "stroke").mockImplementation(() => {
+        if (ctx.lineCap === "square") n++;
+      });
+      canvas!.draw();
+      spy.mockRestore();
+      return n;
+    };
+
+    const origBar = canvas!.bar;
+    try {
+      canvas!.bar = 0.5; // intro bar — playhead suppressed
+      expect(countPlayheadStrokes()).toBe(0);
+      canvas!.bar = 10; // whole, in-range bar — playhead drawn
+      expect(countPlayheadStrokes()).toBe(1);
+    } finally {
+      canvas!.bar = origBar;
+    }
+  });
+});
+
+describe("shouldDrawBarHighlight (#419)", () => {
+  const { shouldDrawBarHighlight } = exportedForTesting;
+  // 139 is the last bar index in the standard fixture (bars 0–139).
+  const barCount = 139;
+
+  // The playhead is hidden for any bar below the first whole bar (bar < 1 —
+  // the intro bar [0, 1) and any negative value), matching MusicScore which
+  // draws only for bar >= 1; it is drawn for whole bars within the piece and
+  // suppressed past the end (bar > barCount) and for a non-finite bar.
+  it("suppresses the playhead at bar 0 (intro bar start)", () => {
+    expect(shouldDrawBarHighlight(0, barCount)).toBe(false);
+  });
+
+  it("suppresses the playhead at bar 0.5 (mid intro bar)", () => {
+    expect(shouldDrawBarHighlight(0.5, barCount)).toBe(false);
+  });
+
+  it("suppresses the playhead just below the first whole bar", () => {
+    expect(shouldDrawBarHighlight(0.999, barCount)).toBe(false);
+  });
+
+  it("suppresses the playhead for a negative bar", () => {
+    expect(shouldDrawBarHighlight(-1, barCount)).toBe(false);
+  });
+
+  it("draws the playhead at bar 1 (first whole bar)", () => {
+    expect(shouldDrawBarHighlight(1, barCount)).toBe(true);
+  });
+
+  it("draws the playhead at the last bar", () => {
+    expect(shouldDrawBarHighlight(139, barCount)).toBe(true);
+  });
+
+  it("suppresses the playhead past the last bar", () => {
+    expect(shouldDrawBarHighlight(140, barCount)).toBe(false);
+  });
+
+  it("suppresses the playhead for a non-finite bar (NaN)", () => {
+    expect(shouldDrawBarHighlight(NaN, barCount)).toBe(false);
+  });
+
+  it("suppresses the playhead before barCount is populated (barCount 0)", () => {
+    expect(shouldDrawBarHighlight(1, 0)).toBe(false);
   });
 });

--- a/src/ts/MusicCanvas.ts
+++ b/src/ts/MusicCanvas.ts
@@ -7,6 +7,16 @@ import { MusicElement } from "./MusicElement";
 
 import { NoteEntry, Range, FRlocation, processLilypond } from "./lily";
 
+// Whether the bar-position playhead should be drawn for a given bar. It is
+// suppressed for any bar below the first whole bar (bar < 1) — both the intro
+// bar [0, 1) and any negative value — to match MusicScore, which draws its
+// playhead only for bar >= 1 (MusicScore.ts). It is also suppressed past the
+// end of the piece (bar > barCount). A non-finite bar (NaN, from an unclamped
+// upstream value) yields false here and so is suppressed too. See #419.
+function shouldDrawBarHighlight(bar: number, barCount: number): boolean {
+  return bar >= 1 && bar <= barCount;
+}
+
 export class MusicCanvas extends MusicElement {
   static observedAttributes = ["choir", "part", "bar", "playing"];
 
@@ -389,7 +399,7 @@ export class MusicCanvas extends MusicElement {
   }
 
   #drawBarHighlight(ctx: CanvasRenderingContext2D) {
-    if (this.bar <= 0 || this.bar > this.barCount) return;
+    if (!shouldDrawBarHighlight(this.bar, this.barCount)) return;
     ctx.save();
     ctx.beginPath();
     ctx.moveTo(
@@ -708,3 +718,7 @@ export class MusicCanvas extends MusicElement {
     this.draw();
   }
 }
+
+export const exportedForTesting = {
+  shouldDrawBarHighlight,
+};


### PR DESCRIPTION
During playback of the intro bar (`0 < bar < 1`), the MusicCanvas overview drew the playhead cursor while MusicScore hides its playhead for `bar < 1`, creating a visual inconsistency between the two displays.

This extracts a pure `shouldDrawBarHighlight(bar, barCount)` helper (`bar >= 1 && bar <= barCount`) and wires `#drawBarHighlight`'s guard to it, so the canvas hides the playhead during the intro bar to match the score. Mark confirmed Option A (hide) on the ticket.

Tests: a `shouldDrawBarHighlight` boundary suite (0, 0.5, 0.999, -1, 1, 139, 140, NaN, barCount=0) plus a `draw()`-level test that pins the guard wiring via the playhead's unique `lineCap = "square"`.

Fixes #419
