### PR TITLE
ci: separate monitor-resources tests into dedicated workflow (#581)

### DIFF
--- a/.github/workflows/monitor-resources-test.yml
+++ b/.github/workflows/monitor-resources-test.yml
@@ -1,0 +1,25 @@
+name: Monitor Resources Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/monitor-resources.mjs"
+      - ".github/scripts/monitor-resources.test.mjs"
+      - ".github/workflows/monitor-resources-test.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/scripts/monitor-resources.mjs"
+      - ".github/scripts/monitor-resources.test.mjs"
+      - ".github/workflows/monitor-resources-test.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+      - run: node --test .github/scripts/monitor-resources.test.mjs

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -107,6 +107,18 @@ Steps:
 
 The script queries the current period's Netlify build-minute usage and GitHub Actions usage. Status thresholds — watch (≥ 50%), throttle (≥ 75%), and critical (≥ 90%) — apply to the higher of actual usage and the linearly projected end-of-period usage, so an unsustainable burn rate raises the alarm early in the billing period. On days with no PRs merged in the past 24 hours and both actual and projected usage below the watch threshold (50%), the Telegram message is skipped to reduce noise; watch and worse always send regardless of PR activity. When the message is sent, it takes the form `Netlify <n>% · GitHub <n>% — <status>` (the percentages are actual usage; the status reflects the worse of actual and projected), appending `· N PR(s) merged` when at least one PR merged in the past 24 hours. If either service reaches, or is projected to reach by period end, **90%** of its quota, the status becomes `STOP` (with a 🚨 prefix) and the workflow opens a critical GitHub issue containing a runbook for reducing build-minute consumption.
 
+### `monitor-resources-test.yml`
+
+Triggers on push to `main` and on `pull_request`, both path-filtered to the monitor script, its test file, and this workflow file. This is a separate, optional build for repository infrastructure: it runs only the monitor's `node:test` suite and does not install application dependencies or run the Spem Player build. It keeps the monitor's tests out of the main `ci.yml` gate while ensuring monitor changes are exercised before merge.
+
+Steps:
+
+- `actions/checkout@v6` — checkout the repository.
+- `actions/setup-node@v6` from `.nvmrc` — install Node.js.
+- `node --test .github/scripts/monitor-resources.test.mjs` — run the monitor tests.
+
+Run locally with `pnpm run test:monitor`.
+
 ## Node.js Version
 
 The Node.js version is pinned in `.nvmrc`. All GitHub Actions workflows read this file via `node-version-file` in `actions/setup-node`. Netlify should be configured to use the same version.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test": "vitest run",
     "test:unit": "vitest run --exclude \"lilypond/test/*.integration.test.ts\"",
     "test:lilypond": "vitest run lilypond/test/*.integration.test.ts",
+    "test:monitor": "node --test .github/scripts/monitor-resources.test.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "e2e": "playwright test",


### PR DESCRIPTION
Fixes #581

## Summary

Create a dedicated, path-filtered workflow for the monitor-resources tests so they run independently of the main Spem Player CI gate. This keeps `ci.yml` minimal and application-focused while ensuring monitor changes are exercised before merge.

## Changes

- `.github/workflows/monitor-resources-test.yml`: new workflow triggered only by changes to the monitor script, its test file, or the workflow itself.
- `package.json`: add `test:monitor` script for local execution.
- `doc/CI.md`: document the new workflow.

## Verification

- `pnpm run check`: all clean
- `pnpm run test:monitor`: 34 tests passed
- YAML validated with Python

## Doc changes

`doc/CI.md` updated with a new `monitor-resources-test.yml` section.
