### PR TITLE
fix: prevent command injection in buildScores via execFileSync + option whitelist (#624)

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -81,6 +81,8 @@ pnpm run build:scores -- --version="Hugh Keyte" --notation=early --choir="II B"
 
 This iterates over matching `Choir*.ly` files under `packages/scores/src/` and runs `lilypond --svg` for each, then post-processes the generated SVG with `packages/scores/build/postprocessSvg.mjs`.
 
+LilyPond is invoked via `execFileSync` (no shell), so no option value — `--version`, `--notation`, `--outDir`, the resolved `.ly` path, or `LILYPOND_CMD` — can inject shell commands: each is passed as a literal argument. Separately, `--version` and `--notation` are whitelisted to their known values because they become output-directory path segments. By default the `lilypond` binary on `PATH` is used; set the `LILYPOND_CMD` environment variable to a JSON array to point at a wrapped install — for example `LILYPOND_CMD='["flatpak","run","org.lilypond.LilyPond"]'` or `LILYPOND_CMD='["wsl","lilypond"]'` (POSIX shell syntax; in PowerShell use `$env:LILYPOND_CMD='[...]'`). The array is `[binary, ...prefixArgs]`; the build appends LilyPond's own arguments.
+
 ### Timing
 
 LilyPond is the slow part: roughly 60 seconds per choir, 16 choirs across early + modern notations. When `.ly` sources are current, `pnpm run build:scores` (and the `prebuild` step inside `pnpm run build`) completes in a few seconds because `needsRebuild` compares mtimes and skips unchanged files. After a batch edit of `.ly` files — particularly shared includes (`basic.ly`, `layout.ly`) — expect the next full `pnpm run ci` to take 10+ minutes as the affected SVGs regenerate. This is a one-off; the next build after that is fast again.

--- a/packages/scores/build/buildScores.mjs
+++ b/packages/scores/build/buildScores.mjs
@@ -2,7 +2,7 @@
 // Copyright (c) 2024-2026 Mark Wainwright
 // SPDX-License-Identifier: MIT
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { existsSync, globSync, mkdirSync, realpathSync, rmSync, statSync } from "fs";
 import { basename, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -75,6 +75,23 @@ function validateOptions(options) {
       process.exit(1);
     }
   }
+
+  // Whitelist version/notation because they become directory-path segments in
+  // the build output (resolve(outDirBase, version, notation)); this bounds them
+  // to known values. It is NOT the shell-injection defence — execFileSync (no
+  // shell) is, and that covers every argument regardless of this list. Omitted
+  // (undefined/null) is fine — the defaults are applied later; bare flags (true)
+  // are handled above (#624).
+  const allowedValues = { version: ["Hugh Keyte", "OUP"], notation: ["early", "modern"] };
+  for (const [flag, values] of Object.entries(allowedValues)) {
+    const value = options[flag];
+    if (value === undefined || value === null || value === true) continue;
+    if (!values.includes(value)) {
+      console.error(`Error: --${flag} "${value}" is not a valid value.`);
+      console.error(`  Valid values: ${values.join(", ")}`);
+      process.exit(1);
+    }
+  }
 }
 
 function parseLilypondVersion(output) {
@@ -94,10 +111,44 @@ function compareVersions(a, b) {
   return 0;
 }
 
+/**
+ * The command used to invoke LilyPond, as `[binary, ...prefixArgs]`.
+ *
+ * Defaults to `["lilypond"]`. Override with the `LILYPOND_CMD` env var (a JSON
+ * array of strings) to point at a wrapped install — e.g.
+ * `["flatpak","run","org.lilypond.LilyPond"]`, `["wsl","lilypond"]`, or a test
+ * fake `["node","/path/to/fake.js"]`. The command is always invoked via
+ * `execFileSync` (no shell), so the override is not a shell-injection surface.
+ */
+function lilypondCommand() {
+  const raw = process.env.LILYPOND_CMD;
+  if (!raw) return ["lilypond"];
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.error('Error: LILYPOND_CMD must be a JSON array of strings, e.g. ["lilypond"].');
+    process.exit(1);
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0 || !parsed.every((s) => typeof s === "string")) {
+    console.error("Error: LILYPOND_CMD must be a non-empty JSON array of strings.");
+    process.exit(1);
+  }
+  return parsed;
+}
+
 function checkLilypond(version) {
   let output;
   try {
-    output = execSync("lilypond --version", { encoding: "utf-8", stdio: "pipe" });
+    const [bin, ...prefix] = lilypondCommand();
+    // Pipe (don't inherit) the child's stderr: without an explicit stdio,
+    // execFileSync leaks LilyPond's startup/Guile noise to the build console
+    // and muddies the catch block's "is not installed" message. stdout stays
+    // piped so the version string below can be parsed (#624).
+    output = execFileSync(bin, [...prefix, "--version"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
   } catch (error) {
     console.error("Error: lilypond is not installed or not on PATH.");
     console.error("Please install LilyPond before building scores.");
@@ -197,7 +248,11 @@ function buildScore(ly, version, notation, maxLyMtime, outDirBase) {
     // LilyPond does not create its output directory; on a clean checkout
     // (src/scores/ is gitignored post-#318) it aborts. Create it first.
     mkdirSync(outDir, { recursive: true });
-    execSync(`lilypond --svg -o "${outDir}/" "${ly}"`, { stdio: "inherit" });
+    // execFileSync (no shell) so user-controlled path segments in `outDir`
+    // (from --version/--notation/--outDir) and `ly` cannot break out of a quoted
+    // argument and inject shell commands (#624). Each value is passed literally.
+    const [bin, ...prefix] = lilypondCommand();
+    execFileSync(bin, [...prefix, "--svg", "-o", `${outDir}/`, ly], { stdio: "inherit" });
   } catch (error) {
     rmSync(svg, { force: true });
     console.error(`\nError building ${choirName}:\n${error.message}`);
@@ -268,4 +323,4 @@ if (isMain) {
   main();
 }
 
-export { parseArgs, buildPattern };
+export { parseArgs, buildPattern, validateOptions, buildScore, lilypondCommand };

--- a/packages/scores/test/buildScores.integration.test.ts
+++ b/packages/scores/test/buildScores.integration.test.ts
@@ -1,4 +1,4 @@
-import { execSync, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import {
   copyFileSync,
   cpSync,
@@ -31,7 +31,9 @@ const FAKE_LILYPOND_LOG = join(
 );
 
 /**
- * Create a fake lilypond executable and return its directory.
+ * Create a fake lilypond helper script and return its directory. The fake is a
+ * plain `_fake_lilypond.js` driven via `LILYPOND_CMD = [node, helper]`, not an
+ * executable on PATH (#624).
  */
 function createFakeLilypond(): string {
   const fakeDir = mkdtempSync(join(tmpdir(), "spem-fake-lilypond-"));
@@ -82,30 +84,20 @@ fs.appendFileSync(logFile, args.join(" ") + "\\n", "utf-8");
     "utf-8"
   );
 
-  // Windows batch file
-  const bat = join(fakeDir, "lilypond.bat");
-  writeFileSync(bat, `@echo off\nnode "${helperJs}" %*\n`, "utf-8");
-
-  // Unix shell script
-  const sh = join(fakeDir, "lilypond");
-  writeFileSync(sh, `#!/bin/sh\nnode "${helperJs}" "$@"\n`, "utf-8");
-  try {
-    execSync(`chmod +x "${sh}"`);
-  } catch (error) {
-    // Windows has no chmod (the .bat fixture is used there). On Unix a
-    // chmod failure would leave the script non-executable and PATH lookup
-    // would silently fall through to another fake — rethrow so the cause
-    // is visible (Vera 539-01).
-    if (process.platform !== "win32") throw error;
-  }
-
+  // The build invokes LilyPond via execFileSync(LILYPOND_CMD) with no shell, so
+  // the fake is driven as [node, helperJs] (see envWithFakeLilypond) rather than
+  // a PATH-resolved .bat/.sh: `node` is a real executable on every platform,
+  // whereas execFileSync cannot run a script or a .bat without a shell (#624).
   return fakeDir;
 }
 
 /**
- * Return an environment object with fake lilypond on PATH and node_modules visible.
+ * Return an environment object that points LILYPOND_CMD at the fake lilypond
+ * (driven as [node, helper], no shell) and makes node_modules visible via
+ * NODE_PATH. The fake is no longer placed on PATH (#624).
  */
 function envWithFakeLilypond(fakeDir: string): NodeJS.ProcessEnv {
+  const helperJs = join(fakeDir, "_fake_lilypond.js");
   const nodePath = process.env.NODE_PATH
     ? join(REPO_ROOT, "node_modules") +
       (process.platform === "win32" ? ";" : ":") +
@@ -113,9 +105,9 @@ function envWithFakeLilypond(fakeDir: string): NodeJS.ProcessEnv {
     : join(REPO_ROOT, "node_modules");
   return {
     ...process.env,
-    PATH:
-      fakeDir + (process.platform === "win32" ? ";" : ":") + process.env.PATH,
     NODE_PATH: nodePath,
+    // Drive the fake via execFileSync([node, helper]) — cross-platform, no shell.
+    LILYPOND_CMD: JSON.stringify([process.execPath, helperJs]),
   };
 }
 
@@ -434,6 +426,9 @@ describe("buildScores.mjs integration", () => {
       ...process.env,
       PATH: "",
     };
+    // Use the default ["lilypond"] (so the spawn fails with ENOENT) even if the
+    // ambient/CI environment has LILYPOND_CMD set — the rest of the suite sets it.
+    delete envNoLilypond.LILYPOND_CMD;
 
     const result = spawnSync(process.execPath, [BUILD_SCRIPT], {
       cwd: REPO_ROOT,
@@ -444,13 +439,11 @@ describe("buildScores.mjs integration", () => {
     expect(result.status).not.toBe(0);
     const output = (result.stdout + result.stderr).toLowerCase();
     expect(output).toContain("lilypond");
-    // Node's checkExecSyncError prefix is platform-stable; shell wordings
-    // are not (cmd "not recognized", bash "command not found", dash plain
-    // "not found" or — via the empty-PATH-element cwd trap — "Permission
-    // denied"). Both branches reach stderr only through the evidence line
-    // #549 added, so this still pins that line. ENOENT covers the one
-    // remaining class: the shell binary itself failing to spawn.
-    expect(result.stderr).toMatch(/Command failed: lilypond --version|ENOENT/);
+    // No shell runs now (execFileSync): an absent lilypond fails to spawn with
+    // ENOENT (status null), not a shell "command not found"/"not recognized".
+    // checkLilypond's evidence line (#549) carries that message to stderr, so
+    // pin ENOENT — the one class an absent binary produces under execFileSync.
+    expect(result.stderr).toMatch(/ENOENT/);
     expect(result.stderr).toMatch(/\(status: (?:\d+|none), signal: none\)/);
   });
 
@@ -707,33 +700,11 @@ describe("buildScores.mjs integration", () => {
         "utf-8"
       );
 
-      const failBat = join(failDir, "lilypond.bat");
-      writeFileSync(
-        failBat,
-        `@echo off\nnode "${failHelperJs}" %*\n`,
-        "utf-8"
-      );
-
-      const failSh = join(failDir, "lilypond");
-      // Delegate to the same helper as the .bat so both platforms execute
-      // identical failure logic by construction (Vera 539-03).
-      writeFileSync(failSh, `#!/bin/sh\nnode "${failHelperJs}" "$@"\n`, "utf-8");
-      try {
-        execSync(`chmod +x "${failSh}"`);
-      } catch (error) {
-        // Windows has no chmod (the .bat fixture is used there). On Unix a
-        // chmod failure would leave the script non-executable and PATH
-        // lookup would silently fall through to the success fake — rethrow
-        // so the cause is visible (Vera 539-01).
-        if (process.platform !== "win32") throw error;
-      }
-
+      // Point LILYPOND_CMD at the failing helper via [node, helper] — the same
+      // no-shell, cross-platform mechanism the success fake uses (#624).
       const envFail = {
         ...env,
-        PATH:
-          failDir +
-          (process.platform === "win32" ? ";" : ":") +
-          env.PATH,
+        LILYPOND_CMD: JSON.stringify([process.execPath, failHelperJs]),
       };
 
       const result2 = spawnSync(

--- a/packages/scores/test/buildScores.security.test.ts
+++ b/packages/scores/test/buildScores.security.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// buildScore must shell out without a shell, so mock the exec layer and the
+// fs/postprocess touchpoints it hits between entry and the exec call.
+vi.mock("child_process", () => ({
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+// existsSync:false makes needsRebuild() short-circuit true at its first check,
+// so buildScore skips the real statSync and reaches the (mocked) exec call;
+// mkdirSync is stubbed because buildScore creates the output dir before exec.
+vi.mock("fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("fs")>()),
+  existsSync: () => false,
+  mkdirSync: () => undefined,
+}));
+vi.mock("../build/postprocessSvg.mjs", () => ({ postprocessSvg: vi.fn() }));
+
+import { execSync, execFileSync } from "child_process";
+import {
+  validateOptions,
+  buildScore,
+  lilypondCommand,
+} from "../build/buildScores.mjs";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("validateOptions value whitelist (#624)", () => {
+  // validateOptions calls process.exit(1) on rejection; capture that as a throw.
+  function run(options: Record<string, unknown>): string | null {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((code?: number) => {
+        throw new Error(`exit:${code}`);
+      });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      validateOptions(options);
+      return null;
+    } catch (e) {
+      return (e as Error).message;
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  }
+
+  it("accepts whitelisted version and notation values", () => {
+    expect(run({ version: "Hugh Keyte", notation: "early" })).toBeNull();
+    expect(run({ version: "OUP", notation: "modern" })).toBeNull();
+  });
+
+  it("accepts omitted version/notation (defaults are applied later)", () => {
+    expect(run({})).toBeNull();
+    expect(run({ notation: null })).toBeNull();
+  });
+
+  it("accepts a bare --version/--notation flag (true is left to the earlier loop)", () => {
+    // The whitelist loop skips value === true; the bare-flag loop above it is
+    // what rejects a bare --version. Document that interaction here so a future
+    // reorder of the two loops is caught (Vera 624-S3).
+    expect(run({ version: true })).toBe("exit:1");
+    expect(run({ notation: true })).toBe("exit:1");
+  });
+
+  it("rejects a version outside the whitelist", () => {
+    expect(run({ version: "Evil Edition" })).toBe("exit:1");
+  });
+
+  it("rejects a notation outside the whitelist", () => {
+    expect(run({ notation: "baroque" })).toBe("exit:1");
+  });
+
+  it("rejects a shell-metacharacter injection payload in --version (#624)", () => {
+    expect(run({ version: '" & echo INJECTED & ' })).toBe("exit:1");
+  });
+});
+
+describe("lilypondCommand LILYPOND_CMD parsing (#624)", () => {
+  // lilypondCommand calls process.exit(1) with a specific message on bad input.
+  // Capture the exit as a throw and the console.error text so we can assert the
+  // branch that fired. These error paths gate an exec call and were previously
+  // untested (Vera 624-03).
+  function call(envValue: string | undefined): {
+    result: string[] | null;
+    exited: boolean;
+    errMsg: string;
+  } {
+    const prev = process.env.LILYPOND_CMD;
+    if (envValue === undefined) delete process.env.LILYPOND_CMD;
+    else process.env.LILYPOND_CMD = envValue;
+    let errMsg = "";
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    const errSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation((m?: unknown) => {
+        errMsg += String(m) + "\n";
+      });
+    try {
+      return { result: lilypondCommand(), exited: false, errMsg };
+    } catch {
+      return { result: null, exited: true, errMsg };
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+      if (prev === undefined) delete process.env.LILYPOND_CMD;
+      else process.env.LILYPOND_CMD = prev;
+    }
+  }
+
+  it("defaults to ['lilypond'] when LILYPOND_CMD is unset", () => {
+    expect(call(undefined)).toMatchObject({
+      result: ["lilypond"],
+      exited: false,
+    });
+  });
+
+  it("returns a valid override array verbatim", () => {
+    expect(call('["node", "/fake/helper.js"]').result).toEqual([
+      "node",
+      "/fake/helper.js",
+    ]);
+  });
+
+  it("rejects a non-JSON value (the most likely typo: no brackets)", () => {
+    const r = call("lilypond");
+    expect(r.exited).toBe(true);
+    expect(r.errMsg).toContain("must be a JSON array");
+  });
+
+  it("rejects JSON that is not an array", () => {
+    const r = call('"lilypond"');
+    expect(r.exited).toBe(true);
+    expect(r.errMsg).toContain("non-empty JSON array");
+  });
+
+  it("rejects an empty array", () => {
+    const r = call("[]");
+    expect(r.exited).toBe(true);
+    expect(r.errMsg).toContain("non-empty JSON array");
+  });
+
+  it("rejects an array with a non-string element", () => {
+    const r = call("[1, 2]");
+    expect(r.exited).toBe(true);
+    expect(r.errMsg).toContain("non-empty JSON array");
+  });
+});
+
+describe("buildScore shells out without a shell (#624)", () => {
+  it("invokes execFileSync with an argument array, never a shell string", () => {
+    buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out");
+
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = vi.mocked(execFileSync).mock.calls[0];
+    expect(cmd).toBe("lilypond");
+    expect(Array.isArray(args)).toBe(true);
+    expect(args).toContain("--svg");
+    expect(args).toContain("-o");
+    expect(args).toContain("/src/Choir I A.ly");
+
+    // The property that actually defeats injection: no shell. With shell:true,
+    // execFile re-joins the array through a shell and the guarantee is lost, yet
+    // every assertion above would still pass — so pin it explicitly (Vera 624-S1).
+    expect((opts as { shell?: unknown } | undefined)?.shell).toBeFalsy();
+
+    // The vulnerable form interpolated everything into one execSync string.
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it("passes a metacharacter-laden outDir to execFileSync as one literal arg (#624)", () => {
+    // outDir flows from --outDir (deliberately not whitelisted, since it is a
+    // real user path). execFileSync (no shell) must pass it literally, so a
+    // shell-metacharacter value cannot inject. Pins the bug class against a
+    // future revert to a template string on the -o argument (Vera 624-06).
+    buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out; touch pwned");
+
+    const args = vi.mocked(execFileSync).mock.calls[0][1] as string[];
+    const outArg = args[args.indexOf("-o") + 1];
+    expect(outArg).toContain("; touch pwned"); // survived as a literal segment
+    expect(outArg).toContain("Hugh Keyte");
+    // It is a single argv element, not split on the metacharacters.
+    expect(args.filter((a) => a.includes("touch pwned"))).toHaveLength(1);
+    expect(execSync).not.toHaveBeenCalled();
+  });
+
+  it("honours a LILYPOND_CMD override as [binary, ...prefix] (#624)", () => {
+    const prev = process.env.LILYPOND_CMD;
+    process.env.LILYPOND_CMD = JSON.stringify(["node", "/fake/helper.js"]);
+    try {
+      buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out");
+      const [cmd, args] = vi.mocked(execFileSync).mock.calls[0];
+      expect(cmd).toBe("node");
+      expect(args?.[0]).toBe("/fake/helper.js");
+      expect(args).toContain("--svg");
+      expect(args).toContain("/src/Choir I A.ly");
+    } finally {
+      if (prev === undefined) delete process.env.LILYPOND_CMD;
+      else process.env.LILYPOND_CMD = prev;
+    }
+  });
+});


### PR DESCRIPTION
Fixes #624.

`buildScores.mjs` invoked LilyPond via `execSync` with the output directory and
`.ly` path interpolated into a shell command string. `--version` and `--notation`
are user-controlled CLI flags that flow into the output path, so a crafted value
could break out of the quoted `-o` argument and run arbitrary shell commands.

## Fix

- Replace both `execSync` call sites with `execFileSync` (no shell), so every
  argument — `outDir` (from `--version`/`--notation`/`--outDir`), the `.ly` path,
  and the LilyPond binary — is passed literally and cannot inject. This is the
  actual injection guarantee.
- Whitelist `--version` (`Hugh Keyte`, `OUP`) and `--notation` (`early`, `modern`)
  values, which become output-directory path segments (defence in depth, not the
  injection barrier).
- Add a `LILYPOND_CMD` JSON-array override (`[binary, ...prefixArgs]`) for wrapped
  installs (`flatpak`, `wsl`) and the test fake — needed because `execFileSync`
  cannot run a `.bat`/script without a shell.

## Tests

- New `buildScores.security.test.ts`: proves `execFileSync` (not `execSync`) is
  used with an argument array and no `shell` option; a shell-metacharacter payload
  is rejected by the whitelist and passed literally on the unwhitelisted
  `--outDir` path; `LILYPOND_CMD` parse/rejection branches are covered.
- Integration test rewired from PATH-resolved `.bat`/`.sh` fakes to
  `LILYPOND_CMD=[node, helper]` (cross-platform, no shell), preserving all prior
  coverage. The scores suite (61 tests) and `pnpm run ci` pass.
- `doc/BUILD.md` documents the `execFileSync`/`LILYPOND_CMD` model.

Reviewed through the Vera gate (two passes); the cycle-1 findings — a version-check
stderr-leak regression, untested `LILYPOND_CMD` error paths, and comment/doc
accuracy on which defence is load-bearing — were addressed. See the VERA-624
report and synthesis comments on #624.

- Vera
