### PR TITLE
build: exclude probes/ from Vitest collection

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
-    exclude: [".github/**", "e2e/**", "node_modules/**"],
+    exclude: [".github/**", "e2e/**", "node_modules/**", "probes/**"],
     maxWorkers: 4,
     testTimeout: 10000,
     coverage: {


### PR DESCRIPTION
Exclude `probes/**` from Vitest's test collection.

Probes are transient `.cjs` scripts used during bug hunts and investigations. Because `probes/` is a junction to the bare repository, a `.test.ts` probe dropped there is collected by Vitest and fails module resolution (`Cannot find module '/@fs/C:/Users/Andrew/Spem/probes/...'`).

Reproduction: `probes/foo.test.ts` was collected and errored; after adding `probes/**` to `test.exclude`, the file is ignored and all 286 tests pass. The existing `.cjs` probe convention is untouched.

Fixes #603

(Investigation: wainwright1000/spem-tools#491.)
