### PR TITLE
fix: restore ESLint coverage for packages/monitor .mjs files (#616)

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -96,6 +96,8 @@ Run the full quality gate locally (Ohm grammar bundle, unused-export check, form
 pnpm run check
 ```
 
+`pnpm run check` now also lints `packages/monitor` via its own `lint` script.
+
 Fix formatting and lint issues automatically:
 
 ```console
@@ -207,7 +209,7 @@ Two independent caches speed up CI and deploy:
 | Cache    | What                 | Key                      |
 | -------- | -------------------- | ------------------------ |
 | pnpm     | pnpm global store    | `pnpm-lock.yaml` hash    |
-| LilyPond | `~/.local/lilypond/` | `lilypond-2.26.0-{os}`  |
+| LilyPond | `~/.local/lilypond/` | `lilypond-2.26.0-{os}`   |
 
 ### Concurrency
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -289,7 +289,7 @@ The repository owner may push directly to `main` only for **non-code changes**: 
 
 The CI pipeline runs `pnpm run check:lint` and `pnpm run check:types`. Pull requests must pass both.
 
-The project uses an ESLint flat config (`eslint.config.js`) with `typescript-eslint`. Some rules are relaxed because the codebase predates them (for example, `no-var` and `@typescript-eslint/no-explicit-any` are currently off). Follow the existing patterns in the file you are editing rather than refactoring legacy code to meet stricter rules.
+The project uses an ESLint flat config (`eslint.config.js`) with `typescript-eslint`. Some rules are relaxed because the codebase predates them (for example, `no-var` and `@typescript-eslint/no-explicit-any` are currently off). Follow the existing patterns in the file you are editing rather than refactoring legacy code to meet stricter rules. `packages/monitor` has its own config for Node `.mjs` files and is linted via `pnpm --filter @spem/monitor lint`.
 
 ESLint honours `.gitignore` (via `includeIgnoreFile`, bundled with ESLint as `eslint/config`), so gitignored paths are never linted. The `ignores` array in `eslint.config.js` lists only the few paths that are *not* gitignored (for example local-only `tests-local/` and `probes/`); the comment there records the current membership. To stop a path being linted, prefer adding it to `.gitignore`; reach for the ESLint `ignores` array only when the path must stay tracked.
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -57,7 +57,7 @@ pnpm run test:coverage
 
 Unit tests live under `src/test/` and `packages/scores/test/` (excluding `*.integration.test.ts`) and follow the naming convention `*.test.ts`. They run in-process under jsdom and should complete in under a few seconds each. In-process tests against `packages/scores/build/` code (for example `postprocessSvg.test.ts`) live in `packages/scores/test/` alongside the integration suite.
 
-Scripts in `packages/monitor/` that expose pure functions use the Node.js built-in test runner (`node:test`) rather than Vitest, and live alongside the script as `*.test.mjs`. Run them directly with `pnpm --filter monitor test`. These files are excluded from the Vitest config (`packages/pwa/vite.config.ts`) and do not appear in `pnpm run test:unit` output.
+Scripts in `packages/monitor/` that expose pure functions use the Node.js built-in test runner (`node:test`) rather than Vitest, and live alongside the script as `*.test.mjs`. Run them directly with `pnpm --filter monitor test` and lint them with `pnpm --filter @spem/monitor lint`. These files are excluded from the Vitest config (`packages/pwa/vite.config.ts`) and do not appear in `pnpm run test:unit` output.
 
 Integration tests live in `packages/scores/test/*.integration.test.ts` and also follow `*.test.ts`. They typically spawn subprocesses (LilyPond, the build pipeline) and are substantially slower.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "pnpm --filter @spem/pwa test:watch",
     "test:coverage": "pnpm --filter @spem/pwa test:coverage",
     "e2e": "pnpm --filter @spem/pwa e2e",
-    "check": "pnpm --filter @spem/pwa check",
+    "check": "pnpm --filter @spem/pwa check && pnpm --filter @spem/monitor lint",
     "ci": "pnpm run check && pnpm run build && pnpm run test:unit",
     "prepare": "husky"
   },

--- a/packages/monitor/eslint.config.js
+++ b/packages/monitor/eslint.config.js
@@ -1,0 +1,17 @@
+import js from '@eslint/js'
+import globals from 'globals'
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.mjs'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        fetch: 'readonly',
+      },
+    },
+  },
+]

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -5,9 +5,13 @@
   "description": "Daily build-resource monitor for Spem Player",
   "type": "module",
   "scripts": {
-    "test": "node --test monitor-resources.test.mjs render-burndown.test.mjs"
+    "test": "node --test monitor-resources.test.mjs render-burndown.test.mjs",
+    "lint": "eslint . --max-warnings 0"
   },
   "devDependencies": {
- "canvas": "^3.2.0"
+    "@eslint/js": "^10.0.1",
+    "canvas": "^3.2.0",
+    "eslint": "^10.4.1",
+    "globals": "^17.6.0"
   }
 }

--- a/packages/pwa/eslint.config.js
+++ b/packages/pwa/eslint.config.js
@@ -50,17 +50,6 @@ export default tseslint.config(
     },
   },
   {
-    files: ['../packages/monitor/*.mjs', '../scripts/*.mjs'],
-    languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      globals: {
-        ...globals.node,
-        fetch: 'readonly',
-      },
-    },
-  },
-  {
     // .gitignore is honoured via includeIgnoreFile above; only paths that are
     // NOT gitignored need listing here. tests-local/ and probes/ are local-only
     // (.git/info/exclude, not .gitignore); .dependency-cruiser.cjs is tracked.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,18 @@ importers:
 
   packages/monitor:
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       canvas:
         specifier: ^3.2.0
         version: 3.2.3
+      eslint:
+        specifier: ^10.4.1
+        version: 10.4.1(jiti@2.7.0)
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
 
   packages/pwa:
     dependencies:


### PR DESCRIPTION
Fixes #616

Restores ESLint coverage for `packages/monitor` `.mjs` files after the workspace restructure left them unlinted, and documents the new lint run in the contributor docs.

- Adds `packages/monitor/eslint.config.js` with `@eslint/js` recommended + Node globals.
- Adds `eslint`, `@eslint/js`, `globals` devDependencies and a `lint` script to `packages/monitor/package.json`.
- Updates root `package.json` `check` script to run `pnpm --filter @spem/monitor lint` after the PWA check.
- Removes the dead monitor/scripts override block from `packages/pwa/eslint.config.js`.
- Updates `doc/BUILD.md`, `doc/TESTING.md`, and `doc/CONTRIBUTING.md` to note the monitor lint run.

- KIMI
