### PR TITLE
build: pin *.ohm to LF to fix Windows build:ohm CRLF phantom diff (#611)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 *.scss text eol=lf
 *.css text eol=lf
 *.html text eol=lf
+*.ohm text eol=lf
 .husky/pre-commit text eol=lf

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -172,6 +172,8 @@ When releasing, update `package.json` only. The build will propagate the new ver
 
 `pnpm run build:ohm` regenerates `src/ohmjs/ly-grammar.ohm-bundle.js` and `src/ohmjs/ly-grammar.ohm-bundle.d.ts` from `src/ohmjs/ly-grammar.ohm` via `@ohm-js/cli`. If you modify the grammar, rebuild before testing or deploying.
 
+`ly-grammar.ohm` is pinned to LF by `.gitattributes` (`*.ohm text eol=lf`) so `build:ohm` is deterministic across platforms. Without the rule, a Windows checkout (e.g. with `core.autocrlf=true`) writes the grammar with CRLF and `build:ohm` bakes those CRLFs into the `source` string literal of the generated bundle, producing a phantom diff on every Windows build, even from a clean tree (#611). The bundle file's own line endings are already LF via the existing `*.js` rule; the `*.ohm` rule is what stops CRLF being baked into that literal.
+
 ## Build Output
 
 The production build writes to `dist/`:

--- a/packages/pwa/src/test/ohm-eol.test.ts
+++ b/packages/pwa/src/test/ohm-eol.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the `.gitattributes` rule that pins `*.ohm` to LF on checkout (#611).
+ *
+ * Without it, a Windows checkout (e.g. with `core.autocrlf=true`) writes
+ * `ly-grammar.ohm` with CRLF, and `build:ohm` bakes those endings into the
+ * `source` literal of `ly-grammar.ohm-bundle.js` (as the escaped sequence
+ * `\r\n`, since Ohm embeds the grammar via `JSON.stringify`), giving a phantom
+ * diff on every Windows build (see doc/BUILD.md). CI is Linux/LF and never
+ * exhibits it, so these two checks are the cross-platform guard: case 1 asserts
+ * the root-cause rule is present; case 2 checks the committed bundle's literal
+ * for a baked `\r\n` escape (the bundle file's own line endings are already LF
+ * via the pre-existing `*.js` rule, so case 2 guards the literal's content, not
+ * the file).
+ *
+ * Reads are relative to the pwa package cwd, matching grammar-consistency.test.ts.
+ */
+describe("ohm grammar line-ending hygiene (#611)", () => {
+  it(".gitattributes pins *.ohm to eol=lf", () => {
+    const attrs = readFileSync("../../.gitattributes", "utf-8");
+    const ohmRule = attrs
+      .split(/\r?\n/)
+      .find((line) => /^\s*\*\.ohm\b/.test(line));
+    expect(
+      ohmRule,
+      "no `*.ohm` rule in .gitattributes, so Windows `build:ohm` bakes CRLF into the grammar bundle (#611)"
+    ).toBeTruthy();
+    expect(ohmRule, "the `*.ohm` rule must pin `eol=lf`").toMatch(/eol=lf/);
+  });
+
+  it("the grammar bundle has no baked-in CRLF escape", () => {
+    const bundle = readFileSync("src/ohmjs/ly-grammar.ohm-bundle.js", "utf-8");
+    // A CRLF-checked-out grammar is baked into the `source` literal as the
+    // escaped sequence \r\n (the characters backslash-r-backslash-n), never a
+    // raw CR byte, so search for the escape, not for a raw "\r".
+    expect(
+      bundle.includes("\\r\\n"),
+      "ly-grammar.ohm-bundle.js has a \\r\\n escape in its source literal; a CRLF .ohm was baked in (#611)"
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #611.

On Windows (e.g. with `core.autocrlf=true`), `ly-grammar.ohm` was checked out with CRLF because `.gitattributes` had no `*.ohm` rule. `build:ohm` then baked those CRLFs into the `source` string literal of the generated `ly-grammar.ohm-bundle.js` (as escaped `\r\n` sequences, since Ohm embeds the grammar via `JSON.stringify`), producing a phantom diff on `git status` after every Windows build, even from a clean tree.

This pins `*.ohm` to LF (`*.ohm text eol=lf`), adds a cross-platform regression test (case 1: the rule is present; case 2: the committed bundle's source literal carries no `\r\n` escape), and documents the invariant in `doc/BUILD.md`. CI runs on Linux (LF) and cannot exhibit the bug, so the test is the guard. This is a `build:` change with no version bump.
