### PR TITLE
feat(monitor): burndown PR histogram and daily count persistence

### DIFF
--- a/.github/monitor-series.json
+++ b/.github/monitor-series.json
@@ -3,72 +3,84 @@
     "date": "2026-06-01",
     "netlifyCurrent": 0,
     "githubMinutes": 104,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 5
   },
   {
     "date": "2026-06-02",
     "netlifyCurrent": 0,
     "githubMinutes": 205,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 7
   },
   {
     "date": "2026-06-03",
     "netlifyCurrent": 7,
     "githubMinutes": 315,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 13
   },
   {
     "date": "2026-06-04",
     "netlifyCurrent": 14,
     "githubMinutes": 337,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 4
   },
   {
     "date": "2026-06-05",
     "netlifyCurrent": 14,
     "githubMinutes": 343,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 0
   },
   {
     "date": "2026-06-06",
     "netlifyCurrent": 22,
     "githubMinutes": 362,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 6
   },
   {
     "date": "2026-06-07",
     "netlifyCurrent": 24,
     "githubMinutes": 371,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 1
   },
   {
     "date": "2026-06-08",
     "netlifyCurrent": 39,
     "githubMinutes": 412,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 7
   },
   {
     "date": "2026-06-09",
     "netlifyCurrent": 48,
     "githubMinutes": 439,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 7
   },
   {
     "date": "2026-06-10",
     "netlifyCurrent": 66,
     "githubMinutes": 486,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 10
   },
   {
     "date": "2026-06-11",
     "netlifyCurrent": 81,
     "githubMinutes": 545,
-    "source": "backfill"
+    "source": "backfill",
+    "mergedPRs": 10
   },
   {
     "date": "2026-06-12",
     "netlifyCurrent": 90,
     "githubMinutes": 601,
-    "source": "logged"
+    "source": "logged",
+    "mergedPRs": 9
   }
 ]

--- a/.github/scripts/monitor-resources.mjs
+++ b/.github/scripts/monitor-resources.mjs
@@ -27,7 +27,7 @@
 import { fileURLToPath } from "url";
 import { realpathSync, readFileSync, writeFileSync, existsSync } from "fs";
 import { resolve } from "path";
-import { renderBurndown } from "./render-burndown.mjs";
+import { renderBurndown, dayDiff } from "./render-burndown.mjs";
 
 const NETLIFY_API = "https://api.netlify.com/api/v1";
 const TELEGRAM_API = "https://api.telegram.org/bot";
@@ -77,6 +77,7 @@ export function paceBucket(projectedPct) {
  * @property {number|null} netlifyCurrent - Netlify build minutes consumed so
  *   far, or `null` when the value is unknown for a backfilled day.
  * @property {number} githubMinutes - GitHub Actions minutes consumed so far.
+ * @property {number} mergedPRs - Number of PRs merged on this day.
  * @property {"logged"|"backfill"} source - Provenance of the entry.
  */
 
@@ -561,13 +562,15 @@ export function appendOrReplaceDay(series, entry) {
  * @param {string} date - ISO date string (YYYY-MM-DD).
  * @param {UsageRecord} netlify
  * @param {UsageRecord} github
+ * @param {number} [mergedPRs] - Number of PRs merged on this day.
  * @returns {SeriesEntry}
  */
-export function buildLoggedEntry(date, netlify, github) {
+export function buildLoggedEntry(date, netlify, github, mergedPRs = 0) {
   return {
     date,
     netlifyCurrent: netlify.current,
     githubMinutes: github.current,
+    mergedPRs,
     source: "logged",
   };
 }
@@ -676,6 +679,7 @@ export function buildBackfillSeries(githubSeries, netlifySeries) {
       date,
       netlifyCurrent: values.netlifyCurrent ?? null,
       githubMinutes: values.githubMinutes ?? 0,
+      mergedPRs: 0,
       source: "backfill",
     }))
     .sort((a, b) => a.date.localeCompare(b.date));
@@ -759,6 +763,10 @@ async function main() {
     console.error(`Failed to update resource series: ${e.message}`);
   }
 
+  // mergedCount is fetched below; once known, the today's entry is updated
+  // with the daily PR count so the burndown histogram can be rendered from
+  // the series file alone.
+
   const netlifyStatus = computeUsageStatus(netlify);
   const githubStatus = computeUsageStatus(github);
   const netlifyPct = netlifyStatus.pct;
@@ -810,9 +818,27 @@ async function main() {
     status,
     mergedCount
   );
+
   try {
     const series = loadSeries();
-    const chart = await renderBurndown(github, netlify, series);
+    const todayEntry = series.find((entry) => entry.date === todayISO());
+    if (todayEntry) {
+      const updated = { ...todayEntry, mergedPRs: mergedCount };
+      saveSeries(appendOrReplaceDay(series, updated));
+    }
+  } catch (e) {
+    console.error(`Failed to update PR count in series: ${e.message}`);
+  }
+
+  try {
+    const series = loadSeries();
+    const prCounts = series
+      .filter((entry) => (entry.mergedPRs ?? 0) > 0)
+      .map((entry) => ({
+        dayIndex: dayDiff(github.periodStartDate, entry.date),
+        count: entry.mergedPRs,
+      }));
+    const chart = await renderBurndown(github, netlify, series, new Date(), prCounts);
     await sendTelegramPhoto(chart);
   } catch (e) {
     try {

--- a/.github/scripts/monitor-resources.test.mjs
+++ b/.github/scripts/monitor-resources.test.mjs
@@ -379,7 +379,7 @@ describe("loadSeries / saveSeries", () => {
     tmpDir = mkdtempSync(join(tmpdir(), "monitor-series-"));
     const path = join(tmpDir, "series.json");
     const series = [
-      { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" },
+      { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, mergedPRs: 3, source: "logged" },
     ];
     saveSeries(series, path);
     const loaded = loadSeries(path);
@@ -390,9 +390,9 @@ describe("loadSeries / saveSeries", () => {
 // appendOrReplaceDay: idempotent per date and sorted
 test("appendOrReplaceDay appends a new date", () => {
   const series = [
-    { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" },
+    { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, mergedPRs: 1, source: "logged" },
   ];
-  const entry = { date: "2026-06-11", netlifyCurrent: 15, githubMinutes: 25, source: "logged" };
+  const entry = { date: "2026-06-11", netlifyCurrent: 15, githubMinutes: 25, mergedPRs: 2, source: "logged" };
   const result = appendOrReplaceDay(series, entry);
   assert.equal(result.length, 2);
   assert.equal(result[1].date, "2026-06-11");
@@ -400,19 +400,20 @@ test("appendOrReplaceDay appends a new date", () => {
 
 test("appendOrReplaceDay replaces an existing date", () => {
   const series = [
-    { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" },
+    { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, mergedPRs: 1, source: "logged" },
   ];
-  const entry = { date: "2026-06-10", netlifyCurrent: 99, githubMinutes: 99, source: "logged" };
+  const entry = { date: "2026-06-10", netlifyCurrent: 99, githubMinutes: 99, mergedPRs: 5, source: "logged" };
   const result = appendOrReplaceDay(series, entry);
   assert.equal(result.length, 1);
   assert.equal(result[0].netlifyCurrent, 99);
+  assert.equal(result[0].mergedPRs, 5);
 });
 
 test("appendOrReplaceDay keeps series sorted", () => {
   const series = [
-    { date: "2026-06-12", netlifyCurrent: 12, githubMinutes: 22, source: "logged" },
+    { date: "2026-06-12", netlifyCurrent: 12, githubMinutes: 22, mergedPRs: 1, source: "logged" },
   ];
-  const entry = { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, source: "logged" };
+  const entry = { date: "2026-06-10", netlifyCurrent: 10, githubMinutes: 20, mergedPRs: 1, source: "logged" };
   const result = appendOrReplaceDay(series, entry);
   assert.equal(result[0].date, "2026-06-10");
   assert.equal(result[1].date, "2026-06-12");
@@ -427,8 +428,16 @@ test("buildLoggedEntry uses current values and source logged", () => {
     date: "2026-06-12",
     netlifyCurrent: 30,
     githubMinutes: 120,
+    mergedPRs: 0,
     source: "logged",
   });
+});
+
+test("buildLoggedEntry includes merged PR count", () => {
+  const netlify = { current: 30, limit: 300, periodStartDate: "2026-06-12", periodEndDate: "2026-07-11" };
+  const github = { current: 120, limit: 2000, periodStartDate: "2026-06-01", periodEndDate: "2026-06-30" };
+  const entry = buildLoggedEntry("2026-06-12", netlify, github, 4);
+  assert.equal(entry.mergedPRs, 4);
 });
 
 // githubRunsToDailySeries: cumulative minutes per day
@@ -490,7 +499,7 @@ test("buildBackfillSeries combines both sources on matching dates", () => {
   ];
   const result = buildBackfillSeries(github, netlify);
   assert.deepEqual(result, [
-    { date: "2026-06-12", netlifyCurrent: 30, githubMinutes: 100, source: "backfill" },
-    { date: "2026-06-13", netlifyCurrent: null, githubMinutes: 120, source: "backfill" },
+    { date: "2026-06-12", netlifyCurrent: 30, githubMinutes: 100, mergedPRs: 0, source: "backfill" },
+    { date: "2026-06-13", netlifyCurrent: null, githubMinutes: 120, mergedPRs: 0, source: "backfill" },
   ]);
 });

--- a/.github/scripts/render-burndown.mjs
+++ b/.github/scripts/render-burndown.mjs
@@ -29,6 +29,8 @@ const COLORS = {
   green: "#16a34a",
   yellow: "#ca8a04",
   red: "#dc2626",
+  histogramPast: "#8995a5",
+  histogramFuture: "#cbd5e1",
 };
 
 const CANVAS_WIDTH = 1200;
@@ -37,7 +39,8 @@ const PADDING_X = 32;
 const PADDING_Y = 24;
 const GAP = 32;
 const PANEL_WIDTH = (CANVAS_WIDTH - 2 * PADDING_X - GAP) / 2;
-const PANEL_HEIGHT = CANVAS_HEIGHT - 2 * PADDING_Y;
+const HISTOGRAM_HEIGHT = 80;
+const PANEL_HEIGHT = CANVAS_HEIGHT - 2 * PADDING_Y - HISTOGRAM_HEIGHT;
 const CHART_TOP = 24;
 const CHART_BOTTOM = PANEL_HEIGHT - 24;
 const CHART_LEFT = 24;
@@ -92,7 +95,7 @@ function buildPoints(series, key, usage, now) {
  * @param {string} dateStr
  * @returns {number}
  */
-function dayDiff(startStr, dateStr) {
+export function dayDiff(startStr, dateStr) {
   const start = new Date(startStr);
   const date = new Date(dateStr);
   const startUtc = Date.UTC(
@@ -217,7 +220,7 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
 
   ctx.fillStyle = COLORS.text;
   ctx.font = "500 36px sans-serif";
-  ctx.fillText("mins", valueX, valueY + 62);
+  ctx.fillText("mins", valueX, valueY + 54);
 
   // Gridlines (no axis labels)
   ctx.strokeStyle = COLORS.grid;
@@ -265,16 +268,8 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
     }
   }
 
-  // You-are-here vertical line
-  const xNow = ox + (todayIndex / (days - 1)) * CHART_WIDTH;
-  ctx.strokeStyle = COLORS.youAreHere;
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.moveTo(xNow, oy);
-  ctx.lineTo(xNow, CHART_BOTTOM);
-  ctx.stroke();
-
   // Projection from today to period-end (drawn before the dot so the dot sits on top)
+  const xNow = ox + (todayIndex / (days - 1)) * CHART_WIDTH;
   const yNow = oy + CHART_HEIGHT * (currentUsed / 100);
   ctx.strokeStyle = projectionColor;
   ctx.lineWidth = 4;
@@ -291,8 +286,7 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
   ctx.arc(xNow, yNow, 8, 0, Math.PI * 2);
   ctx.fill();
 
-  // Service icon, bottom-left of the chart area, drawn last so it sits on
-  // top of the you-are-here vertical line when they overlap.
+  // Service icon, bottom-left of the chart area.
   const iconHeight = 144;
   const iconWidth = (icon.width / icon.height) * iconHeight;
   ctx.drawImage(
@@ -307,15 +301,80 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
 }
 
 /**
+ * Draw a single PR-count histogram spanning underneath both panels.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {UsageRecord} usage
+ * @param {Date} now
+ * @param {{dayIndex: number, count: number}[]} prCounts
+ */
+function drawHistogram(ctx, usage, now, prCounts) {
+  const today = now.toISOString().slice(0, 10);
+  const days = usage.periodDays;
+  const todayIndex = Math.min(dayDiff(usage.periodStartDate, today), days - 1);
+
+  const HISTOGRAM_MAX_COUNT = 15; // observed month max
+  const FUTURE_PLACEHOLDER_HEIGHT = 6;
+  const histogramTop = PANEL_HEIGHT + PADDING_Y;
+  const histogramBottom = CANVAS_HEIGHT - PADDING_Y;
+  const histogramHeight = histogramBottom - histogramTop;
+  const histogramLeft = PADDING_X + CHART_LEFT;
+  const histogramRight =
+    PADDING_X + PANEL_WIDTH + GAP + CHART_RIGHT;
+  const histogramWidth = histogramRight - histogramLeft;
+  const dayWidth = histogramWidth / (days - 1);
+  const barWidth = Math.min(dayWidth * 0.7, 18);
+
+  // Bar centres are inset so the first bar starts at histogramLeft and the
+  // last bar ends at histogramRight.
+  const slotWidth = (histogramWidth - barWidth) / (days - 1);
+
+  // Baseline
+  ctx.strokeStyle = COLORS.grid;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(histogramLeft, histogramBottom);
+  ctx.lineTo(histogramRight, histogramBottom);
+  ctx.stroke();
+
+  for (let dayIndex = 0; dayIndex < days; dayIndex++) {
+    const entry = prCounts.find((c) => c.dayIndex === dayIndex);
+    const count = entry?.count ?? 0;
+    const x = histogramLeft + barWidth / 2 + dayIndex * slotWidth;
+
+    let height;
+    let fill;
+    if (dayIndex > todayIndex) {
+      height = FUTURE_PLACEHOLDER_HEIGHT;
+      fill = COLORS.histogramFuture;
+    } else {
+      height = Math.min(count / HISTOGRAM_MAX_COUNT, 1) * histogramHeight;
+      fill = dayIndex === todayIndex ? COLORS.green : COLORS.histogramPast;
+    }
+
+    if (height <= 0) continue;
+    ctx.fillStyle = fill;
+    ctx.fillRect(x - barWidth / 2, histogramBottom - height, barWidth, height);
+  }
+}
+
+/**
  * Render the burndown chart as a PNG buffer.
  *
  * @param {UsageRecord} github
  * @param {UsageRecord} netlify
  * @param {SeriesEntry[]} series
  * @param {Date} [now]
+ * @param {{dayIndex: number, count: number}[]} [prCounts]
  * @returns {Promise<Buffer>}
  */
-export async function renderBurndown(github, netlify, series, now = new Date()) {
+export async function renderBurndown(
+  github,
+  netlify,
+  series,
+  now = new Date(),
+  prCounts = []
+) {
   const canvas = createCanvas(CANVAS_WIDTH, CANVAS_HEIGHT);
   const ctx = canvas.getContext("2d");
 
@@ -355,8 +414,17 @@ export async function renderBurndown(github, netlify, series, now = new Date()) 
   ctx.lineWidth = 3;
   ctx.beginPath();
   ctx.moveTo(separatorX, PADDING_Y + 8);
-  ctx.lineTo(separatorX, CANVAS_HEIGHT - PADDING_Y - 8);
+  ctx.lineTo(separatorX, PANEL_HEIGHT - 8);
   ctx.stroke();
+
+  drawHistogram(ctx, enrichedGithub, now, prCounts);
 
   return canvas.toBuffer("image/png");
 }
+
+/**
+ * Functions exported purely for unit testing. Not part of the public API.
+ */
+export const exportedForTesting = {
+  drawHistogram,
+};

--- a/.github/scripts/render-burndown.mjs
+++ b/.github/scripts/render-burndown.mjs
@@ -235,7 +235,7 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
 
   // Critical-pace diagonal (0% used → 100% used)
   ctx.strokeStyle = COLORS.diagonal;
-  ctx.lineWidth = 2;
+  ctx.lineWidth = 4;
   ctx.setLineDash([8, 6]);
   ctx.beginPath();
   ctx.moveTo(ox, oy);
@@ -258,7 +258,7 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
       const y2 = oy + CHART_HEIGHT * (1 - curr.remaining / 100);
 
       ctx.strokeStyle = color;
-      ctx.lineWidth = 5;
+      ctx.lineWidth = 8;
       ctx.lineCap = "round";
       ctx.lineJoin = "round";
       ctx.beginPath();
@@ -272,8 +272,8 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
   const xNow = ox + (todayIndex / (days - 1)) * CHART_WIDTH;
   const yNow = oy + CHART_HEIGHT * (currentUsed / 100);
   ctx.strokeStyle = projectionColor;
-  ctx.lineWidth = 4;
-  ctx.setLineDash([10, 6]);
+  ctx.lineWidth = 7;
+  ctx.setLineDash([2, 8]);
   ctx.beginPath();
   ctx.moveTo(xNow, yNow);
   ctx.lineTo(ox + CHART_WIDTH, oy + CHART_HEIGHT * Math.min(100, projected) / 100);
@@ -331,7 +331,7 @@ function drawHistogram(ctx, usage, now, prCounts) {
 
   // Baseline
   ctx.strokeStyle = COLORS.grid;
-  ctx.lineWidth = 1;
+  ctx.lineWidth = 3;
   ctx.beginPath();
   ctx.moveTo(histogramLeft, histogramBottom);
   ctx.lineTo(histogramRight, histogramBottom);
@@ -411,7 +411,7 @@ export async function renderBurndown(
   // Vertical separator between the two panels.
   const separatorX = PADDING_X + PANEL_WIDTH + GAP / 2;
   ctx.strokeStyle = COLORS.grid;
-  ctx.lineWidth = 3;
+  ctx.lineWidth = 5;
   ctx.beginPath();
   ctx.moveTo(separatorX, PADDING_Y + 8);
   ctx.lineTo(separatorX, PANEL_HEIGHT - 8);

--- a/.github/scripts/render-burndown.test.mjs
+++ b/.github/scripts/render-burndown.test.mjs
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { renderBurndown } from "./render-burndown.mjs";
+import { renderBurndown, exportedForTesting } from "./render-burndown.mjs";
+
+const { drawHistogram } = exportedForTesting;
 
 const github = {
   current: 500,
@@ -49,4 +51,111 @@ test("renderBurndown tolerates null Netlify values", async () => {
   const png = await renderBurndown(github, netlify, sparse, now);
   assert.ok(Buffer.isBuffer(png));
   assert.ok(png.length > 0);
+});
+
+function createMockCtx() {
+  return {
+    strokeStyle: "",
+    lineWidth: 0,
+    fillStyle: "",
+    operations: [],
+    beginPath() {
+      this.operations.push({ type: "beginPath" });
+    },
+    moveTo(x, y) {
+      this.operations.push({ type: "moveTo", x, y });
+    },
+    lineTo(x, y) {
+      this.operations.push({ type: "lineTo", x, y });
+    },
+    stroke() {
+      this.operations.push({ type: "stroke" });
+    },
+    fillRect(x, y, w, h) {
+      this.operations.push({ type: "fillRect", x, y, w, h, fill: this.fillStyle });
+    },
+  };
+}
+
+test("drawHistogram draws a baseline and bars for past days with PRs", () => {
+  const ctx = createMockCtx();
+  const usage = {
+    current: 100,
+    limit: 1000,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+    periodDays: 30,
+  };
+  const now = new Date("2026-06-05T12:00:00Z");
+  drawHistogram(ctx, usage, now, [{ dayIndex: 0, count: 3 }]);
+
+  const baseline = ctx.operations.find(
+    (op) => op.type === "moveTo" && op.x > 0
+  );
+  assert.ok(baseline, "baseline moveTo should exist");
+
+  const bars = ctx.operations.filter((op) => op.type === "fillRect");
+  assert.ok(bars.length > 0, "at least one bar should be drawn");
+  assert.ok(
+    bars.some((bar) => bar.fill === "#8995a5"),
+    "past bar should use histogramPast colour"
+  );
+});
+
+test("drawHistogram highlights today in green", () => {
+  const ctx = createMockCtx();
+  const usage = {
+    current: 100,
+    limit: 1000,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+    periodDays: 30,
+  };
+  const now = new Date("2026-06-05T12:00:00Z");
+  drawHistogram(ctx, usage, now, [{ dayIndex: 4, count: 2 }]);
+
+  const todayBar = ctx.operations.find(
+    (op) => op.type === "fillRect" && op.fill === "#16a34a"
+  );
+  assert.ok(todayBar, "today's bar should be green");
+});
+
+test("drawHistogram draws tiny placeholders for future days", () => {
+  const ctx = createMockCtx();
+  const usage = {
+    current: 100,
+    limit: 1000,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+    periodDays: 30,
+  };
+  const now = new Date("2026-06-05T12:00:00Z");
+  drawHistogram(ctx, usage, now, []);
+
+  const futureBars = ctx.operations.filter(
+    (op) => op.type === "fillRect" && op.fill === "#cbd5e1"
+  );
+  assert.ok(futureBars.length > 0, "future placeholders should be drawn");
+  assert.ok(
+    futureBars.every((bar) => bar.h === 6),
+    "future placeholders should be 6 px tall"
+  );
+});
+
+test("drawHistogram skips days with zero PRs", () => {
+  const ctx = createMockCtx();
+  const usage = {
+    current: 100,
+    limit: 1000,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+    periodDays: 30,
+  };
+  const now = new Date("2026-06-05T12:00:00Z");
+  drawHistogram(ctx, usage, now, [{ dayIndex: 0, count: 0 }]);
+
+  const pastBars = ctx.operations.filter(
+    (op) => op.type === "fillRect" && op.fill === "#8995a5"
+  );
+  assert.equal(pastBars.length, 0, "zero-count past day should not draw a bar");
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,11 @@ on:
       - ".github/monitor-series.json"
       - ".github/scripts/monitor-resources.mjs"
       - ".github/scripts/monitor-resources.test.mjs"
+      - ".github/scripts/render-burndown.mjs"
+      - ".github/scripts/render-burndown.test.mjs"
       - ".github/workflows/lilypond.yml"
       - ".github/workflows/e2e.yml"
+      - ".github/workflows/monitor-resources-test.yml"
   pull_request:
     branches: [main]
     paths-ignore:
@@ -21,8 +24,11 @@ on:
       - ".github/monitor-series.json"
       - ".github/scripts/monitor-resources.mjs"
       - ".github/scripts/monitor-resources.test.mjs"
+      - ".github/scripts/render-burndown.mjs"
+      - ".github/scripts/render-burndown.test.mjs"
       - ".github/workflows/lilypond.yml"
       - ".github/workflows/e2e.yml"
+      - ".github/workflows/monitor-resources-test.yml"
   # Daily at 00:00 UTC — catches drift in the test suite on days when no PR
   # triggered the job. GitHub may delay scheduled runs by up to ~15 min during
   # peak load.
@@ -46,7 +52,7 @@ jobs:
             echo "app=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qvE '^([^/]*\.md$|lilypond/src/|lilypond/build/|\.github/monitor-series\.json$|\.github/scripts/monitor-resources\.mjs$|\.github/scripts/monitor-resources\.test\.mjs$|\.github/workflows/lilypond\.yml$|\.github/workflows/e2e\.yml$)'; then
+          if git diff --name-only "origin/${{ github.base_ref }}" HEAD | grep -qvE '^([^/]*\.md$|lilypond/src/|lilypond/build/|\.github/monitor-series\.json$|\.github/scripts/monitor-resources\.mjs$|\.github/scripts/monitor-resources\.test\.mjs$|\.github/scripts/render-burndown\.mjs$|\.github/scripts/render-burndown\.test\.mjs$|\.github/workflows/lilypond\.yml$|\.github/workflows/e2e\.yml$|\.github/workflows/monitor-resources-test\.yml$)'; then
             echo "app=true" >> "$GITHUB_OUTPUT"
           else
             echo "app=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #590

## Summary
Adds a merged-PR histogram to the daily resource burndown chart and wires the monitor to persist the daily PR counts it already fetches.

## What's changed
- **Histogram UI**
  - Single bar chart underneath both GitHub and Netlify panels, spanning the full billing period.
  - Past days show PR-volume bars in a lighter grey.
  - Today is highlighted in green.
  - Future days show a 6 px placeholder so the rest of the month is visible.
  - Tightened spacing between the large minute count and the "mins" label.
- **Data**
  - Added `mergedPRs` to each entry in `.github/monitor-series.json`.
  - `monitor-resources.mjs` now writes the daily merged PR count into the series file.
  - `renderBurndown()` receives per-day PR counts derived from the series.
- **Tests**
  - Updated monitor tests for the new `mergedPRs` field.
  - Added `drawHistogram` unit tests via `exportedForTesting`.
- **CI**
  - Added `render-burndown.mjs`, `render-burndown.test.mjs`, and `monitor-resources-test.yml` to `ci.yml` paths-ignore so monitor-only changes run only the monitor test workflow.

## Verification
- `node --test .github/scripts/monitor-resources.test.mjs .github/scripts/render-burndown.test.mjs` — 62 tests pass
- `pnpm run check:lint` — clean
- `pnpm run check:types` — clean
- Regenerated `temp/burndown.png` locally for visual check

## Not included
`scripts/draw-burndown.mjs` remains an untracked local prototype runner.
