### PR TITLE
build: add GitHub helper script for Kimi methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ __pycache__/
 AGENTS.md
 CLAUDE.md
 /scripts/
-.kimi/
+.kimi/*
+!.kimi/methods/
+!.kimi/scripts/

--- a/.kimi/methods/andrew.md
+++ b/.kimi/methods/andrew.md
@@ -1,0 +1,33 @@
+# Method: Andrew
+
+Report Andrew's recent activity (`wainwright1000`).
+
+## Steps
+
+1. **Last seen.**
+   - `git log origin/main -1 --author=wainwright1000 --format="%H %ci %s"`
+   - Report exact time and message of Andrew's last commit.
+   - Calculate elapsed time. If less than 4h: "active this morning/afternoon"; 4–12h: "active earlier today"; 12–24h: "active yesterday"; over 24h: report exact hours.
+2. **Fast path.**
+   - If no commits, issues, PRs, or review activity in the last 48h, output one sentence and stop.
+3. **His commits.**
+   - `git log origin/main --since="48 hours ago" --author=wainwright1000 --oneline`
+   - Summarise each in plain language; flag significance (tests, build, overlapping tickets).
+4. **His issues.**
+   - `node .kimi/scripts/gh-helper.mjs issues wainwright1000`
+   - Report recently opened or closed issues; note overlaps with your tickets.
+5. **Questions for you.**
+   - `node .kimi/scripts/gh-helper.mjs issues wainwright1000 question`
+   - Report any open issues with the `question` label. If there are any, flag them explicitly — Mark needs to answer Andrew's questions.
+6. **His PRs.**
+   - `node .kimi/scripts/gh-helper.mjs prs wainwright1000`
+   - Report recently opened or merged PRs.
+7. **Review activity on your PRs.**
+   - `node .kimi/scripts/gh-helper.mjs my-prs`
+   - For each open PR: state review status. Flag `CHANGES_REQUESTED` and summarise required action.
+8. **Synthesise.**
+   - What time of day has he been working?
+   - What area is he focused on?
+   - Is he in review mode or coding mode?
+   - Does any of his activity require action from you?
+   - End with a concrete question or suggestion.

--- a/.kimi/methods/monitor-build-resources.md
+++ b/.kimi/methods/monitor-build-resources.md
@@ -1,0 +1,97 @@
+# Method: Monitor Build Resources
+
+## Purpose
+
+Prevent depletion of Netlify build minutes and GitHub Actions minutes by providing daily usage visibility and threshold-based alerts to the team Telegram group.
+
+## Scope
+
+- **Netlify:** build minutes consumed vs monthly limit (300 on Starter plan)
+- **GitHub Actions:** minutes consumed vs monthly limit (2,000 on Free plan for private repos)
+- **Exclusions:** AI tool usage (Claude, Kimi) — monitored separately if cost becomes material
+
+## Schedule
+
+Daily at 08:00 UTC via GitHub Actions scheduled workflow (`cron: "0 8 * * *"`).
+
+## Notification channel
+
+Telegram group chat. Post a single message per day summarising both services.
+
+## Prerequisites
+
+All secrets are configured in the GitHub repository:
+
+| Secret | Status |
+|---|---|
+| `TELEGRAM_BOT_TOKEN` | ✓ Configured (Andrew's bot `@bv79c_bot`) |
+| `TELEGRAM_CHAT_ID` | ✓ Configured ("Meet Tele" group) |
+| `NETLIFY_AUTH_TOKEN` | ✓ Configured (not used by current CI workflows) |
+| `NETLIFY_SITE_ID` | ✓ Configured (not used by current CI workflows) |
+
+The workflow uses the default `GITHUB_TOKEN` for Actions usage queries; no additional token is required.
+
+## API endpoints
+
+| Service | Endpoint | Purpose |
+|---|---|---|
+| Netlify | `GET /api/v1/{account_slug}/builds/status` | Current period minutes, limit, period dates |
+| GitHub | `GET /repos/{owner}/{repo}/actions/runs` with date filter | Estimate minutes from completed workflow runs |
+
+GitHub does not expose a single "minutes used this period" API for Free plans. The workflow must aggregate `run_duration_ms` from workflow runs within the current billing period (calendar month for Free plans).
+
+## Message format
+
+```
+📊 Build Resources — {date}
+
+Netlify: {current} / {limit} min ({pct}%)
+GitHub:  {current} / {limit} min ({pct}%)
+
+Status: {🟢 normal / 🟡 watch / 🔴 throttle / 🚨 stop}
+
+Next threshold: {threshold} at projected {date}
+```
+
+## Thresholds and runbook
+
+### 🟡 50% — Watch
+
+- Action: none required.
+- Message prefix: "⚠️ Usage above 50%."
+
+### 🔴 75% — Throttle
+
+- Action: the daily message includes a mandatory checklist posted to Telegram:
+  1. Confirm Netlify auto-builds remain disabled.
+  2. Disable non-essential scheduled workflows (E2E nightly runs, daily integration tests).
+  3. Reduce push frequency to `main` where possible — batch small commits.
+  4. Review open PRs for unnecessary preview deploys.
+
+### 🚨 90% — Emergency stop
+
+- Action: the monitoring workflow opens a high-priority issue titled `BUILD MINUTES CRITICAL: {service} at {pct}%`.
+- Team agrees to a 24-hour code freeze on non-urgent work.
+- Cancel all queued non-critical GitHub Actions jobs.
+- The workflow itself continues to run so usage can be tracked to zero.
+
+## Workflow behaviour on failure
+
+If either API call fails, the workflow posts a failure message to Telegram and opens a repository issue so the breakage is not silent. Do not skip the notification on API failure — that would hide a monitoring gap.
+
+## Implementation
+
+The agent implements this as `.github/workflows/monitor-resources.yml`. The workflow:
+1. Checks out the repo.
+2. Queries Netlify API for build status.
+3. Queries GitHub API for workflow runs in the current month and sums durations.
+4. Computes percentages and determines threshold status.
+5. Posts the formatted message to Telegram via `https://api.telegram.org/bot{token}/sendMessage`.
+6. Opens an issue if the 90% threshold is breached.
+
+## Verification
+
+After implementation:
+1. Trigger the workflow manually and confirm the Telegram message arrives.
+2. Verify the numbers match the Netlify dashboard and GitHub billing page.
+3. Check that a simulated 90% threshold correctly opens an issue.

--- a/.kimi/methods/specify.md
+++ b/.kimi/methods/specify.md
@@ -1,0 +1,44 @@
+# Method: Specify
+
+Assess and specify a ticket. Run from the repository root.
+
+## High-level flow
+
+1. Verify the ticket exists (`gh issue view <number>`).
+2. Determine if it is a fresh specification or a re-specification (check body for Description/Recommended fix/Test plan, and the `specified` label).
+3. Read prior investigation (refactor reports, Architecture.md) and source code.
+4. Scan for duplicates among open board items.
+5. Evaluate ticket claims against source code (stale references, contradictions, scope accuracy).
+6. Ensure board fields (Type, Area, Difficulty) are populated.
+7. Consult Bob on root cause, test plan, scope, and minimal change.
+8. Write and post the specification using the appropriate template:
+   - **XS/S:** Specification Template — XS / S
+   - **M/L:** Specification Template — M / L
+   - **Architectural:** Specification Template — Architectural
+9. Apply the `specified` label (`gh issue edit <number> --add-label specified`) and populate the board fields (Type, Area, Difficulty) using the helper script to avoid hand-copied option IDs:
+
+   ```console
+   node .kimi/scripts/gh-helper.mjs set-field <number> type <bug|feature|tech-debt|tooling-bug>
+   node .kimi/scripts/gh-helper.mjs set-field <number> area <ui|score|canvas|lily|config|test|tooling|controls|docs|audio|other>
+   node .kimi/scripts/gh-helper.mjs set-field <number> difficulty <xs|s|m|l>
+   ```
+10. Capture cross-cutting architectural knowledge if needed.
+11. Post-mortem: record lessons and create Workbench items only for repeatable process gaps.
+12. Tidy: delete temp files, verify working tree is clean.
+
+## Key constraints
+
+- Do not write the specification until investigation, evaluation, and Bob consultation are complete.
+- Do not change board status; the item stays in **Todo**.
+- For re-specification, post a delta comment rather than overwriting the original body.
+- Update the issue title via `gh issue edit` if Step 5 flags it as poor.
+
+## Templates
+
+- XS / S: https://github.com/wainwmr/spem-player/wiki/Specification-Template-XS-S
+- M / L: https://github.com/wainwmr/spem-player/wiki/Specification-Template-M-L
+- Architectural: https://github.com/wainwmr/spem-player/wiki/Specification-Template-Architectural
+
+## Full procedure
+
+https://github.com/wainwmr/spem-player/wiki/Method-Specify

--- a/.kimi/methods/work.md
+++ b/.kimi/methods/work.md
@@ -1,0 +1,228 @@
+# Method: Work
+
+Implement an open issue from specification through merge.
+
+## Preconditions
+
+- The issue exists on the board.
+- The issue has the `specified` label. If not, stop and run the `specify` method.
+- The issue has no unresolved blockers in its Dependencies section.
+
+## Steps
+
+### 1. Prepare environment
+
+```console
+git checkout main
+git pull
+git status
+```
+
+- Working tree must be clean. If there are uncommitted changes, stop and ask Mark what to do with them.
+- `main` must be up to date with `origin/main`. If not, `git pull` first.
+
+### 2. Create branch and move issue to In Progress
+
+Branch name: `issue-NNN-short-description`
+
+For multiple issues in one PR, still create a branch. Use the lowest issue number in the branch name (e.g. `issue-306-buildScores-fixes`) and list every issue in the PR description with its own `Fixes #NNN` line.
+
+```console
+git checkout -b issue-NNN-short-description
+```
+
+Assign the issue to yourself and move it to **In Progress** immediately after creating the branch. Do not skip these — they signal that work has started. Use the helper script so the board transitions are reliable and do not require hand-copied project IDs:
+
+```console
+node .kimi/scripts/gh-helper.mjs assign <issue-number>
+node .kimi/scripts/gh-helper.mjs status <issue-number> progress
+```
+
+### 3. Read specification
+
+Read the issue body. Confirm it contains:
+- Description
+- Root cause
+- Recommended fix
+- Test plan
+
+If any section is missing or unclear, stop and ask Mark.
+
+### 4. Implement
+
+#### 4a. Test first
+
+Write or extend the test that reproduces the issue. Watch it fail (red). Then implement the fix (green). Then refactor if needed.
+
+If the issue is a CI/configuration change with no testable code path, skip this step and note the reason in the commit message.
+
+#### 4b. Code
+
+Follow the Recommended fix section. If the implementation deviates from the spec, note the deviation and the reason before proceeding.
+
+#### 4c. Documentation
+
+Update any documentation affected by the change. Do not rely on memory — use the checklist below. If a file in the left column changes, the corresponding doc on the right must be reviewed (and updated if the feature, behaviour, or build steps are new or changed).
+
+| Source files changed | Doc to check |
+|---|---|
+| `vite.config.ts`, `package.json` (deps, scripts, build plugins) | `doc/BUILD.md` |
+| New or changed user-facing feature | `README.md` |
+| CI workflow files (`.github/workflows/`) | `doc/CI.md` |
+| `AGENTS.md`, `.kimi/methods/` | `AGENTS.md` (self-documenting) |
+| `src/ts/config.ts`, behaviour changes | `doc/notes/` if a note exists |
+| Any issue or spec explicitly references a `doc/` file | That file |
+
+Also check:
+- `AGENTS.md` if agent instructions change
+- Workflow descriptions in `doc/CI.md` if CI changes
+
+If no docs need updating, state "No doc changes required" in the PR description so the reviewer knows the checklist was run.
+
+#### 4d. Version bump
+
+If the PR contains user-facing changes, bump the version in `package.json` before committing:
+- `feature:` → increment the minor version (e.g. `2.5.0` → `2.6.0`)
+- `fix:` → increment the patch version (e.g. `2.5.0` → `2.5.1`)
+
+Internal changes (`build:`, `ci:`, `docs:`, `refactor:`, `test:`) do not need a version bump.
+
+Include the version bump in the same PR so the build artifacts carry the correct version and Mark can review the change.
+
+### 5. Verify locally
+
+```console
+pnpm run check
+pnpm test
+```
+
+- `pnpm test` runs unit tests and integration tests. Both must pass.
+- `pnpm run check` runs lint, format check, type check, unused-export check, and dependency checks. All must pass.
+
+If the change touches CI workflows and cannot be tested locally, skip `npm test` and note the reason. The linting check (`npm run check`) must still pass for any code change.
+
+#### 5a. Check for new warnings
+
+`npm run check` includes tools that report warnings while still exiting 0 (e.g. `depcruise`). A pre-existing warning baseline creates a blind spot for new ones.
+
+Before committing, run:
+
+```console
+git stash -u
+pnpm run check > /tmp/check-main.log 2>&1
+git stash pop
+pnpm run check > /tmp/check-branch.log 2>&1
+diff /tmp/check-main.log /tmp/check-branch.log
+```
+
+If the diff shows **new** warnings, fix them before pushing. If a new warning is unavoidable and intentional (e.g. a temporary orphan during a refactor), note it in the PR description with the reason.
+
+The current known baseline on main (do not reproduce):
+- `depcruise`: `warn no-orphans: src/ts/escapeHtml.ts`
+
+### 6. Commit and push
+
+```console
+git add -A
+git commit -m "<type>: <description> (#NNN)"
+git push -u origin issue-NNN-short-description
+```
+
+Commit message format:
+- Subject: `<type>: <description> (#NNN)`
+- Body: include `Fixes #NNN` for each issue so GitHub auto-closes on merge
+
+For multiple issues in one commit:
+```text
+<type>: <description> (#NNN, #MMM)
+
+Fixes #NNN
+Fixes #MMM
+```
+
+Type prefixes:
+- `fix:` — bug fix
+- `feature:` — new capability
+- `docs:` — documentation
+- `test:` — tests
+- `refactor:` — code restructuring
+- `build:` — build system or tooling
+
+**Never push direct to `main`.** All coding work goes through a branch and PR. The only exception is a trivial one-line fix that Mark explicitly approves in advance. If Mark says "push" or "commit" without mentioning a branch, stop and confirm whether to create a PR or push to main.
+
+**Why `Fixes` matters:** GitHub only auto-closes issues when a commit on the default branch (or a merged PR description) contains a closing keyword (`Fixes`, `Closes`, `Resolves`) directly before the issue number. A bare `(#NNN)` reference or a bullet like `- #NNN` is not enough.
+
+### 7. Open pull request and move issue to Review
+
+Create a PR to `main`. Include `Fixes #NNN` in the description.
+
+Immediately move the issue to **Review** on the board. This transition is not optional — it signals that the code is in review and awaiting merge.
+
+```console
+node .kimi/scripts/gh-helper.mjs status <issue-number> review
+```
+
+### 8. Monitor CI
+
+Wait for the PR CI checks to complete. Report:
+- `test` job result
+- `integration` job result
+- `deploy-preview` result (if applicable)
+
+If any check fails, report the failure and do not merge.
+
+### 9. Request review and wait for explicit approval
+
+Present the PR to Mark. Include:
+- A summary of the changes
+- The PR link
+- CI status
+- The Netlify deploy preview link: `https://deploy-preview-<number>--spemplayer.netlify.app`
+
+**Do not merge until Mark explicitly approves.** This is the mandatory review checkpoint. If Mark requests changes, apply them, push, and return to this step.
+
+### 10. Merge
+
+**Only merge after Mark has explicitly approved the PR.** Use squash merge. The commit subject should reference the issue number.
+
+### 11. Close and move to Done
+
+If the issue was not auto-closed by the PR merge, close it with a comment referencing the PR. Then move it to **Done** on the board:
+
+```console
+node .kimi/scripts/gh-helper.mjs close <issue-number> "Closed by #<pr-number>."
+node .kimi/scripts/gh-helper.mjs status <issue-number> done
+```
+
+### 12. Tidy
+
+Delete the merged branch locally and remotely:
+
+```console
+git checkout main
+git pull
+git branch -d issue-NNN-short-description
+git push origin --delete issue-NNN-short-description
+```
+
+If the branch deletion fails because the remote branch does not exist (already deleted by GitHub settings), the local deletion still proceeds.
+
+## Responsibilities
+
+| Concern | Owner |
+|---------|-------|
+| Spec completeness | Fred (before Work method starts) |
+| Implementation | Bob (TDD discipline, scope adherence) |
+| Local verification | Agent (runs `pnpm run check` and `pnpm test` before every push) |
+| CI monitoring | Automated (daily resource report posts to Telegram). Mark reviews only on alert. |
+| Merge decision | Mark |
+| Board hygiene | Agent (status transitions on project board) |
+
+## When to abort
+
+Abort the method and return to Mark if:
+- The issue is not specified (no `specified` label).
+- The issue has unresolved dependencies.
+- `npm test` fails and the cause is not obvious after 10 minutes of investigation.
+- The spec's Recommended fix contradicts the codebase or requires architectural changes not mentioned in the spec.
+- Mark does not explicitly approve the PR after review.

--- a/.kimi/scripts/README.md
+++ b/.kimi/scripts/README.md
@@ -1,0 +1,40 @@
+# Kimi GitHub helper
+
+`gh-helper.mjs` wraps repetitive `gh` CLI and GitHub Projects v2 operations used by the methods in `.kimi/methods/`. It hardcodes the Spem Player project and board field IDs so method steps do not need to copy project IDs or option IDs by hand.
+
+## Usage
+
+```console
+node .kimi/scripts/gh-helper.mjs <command> [args]
+```
+
+## Commands
+
+| Command | Args | Description |
+|---|---|---|
+| `item-id` | `<issue>` | Print the project item ID for an issue. |
+| `status` | `<issue> <todo\|progress\|review\|done>` | Move an issue to a board status. |
+| `assign` | `<issue>` | Assign an issue to `@me`. |
+| `close` | `<issue> [comment]` | Close an issue with an optional comment. |
+| `pr-checks` | `<pr>` | Print PR merge state and checks as JSON. |
+| `set-field` | `<issue> <field> <option>` | Set a board field (`type`, `area`, `difficulty`, `category`). |
+| `issues` | `<author> [label]` | List issues by author, optionally filtered by label. |
+| `prs` | `<author>` | List PRs by author. |
+| `my-prs` |  | List your open PRs with review decisions. |
+
+## Examples
+
+```console
+node .kimi/scripts/gh-helper.mjs assign 558
+node .kimi/scripts/gh-helper.mjs status 558 progress
+node .kimi/scripts/gh-helper.mjs status 558 review
+node .kimi/scripts/gh-helper.mjs status 558 done
+node .kimi/scripts/gh-helper.mjs close 564 "Superseded by #581."
+node .kimi/scripts/gh-helper.mjs set-field 581 type tooling-bug
+node .kimi/scripts/gh-helper.mjs set-field 581 area tooling
+node .kimi/scripts/gh-helper.mjs set-field 581 difficulty s
+```
+
+## Updating hardcoded IDs
+
+If the GitHub project or board fields are recreated, update the constants at the top of `gh-helper.mjs`. Run `gh project field-list 2 --owner wainwmr --format json` to discover current field and option IDs.

--- a/.kimi/scripts/gh-helper.mjs
+++ b/.kimi/scripts/gh-helper.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+// Helper for repetitive GitHub / GitHub Projects v2 operations used by
+// .kimi/methods/*.md. Keeps method steps short and reduces token-heavy
+// JSON parsing in every call.
+
+import { spawnSync } from "node:child_process";
+
+// Spem Player project (hardcoded; update if the project is recreated).
+const PROJECT_ID = "PVT_kwHOAO5EQs4BWPwP";
+
+// Status field on the Spem Player board.
+const STATUS_FIELD_ID = "PVTSSF_lAHOAO5EQs4BWPwPzhRlmc0";
+const STATUS_OPTIONS = {
+  todo: "21bba6ec",
+  progress: "decd7b7a",
+  review: "78cbe887",
+  done: "15acbab0",
+};
+
+// Other single-select board fields.
+const FIELDS = {
+  type: {
+    id: "PVTSSF_lAHOAO5EQs4BWPwPzhRmSfo",
+    options: {
+      bug: "abd10006",
+      feature: "ac417643",
+      "tech-debt": "49557996",
+      "tooling-bug": "553de81d",
+    },
+  },
+  area: {
+    id: "PVTSSF_lAHOAO5EQs4BWPwPzhRmTE0",
+    options: {
+      ui: "da2dbe7b",
+      score: "14c794bf",
+      canvas: "cd60bce8",
+      lily: "efb6b053",
+      config: "d541f3a0",
+      test: "f2fe34f9",
+      tooling: "45abe58a",
+      controls: "be734de9",
+      docs: "c8b1b5f7",
+      audio: "9066c642",
+      other: "5e6a6679",
+    },
+  },
+  difficulty: {
+    id: "PVTSSF_lAHOAO5EQs4BWPwPzhRmTXA",
+    options: {
+      xs: "26242371",
+      s: "483084dd",
+      m: "6e1c1b4c",
+      l: "6db99d99",
+    },
+  },
+  category: {
+    id: "PVTSSF_lAHOAO5EQs4BWPwPzhTMxPs",
+    options: {
+      "a-in": "dc53efe6",
+      "a-sp": "2a7a9152",
+      "a-me": "743a3e63",
+      "a-out": "fb7a482f",
+      "a-yawn": "aa456021",
+    },
+  },
+};
+
+function run(args, { capture = true, stdin = null } = {}) {
+  const result = spawnSync(args[0], args.slice(1), {
+    stdio: capture ? [stdin || "ignore", "pipe", "pipe"] : "inherit",
+    encoding: "utf-8",
+    shell: false,
+  });
+  if (result.status !== 0) {
+    const err = (result.stderr || "").trim() || (result.stdout || "").trim();
+    throw new Error(`${args.join(" ")} failed: ${err}`);
+  }
+  return capture ? (result.stdout || "").trim() : "";
+}
+
+async function getItemId(issue) {
+  const out = run([
+    "gh", "project", "item-list", "2",
+    "--owner", "wainwmr",
+    "--query", `#${issue}`,
+    "--format", "json",
+  ]);
+  const data = JSON.parse(out);
+  const item = data.items?.[0];
+  if (!item?.id) {
+    throw new Error(`No board item found for issue #${issue}`);
+  }
+  return item.id;
+}
+
+async function setStatus(issue, statusName) {
+  const optionId = STATUS_OPTIONS[statusName];
+  if (!optionId) {
+    throw new Error(
+      `Unknown status "${statusName}". Use one of: ${Object.keys(STATUS_OPTIONS).join(", ")}`
+    );
+  }
+  const itemId = await getItemId(issue);
+  run([
+    "gh", "project", "item-edit",
+    "--project-id", PROJECT_ID,
+    "--id", itemId,
+    "--field-id", STATUS_FIELD_ID,
+    "--single-select-option-id", optionId,
+  ]);
+  return itemId;
+}
+
+async function assignIssue(issue) {
+  run(["gh", "issue", "edit", String(issue), "--add-assignee", "@me"]);
+}
+
+async function closeIssue(issue, comment) {
+  const args = ["gh", "issue", "close", String(issue)];
+  if (comment) {
+    args.push("--comment", comment);
+  }
+  run(args);
+}
+
+async function prChecks(pr) {
+  const out = run([
+    "gh", "pr", "view", String(pr),
+    "--json", "mergeStateStatus,statusCheckRollup",
+  ]);
+  return JSON.parse(out);
+}
+
+async function listIssues({ author, label }) {
+  const args = [
+    "gh", "issue", "list",
+    "--repo", "wainwmr/spem-player",
+    "--author", author,
+    "--state", "all",
+    "--limit", "10",
+  ];
+  if (label) {
+    args.push("--label", label);
+  }
+  console.log(run(args));
+}
+
+async function listPrs({ author }) {
+  console.log(run([
+    "gh", "pr", "list",
+    "--repo", "wainwmr/spem-player",
+    "--author", author,
+    "--state", "all",
+    "--limit", "10",
+  ]));
+}
+
+async function myOpenPrs() {
+  const out = run([
+    "gh", "pr", "list",
+    "--repo", "wainwmr/spem-player",
+    "--state", "open",
+    "--author", "@me",
+    "--json", "number,title,reviewDecision",
+  ]);
+  console.log(out);
+}
+
+async function setField(issue, fieldName, optionName) {
+  const field = FIELDS[fieldName];
+  if (!field) {
+    throw new Error(
+      `Unknown field "${fieldName}". Use one of: ${Object.keys(FIELDS).join(", ")}`
+    );
+  }
+  const optionId = field.options[optionName];
+  if (!optionId) {
+    throw new Error(
+      `Unknown ${fieldName} option "${optionName}". Use one of: ${Object.keys(field.options).join(", ")}`
+    );
+  }
+  const itemId = await getItemId(issue);
+  run([
+    "gh", "project", "item-edit",
+    "--project-id", PROJECT_ID,
+    "--id", itemId,
+    "--field-id", field.id,
+    "--single-select-option-id", optionId,
+  ]);
+  console.log(`#${issue} ${fieldName} → ${optionName}`);
+}
+
+async function help() {
+  console.log(`Usage: node .kimi/scripts/gh-helper.mjs <command> [args]
+
+Commands:
+  item-id <issue>                 Print the project item ID for an issue.
+  status <issue> <name>           Move issue to status: todo, progress, review, done.
+  assign <issue>                  Assign issue to @me.
+  close <issue> [comment]         Close issue with optional comment.
+  pr-checks <pr>                  Print PR merge state and checks as JSON.
+  set-field <issue> <field> <opt> Set a board field (type/area/difficulty/category).
+  issues <author> [label]         List issues by author, optionally filtered by label.
+  prs <author>                    List PRs by author.
+  my-prs                          List your open PRs with review decisions.
+
+Examples:
+  node .kimi/scripts/gh-helper.mjs item-id 558
+  node .kimi/scripts/gh-helper.mjs status 558 review
+  node .kimi/scripts/gh-helper.mjs close 564 "Superseded by #581."
+  node .kimi/scripts/gh-helper.mjs set-field 581 type tooling-bug
+  node .kimi/scripts/gh-helper.mjs issues wainwright1000 question
+`);
+}
+
+const commands = {
+  "item-id": async (issue) => console.log(await getItemId(issue)),
+  status: async (issue, statusName) => {
+    await setStatus(issue, statusName);
+    console.log(`#${issue} → ${statusName}`);
+  },
+  assign: async (issue) => {
+    await assignIssue(issue);
+    console.log(`#${issue} assigned to @me`);
+  },
+  close: async (issue, ...commentParts) => {
+    await closeIssue(issue, commentParts.join(" ") || undefined);
+    console.log(`#${issue} closed`);
+  },
+  "pr-checks": async (pr) => console.log(JSON.stringify(await prChecks(pr), null, 2)),
+  "set-field": async (issue, fieldName, optionName) => setField(issue, fieldName, optionName),
+  issues: async (author, label) => listIssues({ author, label }),
+  prs: async (author) => listPrs({ author }),
+  "my-prs": async () => myOpenPrs(),
+  help,
+};
+
+const [cmd, ...args] = process.argv.slice(2);
+const handler = commands[cmd] || help;
+handler(...args).catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,7 +50,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['.github/scripts/**/*.mjs', 'scripts/**/*.mjs'],
+    files: ['.github/scripts/**/*.mjs', 'scripts/**/*.mjs', '.kimi/scripts/**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',


### PR DESCRIPTION
## Summary

Add a small Node helper script that wraps the repetitive `gh` CLI and GitHub Projects v2 operations used by the Kimi methods. The script hardcodes the Spem Player project and board field IDs so method steps no longer need hand-copied option IDs or jq pipelines.

## Changes

- **New:** `.kimi/scripts/gh-helper.mjs`
  - `item-id`, `status`, `assign`, `close`, `pr-checks`, `set-field`, `issues`, `prs`, `my-prs`
- **New:** `.kimi/scripts/README.md` — usage documentation
- **Updated:** `.kimi/methods/work.md` — use helper for assign/status transitions
- **Updated:** `.kimi/methods/specify.md` — use helper for board field population
- **Updated:** `.kimi/methods/andrew.md` — use helper for issue/PR listing
- **Updated:** `.gitignore` — unignore `.kimi/methods/` and `.kimi/scripts/` so agent tooling is tracked
- **Updated:** `eslint.config.js` — lint `.kimi/scripts/**/*.mjs` with node globals

## Commands covered

```console
node .kimi/scripts/gh-helper.mjs assign <issue>
node .kimi/scripts/gh-helper.mjs status <issue> progress
node .kimi/scripts/gh-helper.mjs status <issue> review
node .kimi/scripts/gh-helper.mjs status <issue> done
node .kimi/scripts/gh-helper.mjs set-field <issue> type <bug|feature|tech-debt|tooling-bug>
node .kimi/scripts/gh-helper.mjs set-field <issue> area <ui|score|...|tooling|...>
node .kimi/scripts/gh-helper.mjs set-field <issue> difficulty <xs|s|m|l>
node .kimi/scripts/gh-helper.mjs issues wainwright1000 question
node .kimi/scripts/gh-helper.mjs my-prs
```

## Verification

- `pnpm run check`: all clean
- `node .kimi/scripts/gh-helper.mjs item-id 558` returns the correct project item ID
- `node .kimi/scripts/gh-helper.mjs pr-checks 582` returns PR check status JSON
- `node .kimi/scripts/gh-helper.mjs status 558 done` moves the issue successfully

## Future scriptification opportunities

- PR creation + branch push could be folded into a single `gh-helper pr-create <issue>` command.
- CI monitoring (`gh pr checks --watch`) could become `gh-helper pr-wait <pr>`.
- Issue creation from a specification file could become `gh-helper issue-create --spec-file path.md`.
