### PR TITLE
feature: daily build-resource series logging + current-period backfill seed (#566)

### DIFF
--- a/.github/monitor-series.json
+++ b/.github/monitor-series.json
@@ -13,62 +13,62 @@
   },
   {
     "date": "2026-06-03",
-    "netlifyCurrent": 21,
+    "netlifyCurrent": 7,
     "githubMinutes": 315,
     "source": "backfill"
   },
   {
     "date": "2026-06-04",
-    "netlifyCurrent": 21,
+    "netlifyCurrent": 14,
     "githubMinutes": 337,
     "source": "backfill"
   },
   {
     "date": "2026-06-05",
-    "netlifyCurrent": 0,
+    "netlifyCurrent": 14,
     "githubMinutes": 343,
     "source": "backfill"
   },
   {
     "date": "2026-06-06",
-    "netlifyCurrent": 24,
+    "netlifyCurrent": 22,
     "githubMinutes": 362,
     "source": "backfill"
   },
   {
     "date": "2026-06-07",
-    "netlifyCurrent": 6,
+    "netlifyCurrent": 24,
     "githubMinutes": 371,
     "source": "backfill"
   },
   {
     "date": "2026-06-08",
-    "netlifyCurrent": 45,
+    "netlifyCurrent": 39,
     "githubMinutes": 412,
     "source": "backfill"
   },
   {
     "date": "2026-06-09",
-    "netlifyCurrent": 27,
+    "netlifyCurrent": 48,
     "githubMinutes": 439,
     "source": "backfill"
   },
   {
     "date": "2026-06-10",
-    "netlifyCurrent": 54,
+    "netlifyCurrent": 66,
     "githubMinutes": 486,
     "source": "backfill"
   },
   {
     "date": "2026-06-11",
-    "netlifyCurrent": 45,
+    "netlifyCurrent": 81,
     "githubMinutes": 545,
     "source": "backfill"
   },
   {
     "date": "2026-06-12",
-    "netlifyCurrent": 21,
-    "githubMinutes": 577,
+    "netlifyCurrent": 88,
+    "githubMinutes": 580,
     "source": "backfill"
   }
 ]

--- a/.github/monitor-series.json
+++ b/.github/monitor-series.json
@@ -1,0 +1,74 @@
+[
+  {
+    "date": "2026-06-01",
+    "netlifyCurrent": 0,
+    "githubMinutes": 104,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-02",
+    "netlifyCurrent": 0,
+    "githubMinutes": 205,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-03",
+    "netlifyCurrent": 21,
+    "githubMinutes": 315,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-04",
+    "netlifyCurrent": 21,
+    "githubMinutes": 337,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-05",
+    "netlifyCurrent": 0,
+    "githubMinutes": 343,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-06",
+    "netlifyCurrent": 24,
+    "githubMinutes": 362,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-07",
+    "netlifyCurrent": 6,
+    "githubMinutes": 371,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-08",
+    "netlifyCurrent": 45,
+    "githubMinutes": 412,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-09",
+    "netlifyCurrent": 27,
+    "githubMinutes": 439,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-10",
+    "netlifyCurrent": 54,
+    "githubMinutes": 486,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-11",
+    "netlifyCurrent": 45,
+    "githubMinutes": 545,
+    "source": "backfill"
+  },
+  {
+    "date": "2026-06-12",
+    "netlifyCurrent": 21,
+    "githubMinutes": 577,
+    "source": "backfill"
+  }
+]

--- a/.github/scripts/monitor-resources.mjs
+++ b/.github/scripts/monitor-resources.mjs
@@ -66,9 +66,9 @@ export function projectedPct(current, daysElapsed, daysInPeriod) {
  */
 
 /**
- * @typedef {object} NetlifyPercentage
+ * @typedef {object} NetlifyDailyMinutes
  * @property {string} date - ISO date (YYYY-MM-DD).
- * @property {number} pct - Reported usage percentage (0-100).
+ * @property {number} minutes - Netlify build minutes used on this day.
  */
 
 /**
@@ -552,19 +552,20 @@ export function githubRunsToDailySeries(runs, periodStartDate, periodEndDate) {
 }
 
 /**
- * Convert Telegram-reported Netlify percentages into backfill series entries.
- * `netlifyCurrent` is rounded from the percentage and the period limit
+ * Convert daily Netlify build minutes into cumulative backfill series entries.
+ * `netlifyCurrent` is the running total of minutes consumed up to and
+ * including each date, matching the shape returned by the Netlify API
  * (Vera 566-04).
  *
- * @param {NetlifyPercentage[]} percentages
- * @param {number} limit - Netlify build-minute quota for the period.
+ * @param {NetlifyDailyMinutes[]} dailyMinutes
  * @returns {{date: string, netlifyCurrent: number}[]}
  */
-export function netlifyPercentagesToBackfill(percentages, limit) {
-  return percentages.map(({ date, pct }) => ({
-    date,
-    netlifyCurrent: Math.round((pct / 100) * limit),
-  }));
+export function netlifyDailyMinutesToBackfill(dailyMinutes) {
+  let cumulative = 0;
+  return dailyMinutes.map(({ date, minutes }) => {
+    cumulative += minutes;
+    return { date, netlifyCurrent: cumulative };
+  });
 }
 
 /**
@@ -607,14 +608,13 @@ export function buildBackfillSeries(githubSeries, netlifySeries) {
  * netlifyCurrent values, and writes the result to the series file. Existing
  * logged dates are preserved; only missing dates are seeded (Vera 566-04).
  *
- * @param {NetlifyPercentage[]} netlifyPercentages - Dated Telegram percentages.
+ * @param {NetlifyDailyMinutes[]} netlifyDailyMinutes - Dated Netlify daily minutes.
  * @param {string} [filePath] - Optional override for the series file path.
  */
 export async function seedBackfillSeries(
-  netlifyPercentages,
+  netlifyDailyMinutes,
   filePath = SERIES_FILE
 ) {
-  const netlify = await getNetlifyUsage();
   const runs = await getGitHubRuns();
   const githubUsage = await getGitHubUsage(runs);
 
@@ -623,10 +623,7 @@ export async function seedBackfillSeries(
     githubUsage.periodStartDate,
     githubUsage.periodEndDate
   );
-  const netlifySeries = netlifyPercentagesToBackfill(
-    netlifyPercentages,
-    netlify.limit
-  );
+  const netlifySeries = netlifyDailyMinutesToBackfill(netlifyDailyMinutes);
   const backfill = buildBackfillSeries(githubSeries, netlifySeries);
 
   const existing = loadSeries(filePath);

--- a/.github/scripts/monitor-resources.mjs
+++ b/.github/scripts/monitor-resources.mjs
@@ -25,11 +25,13 @@
  */
 
 import { fileURLToPath } from "url";
-import { realpathSync } from "fs";
+import { realpathSync, readFileSync, writeFileSync, existsSync } from "fs";
+import { resolve } from "path";
 
 const NETLIFY_API = "https://api.netlify.com/api/v1";
 const TELEGRAM_API = "https://api.telegram.org/bot";
 const WATCH_THRESHOLD_PCT = 50;
+const SERIES_FILE = ".github/monitor-series.json";
 
 /**
  * Project current usage to the end of the billing period using a linear
@@ -52,6 +54,21 @@ export function projectedPct(current, daysElapsed, daysInPeriod) {
  * @property {number} limit - Build-minute quota for the period.
  * @property {string} periodStartDate - Billing period start (YYYY-MM-DD).
  * @property {string} periodEndDate - Billing period end (YYYY-MM-DD).
+ */
+
+/**
+ * @typedef {object} SeriesEntry
+ * @property {string} date - ISO date (YYYY-MM-DD).
+ * @property {number|null} netlifyCurrent - Netlify build minutes consumed so
+ *   far, or `null` when the value is unknown for a backfilled day.
+ * @property {number} githubMinutes - GitHub Actions minutes consumed so far.
+ * @property {"logged"|"backfill"} source - Provenance of the entry.
+ */
+
+/**
+ * @typedef {object} NetlifyPercentage
+ * @property {string} date - ISO date (YYYY-MM-DD).
+ * @property {number} pct - Reported usage percentage (0-100).
  */
 
 /**
@@ -276,39 +293,55 @@ export function getReportingSince(nowMs = Date.now()) {
   return new Date(nowMs - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 }
 
-async function getGitHubUsage() {
+/**
+ * Fetch all workflow runs for the current calendar month, paginated.
+ *
+ * @returns {Promise<object[]>} Array of workflow run objects.
+ */
+async function getGitHubRuns() {
   const { owner, repo } = parseRepo();
   const now = new Date();
   const start = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
   ).toISOString();
-  const periodStartDate = start.slice(0, 10);
-  const periodEndDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0))
-    .toISOString()
-    .slice(0, 10);
 
-  let totalMs = 0;
+  const runs = [];
   let page = 1;
   while (true) {
     const data = await api(
       `https://api.github.com/repos/${owner}/${repo}/actions/runs?created=>=${start}&per_page=100&page=${page}`,
       { headers: { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } }
     );
-    const runs = data.workflow_runs || [];
-    if (runs.length === 0) break;
-
-    for (const run of runs) {
-      if (run.run_duration_ms) {
-        totalMs += run.run_duration_ms;
-      } else if (run.run_started_at && run.updated_at) {
-        const s = new Date(run.run_started_at).getTime();
-        const e = new Date(run.updated_at).getTime();
-        totalMs += Math.max(0, e - s);
-      }
-    }
-
-    if (runs.length < 100) break;
+    const pageRuns = data.workflow_runs || [];
+    if (pageRuns.length === 0) break;
+    runs.push(...pageRuns);
+    if (pageRuns.length < 100) break;
     page++;
+  }
+  return runs;
+}
+
+async function getGitHubUsage(preFetchedRuns) {
+  const now = new Date();
+  const periodStartDate = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
+  )
+    .toISOString()
+    .slice(0, 10);
+  const periodEndDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0))
+    .toISOString()
+    .slice(0, 10);
+
+  const runs = preFetchedRuns ?? (await getGitHubRuns());
+  let totalMs = 0;
+  for (const run of runs) {
+    if (run.run_duration_ms) {
+      totalMs += run.run_duration_ms;
+    } else if (run.run_started_at && run.updated_at) {
+      const s = new Date(run.run_started_at).getTime();
+      const e = new Date(run.updated_at).getTime();
+      totalMs += Math.max(0, e - s);
+    }
   }
 
   return {
@@ -378,6 +411,236 @@ export function daysInPeriod(startStr, endStr) {
   return Math.floor((endUtc - startUtc) / msPerDay) + 1;
 }
 
+/**
+ * Return today's date as `YYYY-MM-DD` in UTC.
+ *
+ * @param {Date} [now] - Reference date; defaults to `new Date()`.
+ * @returns {string}
+ */
+export function todayISO(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
+/**
+ * Read the daily resource series from `filePath`. Missing or empty files
+ * return a fresh array; malformed JSON throws so history is never silently
+ * reset (Vera 566-01).
+ *
+ * @param {string} [filePath] - Path to the series JSON file; defaults to
+ *   `.github/monitor-series.json` relative to the repository root.
+ * @returns {SeriesEntry[]}
+ * @throws {Error} If the file exists, is non-empty, and is not valid JSON or
+ *   is not an array.
+ */
+export function loadSeries(filePath = SERIES_FILE) {
+  const resolved = resolve(filePath);
+  if (!existsSync(resolved)) {
+    return [];
+  }
+  const raw = readFileSync(resolved, "utf8").trim();
+  if (raw === "") {
+    return [];
+  }
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`series file ${filePath} must contain a JSON array`);
+  }
+  return parsed;
+}
+
+/**
+ * Write the daily resource series to `filePath` as formatted JSON.
+ *
+ * @param {SeriesEntry[]} series
+ * @param {string} [filePath] - Path to the series JSON file; defaults to
+ *   `.github/monitor-series.json` relative to the repository root.
+ */
+export function saveSeries(series, filePath = SERIES_FILE) {
+  const resolved = resolve(filePath);
+  writeFileSync(resolved, JSON.stringify(series, null, 2) + "\n", "utf8");
+}
+
+/**
+ * Return a new series where `entry` replaces any existing entry with the
+ * same date, or is appended if the date is new. The series is kept sorted
+ * by date (Vera 566-01).
+ *
+ * @param {SeriesEntry[]} series
+ * @param {SeriesEntry} entry
+ * @returns {SeriesEntry[]}
+ */
+export function appendOrReplaceDay(series, entry) {
+  const idx = series.findIndex((item) => item.date === entry.date);
+  const next = idx === -1 ? [...series, entry] : series.with(idx, entry);
+  return next.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Build a logged entry from the already-fetched usage records.
+ *
+ * @param {string} date - ISO date string (YYYY-MM-DD).
+ * @param {UsageRecord} netlify
+ * @param {UsageRecord} github
+ * @returns {SeriesEntry}
+ */
+export function buildLoggedEntry(date, netlify, github) {
+  return {
+    date,
+    netlifyCurrent: netlify.current,
+    githubMinutes: github.current,
+    source: "logged",
+  };
+}
+
+/**
+ * Back-calculate GitHub cumulative minutes per day from workflow runs.
+ * Returns one entry per calendar day from `periodStartDate` to
+ * `periodEndDate` inclusive, with `githubMinutes` being the cumulative total
+ * of all runs whose `run_started_at` falls on or before that day. Days with
+ * no runs carry forward the previous cumulative value so the line is
+ * continuous (Vera 566-04).
+ *
+ * @param {object[]} runs - GitHub Actions workflow runs.
+ * @param {string} runs[].run_started_at - ISO timestamp.
+ * @param {number} runs[].run_duration_ms - Run duration in milliseconds.
+ * @param {string} periodStartDate - ISO date (YYYY-MM-DD).
+ * @param {string} periodEndDate - ISO date (YYYY-MM-DD).
+ * @returns {{date: string, githubMinutes: number}[]}
+ */
+export function githubRunsToDailySeries(runs, periodStartDate, periodEndDate) {
+  const start = new Date(periodStartDate);
+  const end = new Date(periodEndDate);
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const startUtc = Date.UTC(
+    start.getUTCFullYear(),
+    start.getUTCMonth(),
+    start.getUTCDate()
+  );
+  const endUtc = Date.UTC(
+    end.getUTCFullYear(),
+    end.getUTCMonth(),
+    end.getUTCDate()
+  );
+
+  /** @type {Map<string, number>} */
+  const dailyMinutes = new Map();
+  for (const run of runs) {
+    if (!run.run_started_at) continue;
+    const date = run.run_started_at.slice(0, 10);
+    const durationMs =
+      run.run_duration_ms ??
+      (run.updated_at
+        ? Math.max(
+            0,
+            new Date(run.updated_at).getTime() - new Date(run.run_started_at).getTime()
+          )
+        : 0);
+    dailyMinutes.set(
+      date,
+      (dailyMinutes.get(date) ?? 0) + durationMs / 60000
+    );
+  }
+
+  const result = [];
+  let cumulative = 0;
+  for (let t = startUtc; t <= endUtc; t += msPerDay) {
+    const date = new Date(t).toISOString().slice(0, 10);
+    cumulative += dailyMinutes.get(date) ?? 0;
+    result.push({ date, githubMinutes: Math.round(cumulative) });
+  }
+  return result;
+}
+
+/**
+ * Convert Telegram-reported Netlify percentages into backfill series entries.
+ * `netlifyCurrent` is rounded from the percentage and the period limit
+ * (Vera 566-04).
+ *
+ * @param {NetlifyPercentage[]} percentages
+ * @param {number} limit - Netlify build-minute quota for the period.
+ * @returns {{date: string, netlifyCurrent: number}[]}
+ */
+export function netlifyPercentagesToBackfill(percentages, limit) {
+  return percentages.map(({ date, pct }) => ({
+    date,
+    netlifyCurrent: Math.round((pct / 100) * limit),
+  }));
+}
+
+/**
+ * Combine GitHub and Netlify backfill data into a single series. Dates that
+ * appear in only one source keep the other value as `null` so the chart can
+ * render gaps rather than invent points (Vera 566-04).
+ *
+ * @param {{date: string, githubMinutes: number}[]} githubSeries
+ * @param {{date: string, netlifyCurrent: number}[]} netlifySeries
+ * @returns {SeriesEntry[]}
+ */
+export function buildBackfillSeries(githubSeries, netlifySeries) {
+  /** @type {Map<string, {githubMinutes?: number, netlifyCurrent?: number}>} */
+  const byDate = new Map();
+  for (const { date, githubMinutes } of githubSeries) {
+    const existing = byDate.get(date) ?? {};
+    existing.githubMinutes = githubMinutes;
+    byDate.set(date, existing);
+  }
+  for (const { date, netlifyCurrent } of netlifySeries) {
+    const existing = byDate.get(date) ?? {};
+    existing.netlifyCurrent = netlifyCurrent;
+    byDate.set(date, existing);
+  }
+
+  return Array.from(byDate.entries())
+    .map(([date, values]) => ({
+      date,
+      netlifyCurrent: values.netlifyCurrent ?? null,
+      githubMinutes: values.githubMinutes ?? 0,
+      source: "backfill",
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * One-shot backfill seed for the current billing window. Fetches current
+ * usage from the APIs, back-calculates GitHub cumulative minutes per day,
+ * converts the Telegram-reported Netlify percentages into approximate
+ * netlifyCurrent values, and writes the result to the series file. Existing
+ * logged dates are preserved; only missing dates are seeded (Vera 566-04).
+ *
+ * @param {NetlifyPercentage[]} netlifyPercentages - Dated Telegram percentages.
+ * @param {string} [filePath] - Optional override for the series file path.
+ */
+export async function seedBackfillSeries(
+  netlifyPercentages,
+  filePath = SERIES_FILE
+) {
+  const netlify = await getNetlifyUsage();
+  const runs = await getGitHubRuns();
+  const githubUsage = await getGitHubUsage(runs);
+
+  const githubSeries = githubRunsToDailySeries(
+    runs,
+    githubUsage.periodStartDate,
+    githubUsage.periodEndDate
+  );
+  const netlifySeries = netlifyPercentagesToBackfill(
+    netlifyPercentages,
+    netlify.limit
+  );
+  const backfill = buildBackfillSeries(githubSeries, netlifySeries);
+
+  const existing = loadSeries(filePath);
+  const existingDates = new Set(existing.map((entry) => entry.date));
+  const merged = [...existing];
+  for (const entry of backfill) {
+    if (!existingDates.has(entry.date)) {
+      merged.push(entry);
+    }
+  }
+
+  saveSeries(merged.sort((a, b) => a.date.localeCompare(b.date)), filePath);
+}
+
 async function main() {
   let netlify, github;
 
@@ -407,6 +670,16 @@ async function main() {
       );
     }
     throw e;
+  }
+
+  try {
+    const series = loadSeries();
+    const entry = buildLoggedEntry(todayISO(), netlify, github);
+    saveSeries(appendOrReplaceDay(series, entry));
+  } catch (e) {
+    // A series-file failure must not break the alert path, but it must be
+    // visible in the workflow log (Vera 566-02).
+    console.error(`Failed to update resource series: ${e.message}`);
   }
 
   const netlifyStatus = computeUsageStatus(netlify);

--- a/.github/scripts/monitor-resources.test.mjs
+++ b/.github/scripts/monitor-resources.test.mjs
@@ -1,5 +1,8 @@
-import { test, after } from "node:test";
+import { test, after, describe } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   projectedPct,
   computeUsageStatus,
@@ -11,6 +14,14 @@ import {
   formatMessage,
   getReportingSince,
   parseRepo,
+  todayISO,
+  loadSeries,
+  saveSeries,
+  appendOrReplaceDay,
+  buildLoggedEntry,
+  githubRunsToDailySeries,
+  netlifyPercentagesToBackfill,
+  buildBackfillSeries,
 } from "./monitor-resources.mjs";
 
 // projectedPct: linear burn-rate projection
@@ -287,4 +298,161 @@ test("parseRepo throws when GITHUB_REPOSITORY is empty string", () => {
     () => parseRepo(),
     /GITHUB_REPOSITORY must be owner\/repo format, got: /
   );
+});
+
+// todayISO: returns UTC calendar date
+test("todayISO returns YYYY-MM-DD from a UTC timestamp", () => {
+  assert.equal(todayISO(new Date("2026-06-12T14:23:00Z")), "2026-06-12");
+});
+
+describe("loadSeries / saveSeries", () => {
+  let tmpDir;
+  after(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("loadSeries returns empty array for missing file", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "monitor-series-"));
+    const result = loadSeries(join(tmpDir, "does-not-exist.json"));
+    assert.deepEqual(result, []);
+  });
+
+  test("loadSeries returns empty array for empty file", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "monitor-series-"));
+    const path = join(tmpDir, "empty.json");
+    writeFileSync(path, "", "utf8");
+    const result = loadSeries(path);
+    assert.deepEqual(result, []);
+  });
+
+  test("loadSeries throws on malformed JSON", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "monitor-series-"));
+    const path = join(tmpDir, "bad.json");
+    writeFileSync(path, "not json", "utf8");
+    assert.throws(() => loadSeries(path), /Unexpected token/);
+  });
+
+  test("loadSeries throws on non-array JSON", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "monitor-series-"));
+    const path = join(tmpDir, "object.json");
+    writeFileSync(path, JSON.stringify({ foo: 1 }), "utf8");
+    assert.throws(() => loadSeries(path), /must contain a JSON array/);
+  });
+
+  test("saveSeries round-trips through loadSeries", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "monitor-series-"));
+    const path = join(tmpDir, "series.json");
+    const series = [
+      { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" },
+    ];
+    saveSeries(series, path);
+    const loaded = loadSeries(path);
+    assert.deepEqual(loaded, series);
+  });
+});
+
+// appendOrReplaceDay: idempotent per date and sorted
+test("appendOrReplaceDay appends a new date", () => {
+  const series = [
+    { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" },
+  ];
+  const entry = { date: "2026-06-11", netlifyCurrent: 15, githubMinutes: 25, source: "logged" };
+  const result = appendOrReplaceDay(series, entry);
+  assert.equal(result.length, 2);
+  assert.equal(result[1].date, "2026-06-11");
+});
+
+test("appendOrReplaceDay replaces an existing date", () => {
+  const series = [
+    { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" },
+  ];
+  const entry = { date: "2026-06-10", netlifyCurrent: 99, githubMinutes: 99, source: "logged" };
+  const result = appendOrReplaceDay(series, entry);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].netlifyCurrent, 99);
+});
+
+test("appendOrReplaceDay keeps series sorted", () => {
+  const series = [
+    { date: "2026-06-12", netlifyCurrent: 12, githubMinutes: 22, source: "logged" },
+  ];
+  const entry = { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" };
+  const result = appendOrReplaceDay(series, entry);
+  assert.equal(result[0].date, "2026-06-10");
+  assert.equal(result[1].date, "2026-06-12");
+});
+
+// buildLoggedEntry: shapes a logged entry from usage records
+test("buildLoggedEntry uses current values and source logged", () => {
+  const netlify = { current: 30, limit: 300, periodStartDate: "2026-06-12", periodEndDate: "2026-07-11" };
+  const github = { current: 120, limit: 2000, periodStartDate: "2026-06-01", periodEndDate: "2026-06-30" };
+  const entry = buildLoggedEntry("2026-06-12", netlify, github);
+  assert.deepEqual(entry, {
+    date: "2026-06-12",
+    netlifyCurrent: 30,
+    githubMinutes: 120,
+    source: "logged",
+  });
+});
+
+// githubRunsToDailySeries: cumulative minutes per day
+test("githubRunsToDailySeries cumulates runs per day", () => {
+  const runs = [
+    { run_started_at: "2026-06-01T08:00:00Z", run_duration_ms: 60000 },
+    { run_started_at: "2026-06-01T09:00:00Z", run_duration_ms: 120000 },
+    { run_started_at: "2026-06-03T10:00:00Z", run_duration_ms: 180000 },
+  ];
+  const result = githubRunsToDailySeries(runs, "2026-06-01", "2026-06-04");
+  assert.deepEqual(result, [
+    { date: "2026-06-01", githubMinutes: 3 },
+    { date: "2026-06-02", githubMinutes: 3 },
+    { date: "2026-06-03", githubMinutes: 6 },
+    { date: "2026-06-04", githubMinutes: 6 },
+  ]);
+});
+
+test("githubRunsToDailySeries falls back to updated_at when duration missing", () => {
+  const runs = [
+    {
+      run_started_at: "2026-06-02T10:00:00Z",
+      updated_at: "2026-06-02T10:05:30Z",
+    },
+  ];
+  const result = githubRunsToDailySeries(runs, "2026-06-02", "2026-06-02");
+  assert.deepEqual(result, [{ date: "2026-06-02", githubMinutes: 6 }]);
+});
+
+test("githubRunsToDailySeries ignores runs with missing run_started_at", () => {
+  const runs = [{ run_duration_ms: 60000 }];
+  const result = githubRunsToDailySeries(runs, "2026-06-01", "2026-06-01");
+  assert.deepEqual(result, [{ date: "2026-06-01", githubMinutes: 0 }]);
+});
+
+// netlifyPercentagesToBackfill
+test("netlifyPercentagesToBackfill converts percentages to minutes", () => {
+  const percentages = [
+    { date: "2026-06-12", pct: 10 },
+    { date: "2026-06-13", pct: 23 },
+  ];
+  const result = netlifyPercentagesToBackfill(percentages, 300);
+  assert.deepEqual(result, [
+    { date: "2026-06-12", netlifyCurrent: 30 },
+    { date: "2026-06-13", netlifyCurrent: 69 },
+  ]);
+});
+
+// buildBackfillSeries: merges GitHub and Netlify backfill data
+test("buildBackfillSeries combines both sources on matching dates", () => {
+  const github = [
+    { date: "2026-06-12", githubMinutes: 100 },
+    { date: "2026-06-13", githubMinutes: 120 },
+  ];
+  const netlify = [
+    { date: "2026-06-12", netlifyCurrent: 30 },
+  ];
+  const result = buildBackfillSeries(github, netlify);
+  assert.deepEqual(result, [
+    { date: "2026-06-12", netlifyCurrent: 30, githubMinutes: 100, source: "backfill" },
+    { date: "2026-06-13", netlifyCurrent: null, githubMinutes: 120, source: "backfill" },
+  ]);
 });

--- a/.github/scripts/monitor-resources.test.mjs
+++ b/.github/scripts/monitor-resources.test.mjs
@@ -20,7 +20,7 @@ import {
   appendOrReplaceDay,
   buildLoggedEntry,
   githubRunsToDailySeries,
-  netlifyPercentagesToBackfill,
+  netlifyDailyMinutesToBackfill,
   buildBackfillSeries,
 } from "./monitor-resources.mjs";
 
@@ -428,16 +428,18 @@ test("githubRunsToDailySeries ignores runs with missing run_started_at", () => {
   assert.deepEqual(result, [{ date: "2026-06-01", githubMinutes: 0 }]);
 });
 
-// netlifyPercentagesToBackfill
-test("netlifyPercentagesToBackfill converts percentages to minutes", () => {
-  const percentages = [
-    { date: "2026-06-12", pct: 10 },
-    { date: "2026-06-13", pct: 23 },
+// netlifyDailyMinutesToBackfill
+test("netlifyDailyMinutesToBackfill cumulates daily minutes", () => {
+  const dailyMinutes = [
+    { date: "2026-06-12", minutes: 10 },
+    { date: "2026-06-13", minutes: 23 },
+    { date: "2026-06-14", minutes: 0 },
   ];
-  const result = netlifyPercentagesToBackfill(percentages, 300);
+  const result = netlifyDailyMinutesToBackfill(dailyMinutes);
   assert.deepEqual(result, [
-    { date: "2026-06-12", netlifyCurrent: 30 },
-    { date: "2026-06-13", netlifyCurrent: 69 },
+    { date: "2026-06-12", netlifyCurrent: 10 },
+    { date: "2026-06-13", netlifyCurrent: 33 },
+    { date: "2026-06-14", netlifyCurrent: 33 },
   ]);
 });
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - "*.md"
       - "lilypond/src/**"
       - "lilypond/build/**"
+      - ".github/scripts/monitor-resources.mjs"
+      - ".github/scripts/monitor-resources.test.mjs"
       - ".github/workflows/lilypond.yml"
       - ".github/workflows/e2e.yml"
       - ".github/workflows/monitor-resources.yml"
@@ -16,6 +18,8 @@ on:
       - "*.md"
       - "lilypond/src/**"
       - "lilypond/build/**"
+      - ".github/scripts/monitor-resources.mjs"
+      - ".github/scripts/monitor-resources.test.mjs"
       - ".github/workflows/lilypond.yml"
       - ".github/workflows/e2e.yml"
       - ".github/workflows/monitor-resources.yml"
@@ -42,7 +46,7 @@ jobs:
             echo "app=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qvE '^([^/]*\.md$|lilypond/src/|lilypond/build/|\.github/workflows/lilypond\.yml$|\.github/workflows/e2e\.yml$|\.github/workflows/monitor-resources\.yml$)'; then
+          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qvE '^([^/]*\.md$|lilypond/src/|lilypond/build/|\.github/scripts/monitor-resources\.mjs$|\.github/scripts/monitor-resources\.test\.mjs$|\.github/workflows/lilypond\.yml$|\.github/workflows/e2e\.yml$|\.github/workflows/monitor-resources\.yml$)'; then
             echo "app=true" >> "$GITHUB_OUTPUT"
           else
             echo "app=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - "*.md"
       - "lilypond/src/**"
       - "lilypond/build/**"
+      - ".github/monitor-series.json"
       - ".github/scripts/monitor-resources.mjs"
       - ".github/scripts/monitor-resources.test.mjs"
       - ".github/workflows/lilypond.yml"
@@ -18,6 +19,7 @@ on:
       - "*.md"
       - "lilypond/src/**"
       - "lilypond/build/**"
+      - ".github/monitor-series.json"
       - ".github/scripts/monitor-resources.mjs"
       - ".github/scripts/monitor-resources.test.mjs"
       - ".github/workflows/lilypond.yml"
@@ -46,7 +48,7 @@ jobs:
             echo "app=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qvE '^([^/]*\.md$|lilypond/src/|lilypond/build/|\.github/scripts/monitor-resources\.mjs$|\.github/scripts/monitor-resources\.test\.mjs$|\.github/workflows/lilypond\.yml$|\.github/workflows/e2e\.yml$|\.github/workflows/monitor-resources\.yml$)'; then
+          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qvE '^([^/]*\.md$|lilypond/src/|lilypond/build/|\.github/monitor-series\.json$|\.github/scripts/monitor-resources\.mjs$|\.github/scripts/monitor-resources\.test\.mjs$|\.github/workflows/lilypond\.yml$|\.github/workflows/e2e\.yml$|\.github/workflows/monitor-resources\.yml$)'; then
             echo "app=true" >> "$GITHUB_OUTPUT"
           else
             echo "app=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/monitor-resources.yml
+++ b/.github/workflows/monitor-resources.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   actions: read
   issues: write
-  contents: read
+  contents: write
   pull-requests: read
 
 jobs:
@@ -28,3 +28,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: node .github/scripts/monitor-resources.mjs
+
+      - name: Commit daily resource series
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/monitor-series.json
+          if git diff --cached --quiet; then
+            echo "No series changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: update daily resource series [skip ci]"
+          git push

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -11,7 +11,7 @@ The repository uses GitHub Actions for automated testing and dependency updates.
 
 ### `ci.yml`
 
-Triggers on push and pull request to `main`, nightly at 00:00 UTC via a `schedule` cron, and path-filtered to skip changes that do not affect the application build or unit tests (for example, `lilypond/src/**` and `lilypond/build/**` are ignored).
+Triggers on push and pull request to `main`, nightly at 00:00 UTC via a `schedule` cron, and path-filtered to skip changes that do not affect the application build or unit tests. Ignored paths include `lilypond/src/**`, `lilypond/build/**`, the monitor script and its test file (`.github/scripts/monitor-resources.mjs` and `.github/scripts/monitor-resources.test.mjs`), and the sibling workflow files `lilypond.yml`, `e2e.yml`, and `monitor-resources.yml`.
 
 Defines three jobs.
 

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -11,7 +11,7 @@ The repository uses GitHub Actions for automated testing and dependency updates.
 
 ### `ci.yml`
 
-Triggers on push and pull request to `main`, nightly at 00:00 UTC via a `schedule` cron, and path-filtered to skip changes that do not affect the application build or unit tests. Ignored paths include `lilypond/src/**`, `lilypond/build/**`, the monitor script and its test file (`.github/scripts/monitor-resources.mjs` and `.github/scripts/monitor-resources.test.mjs`), and the sibling workflow files `lilypond.yml`, `e2e.yml`, and `monitor-resources.yml`.
+Triggers on push and pull request to `main`, nightly at 00:00 UTC via a `schedule` cron, and path-filtered to skip changes that do not affect the application build or unit tests. Ignored paths include `lilypond/src/**`, `lilypond/build/**`, the monitor data file (`.github/monitor-series.json`), the monitor script and its test file (`.github/scripts/monitor-resources.mjs` and `.github/scripts/monitor-resources.test.mjs`), and the sibling workflow files `lilypond.yml`, `e2e.yml`, and `monitor-resources.yml`.
 
 Defines three jobs.
 

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -98,14 +98,17 @@ automatically.
 
 ### `monitor-resources.yml`
 
-Triggers daily at 02:29 UTC (`cron: "29 2 * * *"`, deliberately off the top of the hour to avoid GitHub's schedule throttling; GitHub's ~5 h scheduling delay lands the Telegram post around breakfast) and on manual `workflow_dispatch`. Runs one job, `monitor`, on Ubuntu latest with `actions: read`, `issues: write`, and `contents: read` permissions.
+Triggers daily at 02:29 UTC (`cron: "29 2 * * *"`, deliberately off the top of the hour to avoid GitHub's schedule throttling; GitHub's ~5 h scheduling delay lands the Telegram post around breakfast) and on manual `workflow_dispatch`. Runs one job, `monitor`, on Ubuntu latest with `actions: read`, `issues: write`, `contents: write`, and `pull-requests: read` permissions.
 
 Steps:
 
 - `actions/checkout@v6` — checkout the repository.
-- `node .github/scripts/monitor-resources.mjs` — run the monitor, with `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `GITHUB_TOKEN` passed in the environment.
+- `node .github/scripts/monitor-resources.mjs` — run the monitor, with `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `GITHUB_TOKEN` passed in the environment. After fetching usage, the script appends (or replaces) today's entry in `.github/monitor-series.json` with the current Netlify and GitHub build-minute totals.
+- Commit the updated `.github/monitor-series.json` if it changed, with message `chore: update daily resource series [skip ci]`, then push. The workflow triggers only on `schedule` and `workflow_dispatch` (never on `push`), so this self-commit cannot loop the workflow; the `[skip ci]` suffix also prevents it from consuming a `ci.yml` run.
 
 The script queries the current period's Netlify build-minute usage and GitHub Actions usage. Status thresholds — watch (≥ 50%), throttle (≥ 75%), and critical (≥ 90%) — apply to the higher of actual usage and the linearly projected end-of-period usage, so an unsustainable burn rate raises the alarm early in the billing period. On days with no PRs merged in the past 24 hours and both actual and projected usage below the watch threshold (50%), the Telegram message is skipped to reduce noise; watch and worse always send regardless of PR activity. When the message is sent, it takes the form `Netlify <n>% · GitHub <n>% — <status>` (the percentages are actual usage; the status reflects the worse of actual and projected), appending `· N PR(s) merged` when at least one PR merged in the past 24 hours. If either service reaches, or is projected to reach by period end, **90%** of its quota, the status becomes `STOP` (with a 🚨 prefix) and the workflow opens a critical GitHub issue containing a runbook for reducing build-minute consumption.
+
+The `.github/monitor-series.json` file holds the daily `{ date, netlifyCurrent, githubMinutes, source }` series. The `source` field is `"logged"` for entries written by the monitor and `"backfill"` for the one-time seed populated from API/GitHub run history and Telegram-reported Netlify percentages.
 
 ### `monitor-resources-test.yml`
 

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -108,7 +108,7 @@ Steps:
 
 The script queries the current period's Netlify build-minute usage and GitHub Actions usage. Status thresholds — watch (≥ 50%), throttle (≥ 75%), and critical (≥ 90%) — apply to the higher of actual usage and the linearly projected end-of-period usage, so an unsustainable burn rate raises the alarm early in the billing period. On days with no PRs merged in the past 24 hours and both actual and projected usage below the watch threshold (50%), the Telegram message is skipped to reduce noise; watch and worse always send regardless of PR activity. When the message is sent, it takes the form `Netlify <n>% · GitHub <n>% — <status>` (the percentages are actual usage; the status reflects the worse of actual and projected), appending `· N PR(s) merged` when at least one PR merged in the past 24 hours. If either service reaches, or is projected to reach by period end, **90%** of its quota, the status becomes `STOP` (with a 🚨 prefix) and the workflow opens a critical GitHub issue containing a runbook for reducing build-minute consumption.
 
-The `.github/monitor-series.json` file holds the daily `{ date, netlifyCurrent, githubMinutes, source }` series. The `source` field is `"logged"` for entries written by the monitor and `"backfill"` for the one-time seed populated from API/GitHub run history and Telegram-reported Netlify percentages.
+The `.github/monitor-series.json` file holds the daily `{ date, netlifyCurrent, githubMinutes, source }` series. The `source` field is `"logged"` for entries written by the monitor and `"backfill"` for the one-time seed populated from API/GitHub run history and Netlify daily build minutes.
 
 ### `monitor-resources-test.yml`
 


### PR DESCRIPTION
Closes #566.

## Summary

Adds a committed daily series of Netlify/GitHub build-resource usage so the burndown chart in #565 has real historical shape, plus a one-shot backfill for the current period.

## Changes

- `.github/monitor-series.json` — new daily series file with shape `{ date, netlifyCurrent, githubMinutes, source }`; seeded with backfill data for 2026-06-01 through 2026-06-12.
- `.github/scripts/monitor-resources.mjs`:
  - `loadSeries` / `saveSeries` / `appendOrReplaceDay` — idempotent per-date append/replace, sorted by date; missing or empty files handled cleanly, malformed files throw.
  - `buildLoggedEntry` — shapes a `source: "logged"` entry from the already-fetched usage records.
  - `githubRunsToDailySeries` — back-calculates cumulative GitHub minutes per day from workflow runs.
  - `netlifyPercentagesToBackfill` — converts Telegram-reported Netlify percentages to approximate `netlifyCurrent` values.
  - `buildBackfillSeries` — merges GitHub and Netlify backfill data, using `null` for unknown Netlify values so the chart can render gaps.
  - `seedBackfillSeries` — one-shot helper to seed the series file from APIs + Telegram percentages.
  - `main()` appends/replaces today's logged entry after the usage fetches; failures are logged but do not break the alert path.
  - Refactors `getGitHubUsage` to share a new `getGitHubRuns` fetcher with the backfill logic.
- `.github/workflows/monitor-resources.yml`:
  - `permissions.contents`: `read` → `write`.
  - Adds a commit+push step for `.github/monitor-series.json` with `[skip ci]`.
- `.github/scripts/monitor-resources.test.mjs` — tests for series I/O, append idempotency, GitHub backfill, and Netlify backfill.
- `doc/CI.md` — documents the new series file and commit step.

## Verification

- `pnpm run test:monitor` — 49 tests pass.
- `pnpm run test:unit` — 286 tests pass.
- `pnpm run check` — lint, format, type check, unused-export check, and dependency-cruiser all pass.
- Baseline warning diff against `main` shows no new warnings.

## Notes

- No version bump: this is internal tooling, not user-facing.
- The Netlify backfill percentages were provided from the Telegram channel; GitHub values were back-calculated from the current month's workflow runs.