### PR TITLE
ci(scores): restore git timestamps before build

### DIFF
--- a/.github/workflows/scores-ci.yml
+++ b/.github/workflows/scores-ci.yml
@@ -21,6 +21,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Restore git timestamps
+        run: |
+          # actions/checkout writes files with the current wall-clock time,
+          # so rebuild-by-mtime caches see source files as newer than SVGs.
+          # Reset the relevant files to their last commit time instead.
+          git ls-files -z packages/scores/src packages/scores/build packages/pwa/src/scores |
+            while IFS= read -r -d '' f; do
+              mtime=$(git log -1 --format=%ct -- "$f") && touch -d "@$mtime" "$f"
+            done
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Stops the Scores CI job from rebuilding every SVG on a clean checkout just because `actions/checkout` writes source files with later mtimes than the committed SVGs.

- Fetch full history so `git-restore-mtime` can find each file's last commit time.
- Restore mtimes immediately after checkout, before pnpm/install/build.

This makes the existing mtime cache in `buildScores.mjs` reliable in CI.