### PR TITLE
build: resolve .worktree-offset by walking up to the worktree root

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -23,19 +23,15 @@ This serves the application locally with hot module replacement. The `--host` fl
 
 ### Parallel worktrees
 
-Multiple worktrees can run dev and preview servers simultaneously by setting
-`SPEM_PORT_OFFSET` in each worktree's environment (for example, in a
-`.env.local` file). The offset is added to the default ports:
+Multiple worktrees can run dev and preview servers at once without colliding.
+Each declares a port offset, added to the base ports (dev 5173, preview 4173).
+`worktree-ports.ts` resolves it in order: `SPEM_PORT_OFFSET` if set, otherwise a
+gitignored `.worktree-offset` file (just the number) at the worktree root,
+found by walking up from the module. A checkout with neither (CI, a fork, the
+main checkout) gets offset 0 and the base ports. Each checkout keeps its own
+offset locally in its gitignored `.worktree-offset`; there is no central registry.
 
-| Worktree | Offset | Dev port | Preview port |
-| -------- | ------ | -------- | ------------ |
-| default  | 0      | 5173     | 4173         |
-| vera     | 100    | 5273     | 4273         |
-| kimi     | 200    | 5373     | 4373         |
-| copilot  | 300    | 5473     | 4473         |
-| tele     | 400    | 5573     | 4573         |
-
-`vite.config.ts` and `playwright.config.ts` read the offset from
+`vite.config.ts` and `playwright.config.ts` read the resolved offset from
 `worktree-ports.ts` at config-eval time.
 
 ## Build for Production

--- a/packages/pwa/src/test/worktree-ports.test.ts
+++ b/packages/pwa/src/test/worktree-ports.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -56,7 +56,7 @@ describe("worktree-ports", () => {
 });
 
 describe("readWorktreeOffset", () => {
-  it("reads the trimmed offset from a .worktree-offset file beside the module", () => {
+  it("reads the trimmed offset from a .worktree-offset file in the module's own directory", () => {
     const dir = mkdtempSync(join(tmpdir(), "wt-offset-"));
     try {
       writeFileSync(join(dir, ".worktree-offset"), "200\n");
@@ -67,9 +67,82 @@ describe("readWorktreeOffset", () => {
     }
   });
 
-  it("returns undefined when no .worktree-offset file sits beside the module", () => {
+  it("reads the offset from an ancestor directory (walks up from the module)", () => {
+    // The offset file lives at the worktree root, while the module sits under
+    // packages/pwa/ after the monorepo move (#620). Resolution must walk up.
+    const root = mkdtempSync(join(tmpdir(), "wt-offset-"));
+    try {
+      writeFileSync(join(root, ".worktree-offset"), "200\n");
+      const moduleDir = join(root, "packages", "pwa");
+      mkdirSync(moduleDir, { recursive: true });
+      const moduleUrl = pathToFileURL(
+        join(moduleDir, "worktree-ports.ts")
+      ).href;
+      expect(readWorktreeOffset(moduleUrl)).toBe("200");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when no .worktree-offset exists in the module dir or any ancestor up to the worktree root", () => {
+    // Hermetic: a `.git` marker bounds the walk at the temp root, so the result
+    // cannot depend on whether some real ancestor of tmpdir() happens to hold an
+    // offset file (the convention is live on this machine).
+    const root = mkdtempSync(join(tmpdir(), "wt-offset-"));
+    try {
+      writeFileSync(join(root, ".git"), "gitdir: /elsewhere\n");
+      const moduleDir = join(root, "packages", "pwa");
+      mkdirSync(moduleDir, { recursive: true });
+      const moduleUrl = pathToFileURL(
+        join(moduleDir, "worktree-ports.ts")
+      ).href;
+      expect(readWorktreeOffset(moduleUrl)).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stops at the worktree root (a dir containing .git) and does not inherit an offset above it", () => {
+    // The offset is a worktree-scoped fact: a stray .worktree-offset above the
+    // worktree root must not leak into an offset-less worktree.
+    const above = mkdtempSync(join(tmpdir(), "wt-offset-"));
+    try {
+      writeFileSync(join(above, ".worktree-offset"), "999\n");
+      const worktree = join(above, "worktree");
+      const moduleDir = join(worktree, "packages", "pwa");
+      mkdirSync(moduleDir, { recursive: true });
+      writeFileSync(join(worktree, ".git"), "gitdir: /elsewhere\n");
+      const moduleUrl = pathToFileURL(
+        join(moduleDir, "worktree-ports.ts")
+      ).href;
+      expect(readWorktreeOffset(moduleUrl)).toBeUndefined();
+    } finally {
+      rmSync(above, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the nearest .worktree-offset, not a farther ancestor's", () => {
+    const root = mkdtempSync(join(tmpdir(), "wt-offset-"));
+    try {
+      writeFileSync(join(root, ".worktree-offset"), "200\n");
+      const moduleDir = join(root, "packages", "pwa");
+      mkdirSync(moduleDir, { recursive: true });
+      writeFileSync(join(moduleDir, ".worktree-offset"), "30\n");
+      const moduleUrl = pathToFileURL(
+        join(moduleDir, "worktree-ports.ts")
+      ).href;
+      expect(readWorktreeOffset(moduleUrl)).toBe("30");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when .worktree-offset is present but unreadable (a directory)", () => {
+    // existsSync() is true for a directory, but readFileSync() throws EISDIR;
+    // the inner catch must degrade to undefined, not propagate.
     const dir = mkdtempSync(join(tmpdir(), "wt-offset-"));
     try {
+      mkdirSync(join(dir, ".worktree-offset"));
       const moduleUrl = pathToFileURL(join(dir, "worktree-ports.ts")).href;
       expect(readWorktreeOffset(moduleUrl)).toBeUndefined();
     } finally {

--- a/packages/pwa/worktree-ports.ts
+++ b/packages/pwa/worktree-ports.ts
@@ -3,8 +3,8 @@
 //
 // Each worktree declares its own offset, resolved in order from:
 //   1. the SPEM_PORT_OFFSET environment variable, if set; otherwise
-//   2. a gitignored `.worktree-offset` file beside this module, holding
-//      just the number.
+//   2. a gitignored `.worktree-offset` file at the worktree root, found by
+//      walking up from this module, holding just the number.
 // Anything that declares neither — CI, forks, a fresh clone, the main
 // checkout — gets offset 0 and the default ports, so config evaluation
 // can never fail on an unrecognised checkout.
@@ -12,44 +12,60 @@
 // The file fallback exists because the environment variable is not
 // reliably delivered to programmatically-spawned processes (IDE task
 // runners, test harnesses); a child may never see SPEM_PORT_OFFSET. The
-// file is resolved relative to this module's own location, not the
-// process cwd, so it is correct however the process was launched. The
+// file is resolved by walking up from this module's own location (not the
+// process cwd) to the worktree root, so it is correct however the process
+// was launched and wherever the module sits in the tree. The
 // offset is the worktree's own fact to declare; we do not infer it from
 // the directory name (CI checks out into `spem-player`, a fork could be
 // named anything — the name is an unreliable proxy).
 //
-// Per-worktree values in use (offset -> dev / preview):
-//   main / claude  0  -> 5173 / 4173
-//   copilot        10 -> 5183 / 4183
-//   kimi           20 -> 5193 / 4193
-//   tele           30 -> 5203 / 4203
-//   vera           40 -> 5213 / 4213
-//   zimi           50 -> 5223 / 4223
-//
 // vite.config.ts and playwright.config.ts read DEV_PORT / PREVIEW_PORT at
 // config-eval time; the offset is resolved once here at module load.
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
- * Read the raw offset from a `.worktree-offset` file beside this module.
+ * Read the raw offset from the nearest `.worktree-offset` file, walking up
+ * from this module to the worktree root.
  *
- * @param metaUrl - module URL to resolve the file against (defaults to this
- *   module's own `import.meta.url`). Resolving against the module location,
- *   not `process.cwd()`, keeps it correct however the process was launched.
- * @returns the trimmed file contents, or `undefined` when the file is
- *   absent or unreadable. Never throws.
+ * @param metaUrl - module URL to resolve against (defaults to this module's
+ *   own `import.meta.url`). Walking up from the module location, not
+ *   `process.cwd()`, keeps it correct however the process was launched and
+ *   wherever the module sits in the tree (the file lives at the worktree
+ *   root; this module is under packages/pwa/ after the monorepo move, #620).
+ * @returns the trimmed contents of the first `.worktree-offset` found in the
+ *   module's directory or an ancestor up to and including the worktree root
+ *   (the dir holding `.git`), or `undefined` when none exists (CI, forks, the
+ *   main checkout) or it is unreadable. Never throws.
  */
 export function readWorktreeOffset(
   metaUrl: string = import.meta.url,
 ): string | undefined {
-  try {
-    const dir = dirname(fileURLToPath(metaUrl));
-    return readFileSync(resolve(dir, ".worktree-offset"), "utf-8").trim();
-  } catch {
-    return undefined;
+  let dir = dirname(fileURLToPath(metaUrl));
+  for (;;) {
+    const candidate = resolve(dir, ".worktree-offset");
+    if (existsSync(candidate)) {
+      try {
+        return readFileSync(candidate, "utf-8").trim();
+      } catch {
+        return undefined; // present but unreadable: degrade to default
+      }
+    }
+    // Ceiling: the offset is a worktree-scoped fact, so stop the walk at the
+    // worktree root — the directory holding `.git` (a directory in the main
+    // checkout, a file in a linked worktree; existsSync covers both) — rather
+    // than escaping above it and inheriting a stray ancestor's offset.
+    if (existsSync(resolve(dir, ".git"))) return undefined;
+    // Filesystem-root backstop: a checkout that is not a git tree at all (a
+    // tarball export, a degraded CI checkout with no `.git` anywhere) still
+    // terminates here at offset 0, preserving the never-throw guarantee. Left
+    // deliberately unit-untested — reaching it requires a real filesystem root,
+    // and mocking `dirname` to fake one is more brittle than the two-line guard.
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
   }
 }
 
@@ -66,8 +82,8 @@ export const parseOffset = (raw: string | undefined): number => {
 
 /**
  * Resolve the per-worktree port offset from `SPEM_PORT_OFFSET`, falling
- * back to a `.worktree-offset` file beside this module, then parse it via
- * {@link parseOffset}.
+ * back to a `.worktree-offset` file found by walking up from this module, then
+ * parse it via {@link parseOffset}.
  *
  * @param raw - the raw offset value (defaults to
  *   `process.env.SPEM_PORT_OFFSET`, falling back to the `.worktree-offset`


### PR DESCRIPTION
## Summary

After the monorepo move, `packages/pwa/worktree-ports.ts` read `.worktree-offset` only from beside the module (`packages/pwa/`), but each worktree keeps its offset file at its **root**. So the offset was never found and every worktree fell back to the default ports (5173/4173), colliding across worktrees.

The resolver now **walks up** from the module directory to find `.worktree-offset`, stopping at the worktree root (the directory containing `.git`, file or dir, covering linked worktrees), with a filesystem-root backstop that yields offset 0. First match wins (nearest-wins).

## Changes

- `packages/pwa/worktree-ports.ts` — walk-up resolution with a worktree-root ceiling; header/JSDoc updated to describe the bounded walk; agent-name table removed in favour of a generic, name-free explanation.
- `packages/pwa/src/test/worktree-ports.test.ts` — hermetic tests: root-termination, present-but-unreadable, nearest-wins, root-inclusion.
- `doc/BUILD.md` — each checkout keeps its offset locally in its `.worktree-offset`; no central registry.

## Test plan

- Unit: `worktree-ports.test.ts` (root ceiling, directory-named file, nearest-wins, root-inclusion), hermetic via a `.git` marker.

Reviewed through the Vera pre-publish gate; all findings addressed or rejected with reason (see issue comments).

Fixes #620

- Tele
