### PR TITLE
fix: replace Windows-breaking lilypond symlink with a Vite resolve alias

### DIFF
--- a/packages/pwa/knip.json
+++ b/packages/pwa/knip.json
@@ -2,5 +2,5 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "project": ["src/**/*.ts", "*.ts"],
   "entry": ["src/**/*.ts", "*.ts"],
-  "ignoreDependencies": ["autoprefixer", "lint-staged"]
+  "ignoreDependencies": ["autoprefixer", "lint-staged", "@lilypond/.+"]
 }

--- a/packages/pwa/src/lilypond
+++ b/packages/pwa/src/lilypond
@@ -1,1 +1,0 @@
-../../scores/src/Hugh Keyte

--- a/packages/pwa/src/ts/lily.ts
+++ b/packages/pwa/src/ts/lily.ts
@@ -5,7 +5,7 @@ import config from "./config";
 import lyGrammar from "../ohmjs/ly-grammar.ohm-bundle";
 import * as ohm from "ohm-js";
 import { Duration, BarLine, Note, Rest, Component } from "./music-classes";
-import spem from "../lilypond/spem.ly?raw";
+import spem from "@lilypond/spem.ly?raw";
 
 // A single note entry at a quantised bar position.
 export type NoteEntry = {

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -30,6 +30,17 @@ const versionWithBranch =
   branch && branch !== "main" ? `${pkg.version}-${branch}` : pkg.version;
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The PWA parses spem.ly at runtime (src/ts/lily.ts) from the @spem/scores
+      // package. We resolve it with this build-time alias rather than a tracked
+      // symlink: a git symlink checks out as a plain text file on Windows
+      // (core.symlinks = false by default), which breaks Vite resolution and the
+      // PWA test suite there. The alias resolves identically on every OS with no
+      // per-clone setup, so contributors can work on any platform, Windows included.
+      "@lilypond": resolve(__dirname, "../scores/src/Hugh Keyte"),
+    },
+  },
   assetsInclude: ["**/*.ohm", "**/*.ly"],
   server: {
     // Dev tolerates port collisions: `strictPort: false` lets Vite
@@ -38,8 +49,9 @@ export default defineConfig({
     port: DEV_PORT,
     strictPort: false,
     fs: {
-      // Allow serving files from outside the PWA package (e.g. the
-      // symlinked score source under src/lilypond).
+      // Allow serving files from outside the PWA package: the score
+      // source resolved via the @lilypond alias (see resolve.alias)
+      // lives in the sibling @spem/scores package.
       allow: ["..", "../.."],
     },
   },


### PR DESCRIPTION
## What

Replace the tracked `packages/pwa/src/lilypond` git symlink with a build-time
Vite resolve alias (`@lilypond`).

## Why

On Windows (`core.symlinks=false` by default) the symlink checks out as a
~27-byte text file, so Vite cannot resolve `../lilypond/spem.ly?raw` and the PWA
unit suite is unrunnable there. Linux CI has real symlinks, so the break is
invisible to CI. It hits any Windows clone, not just our setup.

## How

- Delete the symlink `packages/pwa/src/lilypond`.
- Add `resolve.alias` `@lilypond` → `../scores/src/Hugh Keyte` in
  `packages/pwa/vite.config.ts`, with a comment explaining why there is no
  symlink. Vitest reads the same config, so tests resolve too.
- Change the import in `src/ts/lily.ts` to `@lilypond/spem.ly?raw`.
- Whitelist the alias namespace in `knip.json` so `check:unused` passes, and
  update the `server.fs.allow` comment that referenced the old symlink.

The alias resolves identically on every OS with no per-clone setup. Behaviour is
unchanged — the same score source file is read.

## Test

- Reproduced the Windows failure locally (degraded the symlink to its text-file
  form, got the exact `Failed to resolve import "../lilypond/spem.ly?raw"`
  error), then confirmed green after the fix.
- `pnpm --filter pwa run test:unit`: 22 files / 268 tests pass.
- `pnpm run ci`: green.

Fixes #607

- Claude
