### PR TITLE
fix: correct stale threshold values in monitor-resources.mjs JSDoc (#664)

### DIFF
--- a/packages/monitor/monitor-resources.mjs
+++ b/packages/monitor/monitor-resources.mjs
@@ -12,8 +12,8 @@
  *
  * All thresholds apply to the higher of actual and projected end-of-period
  * usage. Skips the Telegram message on days with no PR merges when both
- * actual and projected usage are below 50%. Watch (≥ 50%), throttle (≥ 75%),
- * and critical (≥ 90%) alerts always send regardless of PR activity.
+ * actual and projected usage are below 75% (the watch threshold). Watch (≥ 75%),
+ * throttle (≥ 82%), and critical (≥ 90%) alerts always send regardless of PR activity.
  *
  * Environment variables (all required):
  *   NETLIFY_AUTH_TOKEN


### PR DESCRIPTION
fix: correct stale threshold values in monitor-resources.mjs JSDoc (#664)

The module-level JSDoc in `packages/monitor/monitor-resources.mjs` cited outdated alert thresholds:

- Skip boundary: docstring said below 50%, but `shouldSkipReport` skips when `max(actual, projected) < WATCH_THRESHOLD_PCT` (75).
- Watch: docstring said ≥ 50%, but `WATCH_THRESHOLD_PCT` is 75.
- Throttle: docstring said ≥ 75%, but `THROTTLE_THRESHOLD_PCT` is 82.
- Critical: docstring ≥ 90% was already correct.

The corrected docstring now matches the constants and names the watch threshold.

Fixes #664
