### PR TITLE
ci(scores): drop [skip ci] from SVG bot commit

### DIFF
--- a/.github/workflows/scores-ci.yml
+++ b/.github/workflows/scores-ci.yml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Never re-trigger on the bot's own SVG commit, even if the path filters
+    # would match it.
+    if: github.actor != 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -56,5 +59,5 @@ jobs:
             echo "No SVG changes to commit"
             exit 0
           fi
-          git commit -m "chore: regenerate SVGs [skip ci]"
+          git commit -m "chore: regenerate SVGs"
           git push


### PR DESCRIPTION
Fixes #562.

Changes:
- Remove `[skip ci]` from the bot's SVG regeneration commit so that other required workflows (e.g. PWA CI) can still report on the new head.
- Add an `if: github.actor != 'github-actions[bot]'` guard on the Scores CI job so the bot cannot re-trigger itself if the path filters ever include the generated SVG directory.