### PR TITLE
fix(monitor): colour burndown segments by diagonal position

### DIFF
--- a/.github/scripts/render-burndown.mjs
+++ b/.github/scripts/render-burndown.mjs
@@ -147,6 +147,23 @@ function paceBucket(projectedPct) {
 }
 
 /**
+ * Choose a segment colour. A point below the critical-pace diagonal is using
+ * minutes faster than the steady pace, so it is always red. Points above the
+ * diagonal are coloured by their projected end-of-period percentage.
+ *
+ * @param {number} consumed - Usage percentage at the segment end (0-100+).
+ * @param {number} dayIndex - Day index of the segment end (0-based).
+ * @param {number} days - Total days in the period.
+ * @param {number} projected - Projected end-of-period percentage.
+ * @returns {string} Hex colour.
+ */
+function segmentColor(consumed, dayIndex, days, projected) {
+  const steadyUsed = (dayIndex / (days - 1)) * 100;
+  if (consumed > steadyUsed) return COLORS.red;
+  return COLORS[paceBucket(projected)];
+}
+
+/**
  * Draw a rounded rectangle.
  *
  * @param {CanvasRenderingContext2D} ctx
@@ -212,7 +229,12 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
     ? 100 - lastPoint.remaining
     : 100 - remainingPct(usage.current, usage.limit);
   const projected = projectedEndPct(currentUsed, todayIndex + 1, days);
-  const projectionColor = COLORS[paceBucket(projected)];
+  const projectionColor = segmentColor(
+    currentUsed,
+    todayIndex,
+    days,
+    projected
+  );
 
   ctx.fillStyle = projectionColor;
   ctx.font = "900 52px sans-serif";
@@ -250,7 +272,7 @@ function drawPanel(ctx, originX, icon, usage, points, now) {
       const curr = points[i];
       const consumed = 100 - curr.remaining;
       const projected = projectedEndPct(consumed, curr.dayIndex + 1, days);
-      const color = COLORS[paceBucket(projected)];
+      const color = segmentColor(consumed, curr.dayIndex, days, projected);
 
       const x1 = ox + (prev.dayIndex / (days - 1)) * CHART_WIDTH;
       const y1 = oy + CHART_HEIGHT * (1 - prev.remaining / 100);
@@ -427,4 +449,5 @@ export async function renderBurndown(
  */
 export const exportedForTesting = {
   drawHistogram,
+  segmentColor,
 };

--- a/.github/scripts/render-burndown.test.mjs
+++ b/.github/scripts/render-burndown.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { renderBurndown, exportedForTesting } from "./render-burndown.mjs";
 
-const { drawHistogram } = exportedForTesting;
+const { drawHistogram, segmentColor } = exportedForTesting;
 
 const github = {
   current: 500,
@@ -158,4 +158,19 @@ test("drawHistogram skips days with zero PRs", () => {
     (op) => op.type === "fillRect" && op.fill === "#8995a5"
   );
   assert.equal(pastBars.length, 0, "zero-count past day should not draw a bar");
+});
+
+// segmentColor: below the critical-pace diagonal is always red
+
+test("segmentColor returns red when usage is below the diagonal", () => {
+  // Day 5 of 30, steady used = 5/29*100 ≈ 17.24%. Actual 18% is below diagonal.
+  const color = segmentColor(18, 5, 30, 90);
+  assert.equal(color, "#dc2626");
+});
+
+test("segmentColor uses projection when usage is above the diagonal", () => {
+  // Day 5 of 30, steady used ≈ 17.24%. Actual 15% is above diagonal.
+  assert.equal(segmentColor(15, 5, 30, 95), "#ca8a04"); // yellow
+  assert.equal(segmentColor(15, 5, 30, 80), "#16a34a"); // green
+  assert.equal(segmentColor(15, 5, 30, 110), "#dc2626"); // red
 });


### PR DESCRIPTION
## Bug
A segment of the burndown line could sit **below** the critical-pace diagonal (meaning cumulative usage was faster than the steady pace) yet be coloured **yellow** because the linear projection happened to fall just under 100%.

For example, on 2026-06-06 GitHub had used 18.1% of its quota while the steady pace for that day was ~17.2%. The point was below the diagonal, but the projection was 90%, so the segment was yellow instead of red.

## Fix
- Added `segmentColor(consumed, dayIndex, days, projected)`: **red** if the point is below the diagonal, otherwise the existing `paceBucket(projected)` colour.
- Applied the same rule to the projection line and the large top-right percentage number.

## Result
The chart now colours any below-diagonal segment red. Yellow only appears above the diagonal when the projection is 90–100%.

## Verification
- `node --test .github/scripts/monitor-resources.test.mjs .github/scripts/render-burndown.test.mjs` — 64 tests pass
- `pnpm run check:lint` — clean
- `pnpm run check:types` — clean
- Regenerated `temp/burndown.png` and visually confirmed the yellow-below-diagonal segment is now red.
