### PR TITLE
build: make test:lilypond discover integration tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:unit": "vitest run --exclude \"lilypond/test/*.integration.test.ts\"",
-    "test:lilypond": "vitest run lilypond/test/*.integration.test.ts",
+    "test:lilypond": "vitest run integration.test.ts",
     "test:monitor": "node --test .github/scripts/monitor-resources.test.mjs .github/scripts/render-burndown.test.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## What

`pnpm run test:lilypond` fails on Windows with `No test files found, exiting with code 1`. The script relied on the shell expanding `lilypond/test/*.integration.test.ts` before vitest ran. `cmd.exe` (which pnpm uses for lifecycle scripts on Windows) does not expand globs, so vitest received the literal pattern, matched nothing, and exited 1. Linux/macOS and CI were unaffected because `sh` expands the glob, so the suite ran in `lilypond.yml` but no Windows developer could run it locally.

## Fix

Let vitest do the matching, via a positional substring filter it applies itself cross-platform:

```diff
-"test:lilypond": "vitest run lilypond/test/*.integration.test.ts",
+"test:lilypond": "vitest run integration.test.ts",
```

This discovers both current integration files (`buildScores.integration.test.ts`, `postprocessSvg.cli.integration.test.ts`) and any future `*.integration.test.ts`, matching the Linux glob's behaviour. No source code, no other scripts changed.

## Verification (Windows)

- Before: `pnpm run test:lilypond` → `No test files found`, exit 1.
- After: 2 files / 28 tests / exit 0.
- `pnpm run ci` green; `pnpm run test:unit` unaffected (25 files / 286 tests).

## Scope

Deliberately limited to the Windows defect. The two adjacent changes from the #558 Vera-gate finding 558-05 (appending `test:lilypond` to the `ci` script; renaming `ci` out of the `pnpm ci` shadow) are CI runtime/structure decisions and are left to you; reasoning recorded on #548.

Fixes #548

- Vera
