### PR TITLE
build: guard build:ohm against CRLF ly-grammar.ohm working tree (#648)

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -168,9 +168,9 @@ When releasing, update `package.json` only. The build will propagate the new ver
 
 ### Ohm Grammar
 
-`pnpm run build:ohm` regenerates `packages/pwa/src/ohmjs/ly-grammar.ohm-bundle.js` and `packages/pwa/src/ohmjs/ly-grammar.ohm-bundle.d.ts` from `packages/pwa/src/ohmjs/ly-grammar.ohm` via `@ohm-js/cli`. If you modify the grammar, rebuild before testing or deploying.
+`pnpm run build:ohm` first normalises `packages/pwa/src/ohmjs/ly-grammar.ohm` to LF (via `packages/pwa/build/build-ohm.mjs`), then regenerates `packages/pwa/src/ohmjs/ly-grammar.ohm-bundle.js` and `packages/pwa/src/ohmjs/ly-grammar.ohm-bundle.d.ts` from it via `@ohm-js/cli`. If you modify the grammar, rebuild before testing or deploying.
 
-`ly-grammar.ohm` is pinned to LF by `.gitattributes` (`*.ohm text eol=lf`) so `build:ohm` is deterministic across platforms. Without the rule, a Windows checkout (e.g. with `core.autocrlf=true`) writes the grammar with CRLF and `build:ohm` bakes those CRLFs into the `source` string literal of the generated bundle, producing a phantom diff on every Windows build, even from a clean tree (#611). The bundle file's own line endings are already LF via the existing `*.js` rule; the `*.ohm` rule is what stops CRLF being baked into that literal.
+`ly-grammar.ohm` is pinned to LF by `.gitattributes` (`*.ohm text eol=lf`) so `build:ohm` is deterministic across platforms. Without the rule, a Windows checkout (e.g. with `core.autocrlf=true`) writes the grammar with CRLF and `build:ohm` bakes those CRLFs into the `source` string literal of the generated bundle, producing a phantom diff on every Windows build, even from a clean tree (#611). The bundle file's own line endings are already LF via the existing `*.js` rule; the `*.ohm` rule is what stops CRLF being baked into that literal. The `.gitattributes` rule only fixes *fresh* checkouts, though: a worktree that already held a CRLF `ly-grammar.ohm` keeps it (git reads it clean against the LF blob, so `git checkout --` never rewrites it). So `build:ohm` also normalises the grammar to LF itself before generating (`packages/pwa/build/build-ohm.mjs`), making the build deterministic regardless of the working copy's line endings (#648).
 
 ## Build Output
 

--- a/packages/pwa/build/build-ohm.d.mts
+++ b/packages/pwa/build/build-ohm.d.mts
@@ -1,0 +1,5 @@
+// Types for build-ohm.mjs, so the TS test (and tsc --noEmit) can import the
+// build-time normaliser without TS7016. Kept beside the .mjs; the two functions
+// are stable.
+export function toLf(text: string): string;
+export function ensureLf(path: string): boolean;

--- a/packages/pwa/build/build-ohm.mjs
+++ b/packages/pwa/build/build-ohm.mjs
@@ -1,0 +1,46 @@
+// Normalise the Ohm grammar to LF before `npx ohm generateBundles`, so a worktree
+// that still holds a CRLF `ly-grammar.ohm` cannot bake `\r\n` into the bundle's
+// embedded `source` literal (#648, a recurrence of #611). `.gitattributes`
+// (`*.ohm text eol=lf`) only fixes *fresh* checkouts; an existing CRLF working
+// copy reads clean against the LF blob and `git checkout --` never rewrites it,
+// so the build itself must be the guard.
+//
+// Every Node API is imported (not used as a global) so the file lints clean
+// under the baseline `no-undef` with no node-globals config, matching
+// `eslint.config.js`'s own treatment of `URL`. `generateBundles` stays in the
+// npm script (chained with `&&`) rather than spawned here, to avoid the Windows
+// PATHEXT trap on extensionless `npx`.
+import console from "node:console";
+import { readFileSync, writeFileSync } from "node:fs";
+import { argv } from "node:process";
+import { fileURLToPath, pathToFileURL, URL } from "node:url";
+
+/** Convert CRLF and lone CR to LF. */
+export function toLf(text) {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Force the file at `path` to LF in place. Returns true if it was rewritten,
+ * false if it was already LF (idempotent).
+ */
+export function ensureLf(path) {
+  const raw = readFileSync(path, "utf8");
+  const lf = toLf(raw);
+  if (lf !== raw) writeFileSync(path, lf);
+  return lf !== raw;
+}
+
+// Run the normalisation only when executed as a script (not when imported by a
+// test). pathToFileURL handles Windows drive letters, so this is the safe form
+// of the main-module check.
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  const grammar = fileURLToPath(
+    new URL("../src/ohmjs/ly-grammar.ohm", import.meta.url)
+  );
+  // Log on rewrite so a triggered guard is a visible event, not a silent
+  // recurrence (Vera 648-01).
+  if (ensureLf(grammar)) {
+    console.log("build:ohm: normalised ly-grammar.ohm to LF (#648)");
+  }
+}

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -37,7 +37,7 @@
     "dev": "vite --host",
     "build": "vite build",
     "prebuild": "pnpm run build:ohm",
-    "build:ohm": "npx ohm generateBundles --withTypes src/ohmjs/ly-grammar.ohm",
+    "build:ohm": "node build/build-ohm.mjs && npx ohm generateBundles --withTypes src/ohmjs/ly-grammar.ohm",
     "preview": "vite preview",
     "test": "vitest run",
     "test:unit": "vitest run",

--- a/packages/pwa/src/test/ohm-build-normalise.test.ts
+++ b/packages/pwa/src/test/ohm-build-normalise.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureLf, toLf } from "../../build/build-ohm.mjs";
+
+/**
+ * Guards the `build:ohm` CRLF normalisation step (#648, a #611 recurrence).
+ *
+ * #611 pinned `*.ohm text eol=lf` in `.gitattributes`, which keeps *fresh*
+ * checkouts LF. But a worktree that already held a CRLF `ly-grammar.ohm`
+ * keeps it: git normalises CRLF to LF when diffing against the LF blob, so
+ * the file reads clean and `git checkout --` never rewrites it. An agent
+ * building from such a worktree bakes `\r\n` into the bundle's `source`
+ * literal. The fix is a normalisation step in `build:ohm` that forces the
+ * grammar to LF before `ohm generateBundles` runs, regardless of worktree
+ * state. These tests pin that step's behaviour and its wiring.
+ *
+ * Reads are relative to the pwa package cwd, matching ohm-eol.test.ts.
+ */
+describe("build:ohm CRLF guard (#648)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ohm-eol-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("toLf converts CRLF and lone CR to LF", () => {
+    expect(toLf("a\r\nb\rc\n")).toBe("a\nb\nc\n");
+  });
+
+  it("ensureLf rewrites a CRLF file to LF and reports the change", () => {
+    const f = join(dir, "g.ohm");
+    writeFileSync(f, 'Grammar {\r\n  x = "y"\r\n}\r\n');
+    expect(ensureLf(f)).toBe(true);
+    const out = readFileSync(f, "utf8");
+    expect(out.includes("\r")).toBe(false);
+    expect(out).toBe('Grammar {\n  x = "y"\n}\n');
+  });
+
+  it("ensureLf leaves an LF file untouched and reports no change", () => {
+    const f = join(dir, "g.ohm");
+    const lf = 'Grammar {\n  x = "y"\n}\n';
+    writeFileSync(f, lf);
+    expect(ensureLf(f)).toBe(false);
+    expect(readFileSync(f, "utf8")).toBe(lf);
+  });
+
+  it("build:ohm normalises the grammar before generateBundles", () => {
+    const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+    const script: string = pkg.scripts["build:ohm"];
+    expect(
+      script,
+      "build:ohm must invoke the build-ohm normaliser (#648)"
+    ).toContain("build-ohm.mjs");
+    expect(script).toContain("generateBundles");
+    expect(
+      script.indexOf("build-ohm.mjs"),
+      "the normaliser must run before generateBundles"
+    ).toBeLessThan(script.indexOf("generateBundles"));
+  });
+});


### PR DESCRIPTION
## Summary

Guard `build:ohm` against a CRLF `ly-grammar.ohm` working copy (a #611 recurrence).

`.gitattributes` (`*.ohm text eol=lf`, added in #611) only fixes *fresh* checkouts. A worktree that already held a CRLF `ly-grammar.ohm` keeps it: git reads it as clean against the LF blob, so `git checkout --` and `git add --renormalise` never rewrite it. `pnpm run build:ohm` then bakes the CRLFs into the `source` literal of the generated bundle as `\r\n`, and the #611 ohm-eol test fails locally on Windows even from a clean tree.

## Fix

`build:ohm` now normalises `packages/pwa/src/ohmjs/ly-grammar.ohm` to LF (via `packages/pwa/build/build-ohm.mjs`) before invoking `@ohm-js/cli generateBundles`, so the build is deterministic regardless of the working copy's line endings.

## Test plan

`packages/pwa/src/test/ohm-build-normalise.test.ts` covers the normalisation. On a Windows worktree with a CRLF `ly-grammar.ohm`, `pnpm run build:ohm` now produces a bundle with no `\r\n` escape and `git status` shows no diff.

`doc/BUILD.md` updated to describe the new normalisation step.

Fixes #648
