### PR TITLE
fix: use --color-on-light for help links and feedback controls (#569)

### DIFF
--- a/packages/pwa/e2e/lightmode-contrast.spec.ts
+++ b/packages/pwa/e2e/lightmode-contrast.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const selectors = [
+  ["#test-help-link", "help link"],
+  ['#feedback-submit[type="submit"]', "feedback submit button"],
+  ['#feedback-cancel[type="button"]', "feedback cancel button"],
+  ["label[for='star1']", "star rating label"],
+] as const;
+
+async function elementColours(page: Page) {
+  return page.evaluate(
+    (sel) =>
+      sel.map((s) => {
+        const el = document.querySelector(s);
+        if (!el) throw new Error(`selector matched nothing: ${s}`);
+        return window.getComputedStyle(el).color;
+      }),
+    selectors.map(([s]) => s)
+  );
+}
+
+test.describe("Light mode contrast", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+
+    // Inject a help link with no inline colour so the `#help a` SCSS rule is
+    // tested, not the Buy Me a Coffee script's injected anchor (its inline
+    // colours would override the stylesheet). Fail loudly if the fixtures the
+    // suite depends on are missing, rather than silently testing nothing.
+    await page.evaluate(() => {
+      const help = document.getElementById("help");
+      const modal = document.getElementById("feedback-modal");
+      if (!help || !modal) {
+        throw new Error(
+          "lightmode-contrast fixture drift: #help/#feedback-modal not found"
+        );
+      }
+      const link = document.createElement("a");
+      link.id = "test-help-link";
+      link.href = "https://example.com";
+      link.textContent = "Test help link";
+      help.appendChild(link);
+      help.style.display = "block";
+      modal.style.display = "block";
+    });
+  });
+
+  test("help links and feedback controls are not white in light mode", async ({
+    page,
+  }) => {
+    const body = page.locator("body");
+    await page.locator("#darkswitch").click();
+    await expect(body).toHaveClass(/light-theme/);
+
+    for (const [selector, name] of selectors) {
+      const locator = page.locator(selector).first();
+      await expect(locator).toBeVisible();
+
+      const colour = await locator.evaluate(
+        (el) => window.getComputedStyle(el).color
+      );
+      expect(colour, `${name} colour in light mode`).not.toBe(
+        "rgb(255, 255, 255)"
+      );
+    }
+  });
+
+  test("help links and feedback controls use the same colour in both modes", async ({
+    page,
+  }) => {
+    const body = page.locator("body");
+    const darkColours = await elementColours(page);
+
+    await page.locator("#darkswitch").click();
+    await expect(body).toHaveClass(/light-theme/);
+
+    const lightColours = await elementColours(page);
+
+    expect(lightColours).toEqual(darkColours);
+  });
+});

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/packages/pwa/src/scss/style.scss
+++ b/packages/pwa/src/scss/style.scss
@@ -10,6 +10,8 @@ html {
 /* Default colors (dark theme) */
 body {
   --color-background: hsl(210, 65%, 20%);
+  // stays dark in both themes: ink for elements on fixed light surfaces (#569)
+  --color-on-light: hsl(210, 65%, 20%);
   --color-text: hsl(0, 0%, 92%);
   --color-title: hsl(210, 65%, 80%);
   --color-highlight: hsl(210, 65%, 25%);
@@ -227,7 +229,7 @@ header {
   }
 
   a {
-    color: var(--color-background);
+    color: var(--color-on-light);
     text-decoration: none;
     &:hover {
       text-decoration: underline;
@@ -661,12 +663,12 @@ kbd {
 
       &[type="submit"] {
         background: var(--color-active-button);
-        color: var(--color-background);
+        color: var(--color-on-light);
       }
 
       &[type="button"] {
         background: transparent;
-        color: var(--color-background);
+        color: var(--color-on-light);
       }
 
       &:hover {
@@ -707,7 +709,7 @@ kbd {
   label {
     cursor: pointer;
     font-size: 2rem;
-    color: var(--color-background);
+    color: var(--color-on-light);
     opacity: 0.4;
 
     &::before {


### PR DESCRIPTION
Fixes #569.

In light mode, the help links and feedback controls used a colour that rendered them invisible against the light background. This switches them to `--color-on-light` so they are legible in light mode.

Adds an e2e test (`packages/pwa/e2e/lightmode-contrast.spec.ts`) covering the contrast, and bumps the PWA version (user-facing fix). The Vera gate passed (Area UI) during the original work; this PR is the unparked branch (it was previously held only by the Review WIP limit, now cleared), rebased onto current `main` with no content change.
