### PR TITLE
fix: re-enable @typescript-eslint/no-unused-expressions for test files (#625)

### DIFF
--- a/packages/pwa/eslint.config.js
+++ b/packages/pwa/eslint.config.js
@@ -51,7 +51,6 @@ export default tseslint.config(
   {
     files: ['src/**/*.test.ts'],
     rules: {
-      '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
     },
   },


### PR DESCRIPTION
Re-enable `@typescript-eslint/no-unused-expressions` for test files by removing the rule override in `packages/pwa/eslint.config.js`.

A call-less assertion such as `expect(x).toBe;` is currently a valid expression statement that asserts nothing, yet reads like a real test. With the rule re-enabled, lint catches this class of mistake.

- `pnpm run ci` passes.
- Verified with a temporary probe that the rule now flags a call-less `expect`.

Fixes #625
