### PR TITLE
build: have ESLint honour .gitignore via includeIgnoreFile (#509)

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -247,6 +247,8 @@ The CI pipeline runs `pnpm run check:lint` and `pnpm run check:types`. Pull requ
 
 The project uses an ESLint flat config (`eslint.config.js`) with `typescript-eslint`. Some rules are relaxed because the codebase predates them (for example, `no-var` and `@typescript-eslint/no-explicit-any` are currently off). Follow the existing patterns in the file you are editing rather than refactoring legacy code to meet stricter rules.
 
+ESLint honours `.gitignore` (via `includeIgnoreFile`, bundled with ESLint as `eslint/config`), so gitignored paths are never linted. The `ignores` array in `eslint.config.js` lists only the few paths that are *not* gitignored (for example local-only `tests-local/` and `probes/`, or tracked `lilypond/build/`); the comment there records the current membership. To stop a path being linted, prefer adding it to `.gitignore`; reach for the ESLint `ignores` array only when the path must stay tracked.
+
 The project uses **Prettier** for automatic formatting. Run `pnpm run fix:format` before committing, or configure your editor to format on save. The CI pipeline runs `pnpm run check:format` as part of the build gate.
 
 All `.md` files must pass `markdownlint-cli2` before a PR is opened. Run `npx markdownlint-cli2 <file>` after editing any markdown file.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,8 +2,16 @@ import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import globals from 'globals'
 import eslintConfigPrettier from 'eslint-config-prettier'
+import { includeIgnoreFile } from 'eslint/config'
+// URL is imported (rather than used as a global) so ESLint can lint this config
+// file itself under no-undef, which has no node globals in scope here.
+import { fileURLToPath, URL } from 'node:url'
+
+const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url))
 
 export default tseslint.config(
+  // Honour .gitignore so the ignore list is not hand-duplicated here (#509).
+  includeIgnoreFile(gitignorePath),
   js.configs.recommended,
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
@@ -53,16 +61,14 @@ export default tseslint.config(
     },
   },
   {
+    // .gitignore is honoured via includeIgnoreFile above; only paths that are
+    // NOT gitignored need listing here. tests-local/ and probes/ are local-only
+    // (.git/info/exclude, not .gitignore); lilypond/build/ and
+    // .dependency-cruiser.cjs are tracked.
     ignores: [
-      'dist/',
-      'node_modules/',
-      'coverage/',
-      '.netlify/',
       'lilypond/build/',
       'tests-local/',
       'probes/',
-      'src/ohmjs/*.ohm-bundle.js',
-      'src/ohmjs/*.ohm-bundle.d.ts',
       '.dependency-cruiser.cjs',
     ],
   }


### PR DESCRIPTION
`check:lint` ran `eslint . --max-warnings 0` over a hand-maintained `ignores` array that duplicated `.gitignore` (`dist/`, `node_modules/`, `coverage/`, `.netlify/`). The two could drift, and any gitignored dir that gained a lintable file (for example a Vite build artifact in `temp/`) broke `check:lint` until someone added it to the ESLint ignores by hand.

This uses `includeIgnoreFile` (bundled with ESLint as `eslint/config`, no new dependency) so `.gitignore` is the single source of truth for what is not linted. The manual `ignores` array now lists only paths that are *not* gitignored: `lilypond/build/` (tracked), `tests-local/`/`probes/` (local-only via `.git/info/exclude`), `.dependency-cruiser.cjs` (tracked).

Spec note: the ticket recommended `@eslint/compat`'s `includeIgnoreFile`, but that export is `@deprecated`; the same function ships bundled with ESLint as `eslint/config`, so no dependency is added.

Verification (an ESLint flat-config change has no unit-test harness here, so this is behavioural):

- `pnpm run ci` is green.
- A scratch `.ts` with a lint error placed in gitignored `temp/` goes from linted to ignored.
- A lint error in a tracked, non-ignored file is still reported.
- The "silently ignore everything" failure mode is not CI-invisible: `build:ohm` runs before `check:lint` and emits the ohm bundle into the linted `src/**`, so a broken `includeIgnoreFile` would fail `--max-warnings 0` loudly. (That guard is incidental on the `build:ohm`-before-`check:lint` ordering.)

Fixes #509
