### PR TITLE
fix: seek canvas sections via ranges so keyboard nav stops at fractional bar boundaries

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/packages/pwa/src/test/canvas.test.ts
+++ b/packages/pwa/src/test/canvas.test.ts
@@ -17,6 +17,17 @@ describe("MusicCanvas custom element", () => {
     vi.clearAllMocks();
   });
 
+  // seek() tests overwrite choir ranges on the shared beforeAll canvas; snapshot
+  // and restore the map per test so a fixture never leaks into a later test (#598).
+  let savedRanges: NonNullable<typeof canvas>["ranges"];
+  beforeEach(() => {
+    savedRanges = new Map();
+    for (const [key, value] of canvas!.ranges) savedRanges.set(key, [...value]);
+  });
+  afterEach(() => {
+    canvas!.ranges = savedRanges;
+  });
+
   it("Check that the canvasent contains a canvas", async () => {
     expect(canvas).not.toBeNull();
     expect(canvas?.querySelector("canvas")).not.toBe(null);
@@ -234,22 +245,80 @@ describe("MusicCanvas custom element", () => {
     expect(result).toBeLessThanOrEqual(canvas!.barCount);
   });
 
-  it("seek() does not throw when notesByQuant.get(intbar) is undefined (#244)", () => {
+  it("seek() does not throw when a choir-part range key is absent (#244, now via ranges)", () => {
     expect(canvas).not.toBeNull();
-    const saved = canvas!.notesByQuant.get(2);
-    canvas!.notesByQuant.delete(2);
+    // seek no longer reads notesByQuant (#598); the #244 "no data -> no throw"
+    // intent now applies to the `ranges` lookup, which tolerates an absent
+    // "choir-part" key (?? []).
+    for (let p = 0; p < config.parts.length; p++)
+      canvas!.ranges.delete(`0-${p}`);
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     expect(() => canvas!.seek(pos, +1)).not.toThrow();
-    if (saved) canvas!.notesByQuant.set(2, saved);
   });
 
-  it("seek() backward from bar 1 with empty notesByQuant.get(0) returns 0 (#244)", () => {
+  it("seek() backward from bar 1 with no choir-0 ranges returns 0 (#244, now via ranges)", () => {
     expect(canvas).not.toBeNull();
-    const saved = canvas!.notesByQuant.get(0);
-    canvas!.notesByQuant.delete(0);
+    // With choir 0 silent (no ranges), backward seek finds no flip edge and
+    // clamps to bar 0 — the #244 clamp intent, now asserted against `ranges`.
+    for (let p = 0; p < config.parts.length; p++)
+      canvas!.ranges.set(`0-${p}`, []);
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     expect(canvas!.seek(pos, -1)).toBe(0);
-    if (saved) canvas!.notesByQuant.set(0, saved);
+  });
+
+  it("seek() stops at a section boundary that starts on a fractional bar, forward (#598)", () => {
+    expect(canvas).not.toBeNull();
+    // Choir 0 is silent until 1.5, then sings [1.5, 3.0]; isolate it by clearing
+    // every part of choir 0 first, then declaring the one fractional range.
+    for (let p = 0; p < config.parts.length; p++)
+      canvas!.ranges.set(`0-${p}`, []);
+    canvas!.ranges.set("0-0", [{ from: 1.5, to: 3.0 }]);
+    const pos = { choir: 0, part: "all" as const, bar: 1 };
+    // The old integer scan can only ever return an integer bar; the fractional
+    // boundary 1.5 is reachable only by reading `ranges`.
+    expect(canvas!.seek(pos, +1)).toBe(1.5);
+  });
+
+  it("seek() stops at a fractional section boundary, backward (#598)", () => {
+    expect(canvas).not.toBeNull();
+    for (let p = 0; p < config.parts.length; p++)
+      canvas!.ranges.set(`0-${p}`, []);
+    canvas!.ranges.set("0-0", [{ from: 1.5, to: 3.0 }]);
+    const pos = { choir: 0, part: "all" as const, bar: 2.5 };
+    expect(canvas!.seek(pos, -1)).toBe(1.5);
+  });
+
+  it("seek() suppresses an inner edge where the collective state does not flip (#598)", () => {
+    expect(canvas).not.toBeNull();
+    // Two contiguous parts sing back-to-back: part 0 [1.5, 3.0], part 1 [3.0, 4.5].
+    // "Any part singing" never changes at the shared edge 3.0, so seek must skip
+    // it. Seeking forward from 2.0 (inside part 0's range, BELOW the shared edge)
+    // must land on 4.5: if the collective-flip filter regressed, the unsuppressed
+    // 3.0 would be returned instead. (A start above 3.0 would not bite — 3.0 is
+    // already behind it.)
+    for (let p = 0; p < config.parts.length; p++)
+      canvas!.ranges.set(`0-${p}`, []);
+    canvas!.ranges.set("0-0", [{ from: 1.5, to: 3.0 }]);
+    canvas!.ranges.set("0-1", [{ from: 3.0, to: 4.5 }]);
+    expect(canvas!.seek({ choir: 0, part: "all" as const, bar: 2.0 }, +1)).toBe(
+      4.5
+    );
+    // Forward from 1 still finds the genuine first flip at 1.5.
+    expect(canvas!.seek({ choir: 0, part: "all" as const, bar: 1 }, +1)).toBe(
+      1.5
+    );
+  });
+
+  it("seek() unions ranges across parts, not just part 0 (#598)", () => {
+    expect(canvas).not.toBeNull();
+    // The only singing part of choir 0 is part 3; its boundary must still be
+    // found via the "any part" union, not just part 0.
+    for (let p = 0; p < config.parts.length; p++)
+      canvas!.ranges.set(`0-${p}`, []);
+    canvas!.ranges.set("0-3", [{ from: 2.5, to: 4.0 }]);
+    expect(canvas!.seek({ choir: 0, part: "all" as const, bar: 1 }, +1)).toBe(
+      2.5
+    );
   });
 
   it("canvas click fires music-canvas-click event", async () => {

--- a/packages/pwa/src/ts/MusicCanvas.ts
+++ b/packages/pwa/src/ts/MusicCanvas.ts
@@ -282,22 +282,52 @@ export class MusicCanvas extends MusicElement {
     return c * ((t = t / d - 1) * t * t + 1) + b;
   }
 
-  seek(pos: Position, direction: 1 | -1) {
-    var intbar = Math.floor(pos.bar);
-    const choirnotes = (this.notesByQuant.get(intbar) ?? []).filter(
-      (x) => x.c == pos.choir
-    );
-    const singing = choirnotes.length != 0;
+  seek(pos: Position, direction: 1 | -1): number {
+    // A choir is "singing" wherever ANY of its parts has a range covering the
+    // bar, so its state changes at the edges of those ranges. Those edges can
+    // fall on fractional bars; `notesByQuant` is keyed by fractional quant
+    // positions, so the old integer scan stepped right over them (#598). `ranges`
+    // is the boundary-bearing source, and walking its edges is O(sections), not
+    // O(bars).
+    const singingAt = (bar: number): boolean => {
+      for (let p = 0; p < config.parts.length; p++) {
+        const list = this.ranges.get(`${pos.choir}-${p}`);
+        if (list?.some((r) => bar >= r.from && bar < r.to)) return true;
+      }
+      return false;
+    };
 
-    // loop until we find a bar where choir is not doing what it's doing in currentBar
-    while (intbar + direction >= 0 && intbar + direction <= this.barCount) {
-      intbar = intbar + direction;
-      const newsinging =
-        (this.notesByQuant.get(intbar) ?? []).filter((x) => x.c == pos.choir)
-          .length != 0;
-      if (singing !== newsinging) break;
+    // Every part-range edge for this choir, de-duplicated and sorted.
+    const edges = new Set<number>();
+    for (let p = 0; p < config.parts.length; p++) {
+      for (const r of this.ranges.get(`${pos.choir}-${p}`) ?? []) {
+        edges.add(r.from);
+        edges.add(r.to);
+      }
     }
-    return intbar;
+    const sorted = [...edges].sort((a, b) => a - b);
+
+    // Keep only edges where the COLLECTIVE "any part singing" state actually
+    // flips — contiguous or overlapping parts can leave inner edges that do not
+    // change it. Sample `singingAt` at the MIDPOINT between consecutive edges,
+    // not on an edge itself: ranges are half-open ([from, to)), so a sample
+    // exactly on an edge is ambiguous, whereas the midpoint reads the settled
+    // state of the whole interval below `b`. The first edge is compared against
+    // `false` (i === 0), encoding that a choir is silent before its first edge.
+    const flips = sorted.filter((b, i) => {
+      const below = i === 0 ? false : singingAt((sorted[i - 1] + b) / 2);
+      return singingAt(b) !== below;
+    });
+
+    // Strict `>` / `<`: a seek already sitting exactly on a flip edge advances
+    // PAST it, so repeated key-presses keep moving rather than sticking on the
+    // current bar.
+    if (direction > 0) {
+      const next = flips.find((b) => b > pos.bar);
+      return next === undefined ? this.barCount : Math.min(next, this.barCount);
+    }
+    const prev = [...flips].reverse().find((b) => b < pos.bar);
+    return prev === undefined ? 0 : Math.max(prev, 0);
   }
 
   play() {


### PR DESCRIPTION
## Summary

Canvas keyboard section-navigation (Cmd/Ctrl + Left/Right) skipped sections that begin on a fractional bar, stepping over them to the next whole-bar section.

`MusicCanvas.seek()` now derives section boundaries from the `ranges` map (which carries fractional quant positions) instead of scanning integer `notesByQuant` keys. It walks de-duplicated, sorted range edges and keeps only edges where the collective "any part of the choir singing" state flips, so it lands on fractional boundaries the old integer scan stepped over. Half-open `[from, to)` semantics and `[0, barCount]` clamping are preserved.

## Changes

- `packages/pwa/src/ts/MusicCanvas.ts` — rewrite `seek()` to use range edges; explicit `: number` return; comments on the strict-comparison "always advance" semantic and the midpoint flip-detection.
- `packages/pwa/src/test/canvas.test.ts` — tests for the fractional boundary, the collective-flip filter, the multi-part union, and shared-fixture save/restore; #244 tests re-pointed at `ranges`.

## Test plan

- Unit: new canvas seek tests (fractional boundary 1.5, collective-flip suppression, multi-part union) plus the existing suite.
- Manual: Cmd/Ctrl + Right/Left now stops at sections starting on fractional bars (verified in the dev build).

Reviewed through the Vera pre-publish gate; findings addressed or deferred (see issue comments).

Fixes #598

- Tele
