### PR TITLE
fix: play/pause button keyboard-activatable via <button> (#634)

### DIFF
--- a/packages/pwa/e2e/playback-toggle.spec.ts
+++ b/packages/pwa/e2e/playback-toggle.spec.ts
@@ -51,6 +51,58 @@ test.describe("Playback keyboard toggle", () => {
     await expect(pauseIcon).toBeHidden();
   });
 
+  test("focused play/pause button activates on Enter (#634)", async ({ page }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      HTMLAudioElement.prototype.play = function () {
+        (this as HTMLAudioElement).dispatchEvent(new Event("play"));
+        return Promise.resolve();
+      };
+    });
+
+    const controls = page.locator("music-controls");
+    const pauseIcon = controls.locator("#playpausebutton svg").nth(1);
+
+    await page.locator("#playpausebutton").focus();
+    await expect(pauseIcon).toBeHidden();
+
+    await page.keyboard.press("Enter");
+    await expect(pauseIcon).toBeVisible();
+
+    await page.keyboard.press("Enter");
+    await expect(pauseIcon).toBeHidden();
+  });
+
+  test("focused play/pause button activates on Space without scrolling (#634)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      HTMLAudioElement.prototype.play = function () {
+        (this as HTMLAudioElement).dispatchEvent(new Event("play"));
+        return Promise.resolve();
+      };
+      // Make the page tall enough that a stray Space-scroll would move it.
+      document.body.style.minHeight = "3000px";
+      window.scrollTo(0, 0);
+    });
+
+    const controls = page.locator("music-controls");
+    const pauseIcon = controls.locator("#playpausebutton svg").nth(1);
+
+    await page.locator("#playpausebutton").focus();
+    await expect(pauseIcon).toBeHidden();
+
+    await page.keyboard.press("Space");
+    await expect(pauseIcon).toBeVisible();
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+
+    await page.keyboard.press("Space");
+    await expect(pauseIcon).toBeHidden();
+  });
+
   test("play/pause button stays circular when the recording changes (#398)", async ({
     page,
   }) => {

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/packages/pwa/src/test/controls.test.ts
+++ b/packages/pwa/src/test/controls.test.ts
@@ -128,7 +128,8 @@ describe("MusicControls custom element", () => {
   it("MusicControls has the loading, play and pause SVGs", () => {
     const ppbutton = document.getElementById("playpausebutton");
     expect(ppbutton, document.body.innerHTML).not.toBeNull();
-    expect(ppbutton?.getAttribute("tabindex")).toBe("0");
+    expect(ppbutton?.tagName).toBe("BUTTON");
+    expect(ppbutton?.getAttribute("aria-label")).toBe("Play or pause");
 
     const spinner = document.getElementById("spinner");
     expect(spinner, document.body.innerHTML).not.toBeNull();

--- a/packages/pwa/src/test/keyboard.test.ts
+++ b/packages/pwa/src/test/keyboard.test.ts
@@ -108,6 +108,22 @@ describe("Space bar play/pause", () => {
     document.body.removeChild(select);
   });
 
+  it("Space does not toggle play/pause when the play/pause button is focused (#634)", () => {
+    const controls = document.querySelector("music-controls") as MusicControls;
+    const button = document.getElementById("playpausebutton");
+    expect(button).not.toBeNull();
+
+    controls.playing = false;
+    // The button carries class="control", so the global keydown handler returns
+    // early and never toggles. The native button click that would toggle once is
+    // not synthesised by jsdom from a dispatched keydown, so isPlaying stays put.
+    // This pins the no-double-toggle invariant the <button> change relies on.
+    button!.dispatchEvent(
+      new KeyboardEvent("keydown", { code: "Space", bubbles: true })
+    );
+    expect(controls.isPlaying()).toBe(false);
+  });
+
   it("Space does not toggle play/pause when a textarea is focused", () => {
     const controls = document.querySelector("music-controls") as MusicControls;
     const textarea = document.createElement("textarea");

--- a/packages/pwa/src/test/main.test.ts
+++ b/packages/pwa/src/test/main.test.ts
@@ -36,7 +36,7 @@ describe("index.js", () => {
 
     expect(document.querySelector("svg")).not.toBe(null);
     console.log(score?.innerHTML);
-    expect(document.querySelector("div[id='playpausebutton']")).not.toBe(null);
+    expect(document.querySelector("#playpausebutton")).not.toBe(null);
     // expect(document.querySelector("music-canvas canvas")).not.toBe(null);
   });
 

--- a/packages/pwa/src/ts/MusicControls.ts
+++ b/packages/pwa/src/ts/MusicControls.ts
@@ -20,7 +20,7 @@ export class MusicControls extends MusicElement {
   partselect: HTMLSelectElement | null = null;
   barinput: HTMLInputElement | null = null;
 
-  playpausebutton: HTMLDivElement | null = null;
+  playpausebutton: HTMLButtonElement | null = null;
   svgLoading: SVGElement | null = null;
   svgPlay: SVGElement | null = null;
   svgPause: SVGElement | null = null;
@@ -35,10 +35,16 @@ export class MusicControls extends MusicElement {
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
 
-    // Build a DIV with the play, pause and loading SVG icons
-    this.playpausebutton = document.createElement("div");
+    // Build a BUTTON with the play, pause and loading SVG icons. A native
+    // <button> is keyboard-activatable (Enter/Space fire the click handler) and
+    // exposes the button role and accessible name, unlike the old <div> (#634).
+    // Keep class="control" so the global key handler in packages/pwa/index.ts
+    // returns early and does not toggle playback a second time via its
+    // page-level keydown shortcut.
+    this.playpausebutton = document.createElement("button");
     this.playpausebutton.setAttribute("id", "playpausebutton");
-    this.playpausebutton.setAttribute("tabindex", "0");
+    this.playpausebutton.setAttribute("type", "button");
+    this.playpausebutton.setAttribute("aria-label", "Play or pause");
     this.playpausebutton.setAttribute("class", "control");
     this.svgLoading = new DOMParser()
       .parseFromString(loadingSVG, "image/svg+xml")


### PR DESCRIPTION
Fixes #634

The play/pause control in `MusicControls` was a `<div>`: focusable but not
keyboard-activatable, so Enter/Space did nothing once it had focus. This swaps it
to a native `<button>`, restoring keyboard activation while preserving the
existing appearance and click behaviour.

## Tests
- `src/test/controls.test.ts`, `src/test/keyboard.test.ts`, `src/test/main.test.ts`
  — unit coverage for keyboard activation of the play/pause control.
- `e2e/playback-toggle.spec.ts` — end-to-end keyboard toggle of playback.
