### PR TITLE
ci: skip husky pre-commit for daily monitor series commit (#614)

### DIFF
--- a/.github/workflows/monitor-run.yml
+++ b/.github/workflows/monitor-run.yml
@@ -46,5 +46,5 @@ jobs:
             echo "No series changes to commit"
             exit 0
           fi
-          git commit -m "chore: update daily resource series [skip ci]"
+          git commit --no-verify -m "chore: update daily resource series [skip ci]"
           git push


### PR DESCRIPTION
## Summary

The daily `.github/workflows/monitor-run.yml` job only installs the `@spem/monitor` workspace, but the husky pre-commit hook runs `pnpm --filter @spem/pwa exec lint-staged`. Because the PWA workspace is not installed, the bot's commit fails with:

```
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "lint-staged" not found
husky - pre-commit script failed (code 1)
```

## Change

Add `--no-verify` to the `git commit` step so the daily, machine-generated `.github/monitor-series.json` update bypasses the pre-commit hook.

## Verification

- This is a CI-only change; no code paths are affected.
- The hook still runs for human commits in the PWA workspace.

Fixes #614

No doc changes required.
