### PR TITLE
build: pin *.mjs and *.mts to LF in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,8 @@
 *.tsx text eol=lf
 *.js text eol=lf
 *.jsx text eol=lf
+*.mjs text eol=lf
+*.mts text eol=lf
 *.json text eol=lf
 *.scss text eol=lf
 *.css text eol=lf


### PR DESCRIPTION
Pin `*.mjs` and `*.mts` to LF in `.gitattributes` so Windows worktrees with `core.autocrlf=true` check out ESM build scripts and their TypeScript declaration files with Unix line endings.

Fixes #661
