### PR TITLE
docs: re-ratify #484 tech-debt categories after post-rollout calibration

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -25,15 +25,15 @@ These principles guide what we fix, how much we fix, and when we decline a fix. 
 
 ### When we decline
 
-- Decline a fix whose cost is disproportionate to the harm. Cost includes new abstraction, infrastructure, complexity, and ongoing maintenance burden.
-- Prefer the simpler rule when the residual cost is small.
+- A fix earns a board ticket only when the harm it removes (likelihood x severity) justifies its cost — new abstraction, infrastructure, complexity, ongoing maintenance. What earns it is the harm removed, not how little the fix costs; cheapness alone is never the reason.
+- Once justified, prefer the simpler shape where the extra cost is small — choosing between shapes of a worthwhile fix, not licensing a low-value one.
 
 ### Tech debt that earns a board ticket
 
 Tech debt is refactor-report-only by default and rides along with adjacent work. It may become its own board ticket (`Type: tech debt`) only if it demonstrably and now does one of:
 
-- **Performance**: a measurable win on responsiveness, build/CI time or cost, or bundle size.
-- **Simplify**: a net reduction in the production *code* — fewer lines, branches, abstractions, or indirection; dead code or a redundant layer removed. The test is the *code* diff coming out smaller and flatter, not the file size. Comments or fast tests added alongside do not count against it.
+- **Performance**: a discernible benefit to responsiveness, build/CI time or cost, or bundle size — discernible meaning you can name the specific waste removed (a redundant per-file program build, an O(n^2) where O(n) suffices, repeated recomputation), not a win you'd need a benchmark to believe or could merely assert. No number is required to qualify; a probe can confirm magnitude when it's genuinely in doubt.
+- **Simplify**: a net reduction in production-code complexity — fewer lines, branches, abstractions, or indirection; dead code or a redundant layer removed; or fewer distinct cases / special-cases / divergent variants (e.g. two divergent config regimes collapsed into one). The test is a countable drop — in lines/branches or in distinct cases — not "feels cleaner"; the case-count may fall even if line-count holds or rises slightly. Comments or fast tests added alongside do not count against it.
 - **Maintainable**: a *specific* future change made safer, or a *specific* way the code is easy to use wrongly removed — for example a compiler-enforced invariant, or a fragile structure made robust. "Feels cleaner" is not enough; naming the future risk removed does. Two cases count explicitly:
   - **Comments**: replacing misleading, verbose, or needlessly complex comments with clear ones.
   - **Tests**: pinning a specific, currently-unverified behaviour with a fast test, shown to fail if that behaviour breaks. The win is the named regression it now catches, not a coverage percentage.


### PR DESCRIPTION
## Re-ratification: refined #484 tech-debt categories

Wording calibrations of the tech-debt-ticketing principles you ratified in #595 — **no new categories, no code change**. Post-rollout use surfaced three wording traps; this PR sharpens them so they read as intended.

Fixes #618. Context: #595 (original ratification of these principles), #484 (original categories). Calibration recorded in our Workbench Item #524.

### The three changes in `doc/CONTRIBUTING.md`

**Performance** — "measurable win" was being read as *requires a number*, discouraging plainly-wasteful removals that are hard to benchmark. Now:
> - **Performance**: a discernible benefit to responsiveness, build/CI time or cost, or bundle size — discernible meaning you can name the specific waste removed (a redundant per-file program build, an O(n^2) where O(n) suffices, repeated recomputation), not a win you'd need a benchmark to believe or could merely assert. No number is required to qualify; a probe can confirm magnitude when it's genuinely in doubt.

**Simplify** — was line-count-biased; it missed case-count reductions where line-count holds or rises. Now:
> - **Simplify**: a net reduction in production-code complexity — fewer lines, branches, abstractions, or indirection; dead code or a redundant layer removed; or fewer distinct cases / special-cases / divergent variants (e.g. two divergent config regimes collapsed into one). The test is a countable drop — in lines/branches or in distinct cases — not "feels cleaner"; the case-count may fall even if line-count holds or rises slightly. Comments or fast tests added alongside do not count against it.

**When we decline** — was read as a low-cost greenlight rather than a proportionality check, and the "once justified" guard was lost. Now:
> - A fix earns a board ticket only when the harm it removes (likelihood x severity) justifies its cost — new abstraction, infrastructure, complexity, ongoing maintenance. What earns it is the harm removed, not how little the fix costs; cheapness alone is never the reason.
> - Once justified, prefer the simpler shape where the extra cost is small — choosing between shapes of a worthwhile fix, not licensing a low-value one.

- Sauron
