### PR TITLE
build: *.ohm eol=lf — stop Windows build:ohm baking CRLF into the grammar bundle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 *.scss text eol=lf
 *.css text eol=lf
 *.html text eol=lf
+*.ohm text eol=lf
 .husky/pre-commit text eol=lf


### PR DESCRIPTION
Fixes #611.

On Windows (`core.autocrlf=true`), `packages/pwa/src/ohmjs/ly-grammar.ohm` was checked out with **CRLF** because `.gitattributes` had no `*.ohm` rule (the repo stores it LF). `pnpm build:ohm` reads the working-tree source and bakes its line endings into the `source` string literal of the tracked `ly-grammar.ohm-bundle.js` (and shifts every `sourceInterval` offset), so **every Windows build produced a phantom diff** on the bundle.

This adds `*.ohm text eol=lf` so the grammar source is always checked out LF (overriding `autocrlf`). The bundle (`*.js` / `*.d.ts`) is already covered by the existing `*.js` / `*.ts text eol=lf` rules and needs no new rule — once `.ohm` is LF, `build:ohm` regenerates the bundle identically.

**Verified on Windows:** with the rule, `git status` is clean after `pnpm build:ohm` (the bundle comes out byte-identical to `main`). The bundle is unchanged by this PR, so there is no behaviour change; Linux CI already builds LF-clean.

- Vera
