### PR TITLE
build: move Ohm bundle lint-exclusion to eslint ignores, drop dead .gitignore line (#637)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ coverage
 temp/*
 src/scss/*.css
 src/scss/*.css.map
-src/ohmjs/ly-grammar.ohm-bundle.*
 publish.py
 playwright-output/
 playwright-report/

--- a/packages/pwa/eslint.config.js
+++ b/packages/pwa/eslint.config.js
@@ -58,11 +58,15 @@ export default tseslint.config(
   {
     // .gitignore is honoured via includeIgnoreFile above; only paths that are
     // NOT gitignored need listing here. tests-local/ and probes/ are local-only
-    // (.git/info/exclude, not .gitignore); .dependency-cruiser.cjs is tracked.
+    // (.git/info/exclude, not .gitignore); .dependency-cruiser.cjs is tracked;
+    // the Ohm grammar bundle is generated code that is deliberately tracked but
+    // must skip lint (it uses require/module). It was previously excluded only by
+    // a stale, path-wrong .gitignore line; that exclusion lives here now (#637).
     ignores: [
       'tests-local/',
       'probes/',
       '.dependency-cruiser.cjs',
+      'src/ohmjs/ly-grammar.ohm-bundle.*',
     ],
   }
 )


### PR DESCRIPTION
Fixes #637

The Ohm grammar bundle (`packages/pwa/src/ohmjs/ly-grammar.ohm-bundle.{js,d.ts}`)
is generated code that is deliberately tracked but must skip lint (it uses
`require`/`module`). It was previously excluded only by a stale `.gitignore` line
(`src/ohmjs/ly-grammar.ohm-bundle.*`) whose path predated the monorepo move, so it
matched nothing and was dead. This drops that dead line and moves the
lint-exclusion into the eslint `ignores` array, where tracked-but-unlinted paths
belong (per CONTRIBUTING § Lint).

Config only — no behaviour change.
