### PR TITLE
fix: order pre-release LilyPond versions below their release (#519)

### DIFF
--- a/lilypond/build/buildScores.mjs
+++ b/lilypond/build/buildScores.mjs
@@ -73,18 +73,46 @@ function validateOptions(options) {
 }
 
 function parseLilypondVersion(output) {
-  const match = output.match(/GNU LilyPond (\d+\.\d+\.\d+)/);
+  // Capture the numeric core PLUS any pre-release suffix (e.g.
+  // "2.26.0-rc1"). The previous `\d+\.\d+\.\d+` silently truncated the
+  // suffix, which masked the pre-release ordering bug in compareVersions
+  // and let a pre-release of the minimum version pass the check (#519).
+  // The trailing `\S*` keeps the suffix while still requiring an X.Y.Z
+  // core, so a non-version banner returns null and is reported as
+  // "unknown" with the raw stdout echoed (#549) — a bare `\S+` would
+  // wrongly accept garbage tokens as a version.
+  const match = output.match(/GNU LilyPond (\d+\.\d+\.\d+\S*)/);
   return match ? match[1] : null;
 }
 
+// Compare two dot-separated version strings. Each part is split into its
+// leading integer run and any trailing suffix; integers compare numerically
+// and a part with no suffix outranks one with a suffix (release > pre-release,
+// per semver precedence), so "2.26.0" > "2.26.0-rc1". Suffixes among
+// themselves compare lexicographically, which orders multi-digit identifiers
+// wrongly — "-rc10" sorts BELOW "-rc2". Not a full semver implementation
+// (no build metadata, no multi-identifier pre-release ordering) — see #519.
 function compareVersions(a, b) {
-  const partsA = a.split(".").map(Number);
-  const partsB = b.split(".").map(Number);
+  const parse = (v) =>
+    v.split(".").map((p) => {
+      // Match the leading digit run explicitly so a part keeps its full
+      // suffix and a leading-zero part is not mis-sliced. The sole caller
+      // feeds X.Y.Z[suffix], but the exported comparator must not mangle a
+      // digit-less or leading-zero part (Vera 519-01).
+      const [, digits, rest] = /^(\d*)(.*)$/.exec(p);
+      return { num: digits === "" ? 0 : parseInt(digits, 10), rest };
+    });
+  const partsA = parse(a);
+  const partsB = parse(b);
   for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-    const numA = partsA[i] || 0;
-    const numB = partsB[i] || 0;
-    if (numA < numB) return -1;
-    if (numA > numB) return 1;
+    const pa = partsA[i] || { num: 0, rest: "" };
+    const pb = partsB[i] || { num: 0, rest: "" };
+    if (pa.num !== pb.num) return pa.num < pb.num ? -1 : 1;
+    if (pa.rest !== pb.rest) {
+      if (pa.rest === "") return 1;
+      if (pb.rest === "") return -1;
+      return pa.rest < pb.rest ? -1 : 1;
+    }
   }
   return 0;
 }
@@ -261,4 +289,4 @@ if (isMain) {
   main();
 }
 
-export { parseArgs, buildPattern };
+export { parseArgs, buildPattern, parseLilypondVersion, compareVersions };

--- a/lilypond/test/buildScores.integration.test.ts
+++ b/lilypond/test/buildScores.integration.test.ts
@@ -509,6 +509,39 @@ describe("buildScores.mjs integration", () => {
     }
   });
 
+  it("rejects a pre-release of the minimum version (#519)", () => {
+    // The #519 bug lived at this call site: compareVersions returned 0 for a
+    // pre-release of the minimum, so 2.26.0-rc1 silently passed the gate.
+    // Pin the rejection end-to-end — a checkLilypond refactor that
+    // reintroduced the bug (e.g. < 0 -> <= 0) would pass every
+    // compareVersions unit test but fail here.
+    const ws = createWorkspace();
+    try {
+      const envRc = {
+        ...env,
+        FAKE_LILYPOND_VERSION: "2.26.0-rc1",
+      };
+
+      const result = spawnSync(
+        process.execPath,
+        [join(ws, "build", "buildScores.mjs")],
+        {
+          cwd: ws,
+          env: envRc,
+          encoding: "utf-8",
+        }
+      );
+
+      expect(result.status).not.toBe(0);
+      const output = (result.stdout + result.stderr).toLowerCase();
+      // The version is parsed (not "unknown") and rejected as too old.
+      expect(output).toContain("2.26.0-rc1");
+      expect(output).toContain("2.26.0 or later is required");
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
   it("deletes SVG on post-processing failure", () => {
     const ws = createWorkspace();
     try {

--- a/lilypond/test/buildScores.test.ts
+++ b/lilypond/test/buildScores.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseArgs, buildPattern } from "../build/buildScores.mjs";
+import {
+  parseArgs,
+  buildPattern,
+  parseLilypondVersion,
+  compareVersions,
+} from "../build/buildScores.mjs";
 
 describe("parseArgs", () => {
   it("returns defaults when given no arguments", () => {
@@ -59,5 +64,85 @@ describe("buildPattern", () => {
     expect(buildPattern("lilypond/src/Hugh Keyte/early", "I A")).toBe(
       "lilypond/src/Hugh Keyte/early/Choir I A.ly"
     );
+  });
+});
+
+describe("parseLilypondVersion", () => {
+  it("captures a plain release version", () => {
+    expect(parseLilypondVersion("GNU LilyPond 2.26.0")).toBe("2.26.0");
+  });
+
+  it("captures a pre-release version including its suffix (#519)", () => {
+    // The previous regex (\d+\.\d+\.\d+) silently truncated the suffix,
+    // masking the compareVersions defect below.
+    expect(parseLilypondVersion("GNU LilyPond 2.26.0-rc1")).toBe("2.26.0-rc1");
+  });
+
+  it("returns null when the banner does not match", () => {
+    expect(parseLilypondVersion("not a lilypond banner")).toBeNull();
+  });
+
+  it("returns null for a non-version token so garbage is reported as unknown (#549)", () => {
+    // The X.Y.Z core is required: a bare \S+ would accept "weird-build"
+    // as a version and defeat the "unknown version, echo raw stdout"
+    // diagnostic path.
+    expect(parseLilypondVersion("GNU LilyPond weird-build")).toBeNull();
+  });
+});
+
+describe("compareVersions", () => {
+  it("treats equal versions as equal", () => {
+    expect(compareVersions("2.26.0", "2.26.0")).toBe(0);
+  });
+
+  it("orders a lower patch/minor as less", () => {
+    expect(compareVersions("2.25.0", "2.26.0")).toBeLessThan(0);
+  });
+
+  it("orders a higher minor as greater", () => {
+    expect(compareVersions("2.27.0", "2.26.0")).toBeGreaterThan(0);
+  });
+
+  it("orders a pre-release below its release (#519)", () => {
+    // Exact -1, not just sign: a regression that flipped magnitude without
+    // flipping sign would slip past a relational matcher (Vera 519-04).
+    expect(compareVersions("2.26.0-rc1", "2.26.0")).toBe(-1);
+  });
+
+  it("orders pre-releases lexicographically among themselves", () => {
+    expect(compareVersions("2.26.0-rc1", "2.26.0-rc2")).toBeLessThan(0);
+  });
+
+  it("orders a release above its pre-release (#519)", () => {
+    expect(compareVersions("2.26.0", "2.26.0-rc1")).toBe(1);
+  });
+
+  it("lets a higher patch outrank a pre-release of a lower patch", () => {
+    expect(compareVersions("2.26.1-rc1", "2.26.0")).toBeGreaterThan(0);
+  });
+
+  it("accepts a pre-release of a higher version (Vera 519-03)", () => {
+    // The suffix branch only runs when the numeric parts tie; pin that a
+    // higher numeric core wins regardless of suffix, so a "return early on
+    // any suffix" simplification cannot wrongly reject 2.27.0-rc1.
+    expect(compareVersions("2.27.0-rc1", "2.26.0")).toBeGreaterThan(0);
+  });
+
+  it("treats two identical pre-releases as equal (Vera 519-06)", () => {
+    expect(compareVersions("2.26.0-rc1", "2.26.0-rc1")).toBe(0);
+  });
+
+  it("orders multi-digit pre-release identifiers lexicographically — a known limitation (Vera 519-05)", () => {
+    // Documented limitation: lexicographic suffix compare puts "-rc10"
+    // BELOW "-rc2". LilyPond ships no double-digit rc, so this never bites
+    // the version gate; the test exists to make the contract honest.
+    expect(compareVersions("2.26.0-rc10", "2.26.0-rc2")).toBeLessThan(0);
+  });
+
+  it("parses each part's leading integer so a leading-zero part equals its bare form (Vera 519-01)", () => {
+    // Pins the {num, rest} split. The old slice(String(num).length) turned
+    // "08" into {num: 8, rest: "8"}, mis-ranking it below "8"; the regex
+    // split keeps rest empty so "2.08.0" compares equal to "2.8.0".
+    expect(compareVersions("2.08.0", "2.8.0")).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #519.

`compareVersions` split each dot-separated part with `Number()`, so a pre-release suffix like `0-rc1` became `NaN` and the comparison returned 0 (equal) — a pre-release of the minimum LilyPond version silently passed the build's version check. `parseLilypondVersion` also truncated the suffix, masking it.

## What changed

- **`parseLilypondVersion`**: regex widened from `\d+\.\d+\.\d+` to `\d+\.\d+\.\d+\S*` so it captures the pre-release suffix, while still requiring an X.Y.Z core — a non-version banner returns `null` and is reported as "unknown" with raw stdout echoed (preserving the #549 diagnostic; a bare `\S+` would wrongly accept garbage).
- **`compareVersions`**: rewritten to parse each part's leading digit run via `/^(\d*)(.*)$/` into `{num, rest}`. Integers compare numerically and a missing suffix outranks a present one (release > pre-release, per semver), so `2.26.0` > `2.26.0-rc1`. The explicit digit-run match also avoids mangling a digit-less or leading-zero part now that the comparator is exported.
- Both functions are now exported for testing.

## Tests

- **Unit** (`buildScores.test.ts`): pre-release ordering both directions (exact `-1`/`1`), higher-version pre-release accepted, suffix equality, a leading-zero discriminator, and a documented lexicographic-limitation case (`-rc10` < `-rc2`); plus `parseLilypondVersion` plain / suffix / garbage→null.
- **Integration** (`buildScores.integration.test.ts`): a pre-release of the minimum version (`2.26.0-rc1`) is rejected at the call site — non-zero exit, parsed not "unknown", "2.26.0 or later is required". This pins the bug end-to-end, so a `< 0` → `<= 0` refactor of `checkLilypond` cannot silently reintroduce it.

## Notes

Went through the Vera gate (one cycle, two passes; pass 2 clean). Two important findings addressed: the exported comparator's `{num, rest}` parse hardening (519-01) and the missing call-site rejection test (pr-test-analyzer) — see the #519 comments. Developer-facing build-script fix: no user-visible app change, no version bump.

- Claude
