### PR TITLE
docs: dedicated doc/MONITOR.md, trim doc/CI.md monitor section (#636)

### DIFF
--- a/doc/CI.md
+++ b/doc/CI.md
@@ -92,32 +92,13 @@ updated SVGs, and the SVG commit then triggers Netlify.
 **Deploy preview:** Netlify posts a preview URL as a comment on each PR
 automatically.
 
-### `monitor-run.yml`
+### `monitor-run.yml` and `monitor-ci.yml`
 
-Triggers daily at 02:29 UTC (`cron: "29 2 * * *"`, deliberately off the top of the hour to avoid GitHub's schedule throttling; GitHub's ~5 h scheduling delay lands the Telegram post around breakfast) and on manual `workflow_dispatch`. Runs one job, `monitor`, on Ubuntu latest with `actions: read`, `issues: write`, `contents: write`, and `pull-requests: read` permissions.
-
-Steps:
-
-- `actions/checkout@v6` — checkout the repository.
-- `pnpm --filter monitor exec node monitor-resources.mjs` — run the monitor, with `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `GITHUB_TOKEN` passed in the environment. After fetching usage, the script appends (or replaces) today's entry in `.github/monitor-series.json` with the current Netlify and GitHub build-minute totals.
-- Commit the updated `.github/monitor-series.json` if it changed, with message `chore: update daily resource series [skip ci]`, then push. The workflow triggers only on `schedule` and `workflow_dispatch` (never on `push`), so this self-commit cannot loop the workflow; the `[skip ci]` suffix also prevents it from consuming a `pwa-ci.yml` run.
-
-The script queries the current period's Netlify build-minute usage and GitHub Actions usage. Status thresholds — good (< 75%), watch (≥ 75%), throttle (≥ 82%), and stop (≥ 90%) — apply to actual usage, while a linearly projected end-of-period usage can raise an early warning up to throttle (82%) when actual usage is below 90%. This prevents a single high-burn day early in the period from opening a false critical issue while still surfacing an unsustainable burn rate. On days with no PRs merged in the past 24 hours and both actual and projected usage below the watch threshold (50%), the Telegram post is skipped to reduce noise; watch and worse always send regardless of PR activity. The monitor posts only the burndown chart image — no caption and no separate text message — because the chart encodes the full signal: green for good, yellow/amber for watch, red for throttle, and red with a fire icon for stop. If either service actually reaches **90%** of its quota, the status becomes `stop` and the workflow opens a critical GitHub issue containing a runbook for reducing build-minute consumption; projection alone cannot open a critical issue.
-
-The `.github/monitor-series.json` file holds the daily `{ date, netlifyCurrent, githubMinutes, mergedPRs, summary, source }` series. `mergedPRs` is the number of PRs merged on that day; `summary` is a pre-computed snapshot `{ netlifyPct, netlifyProjected, netlifyStatus, githubPct, githubProjected, githubStatus, overallStatus, mergedPRs }` so agents can read status without recalculating. Status values are `"good"`, `"watch"`, `"throttle"`, or `"stop"`. The `source` field is `"logged"` for entries written by the monitor and `"backfill"` for the one-time seed populated from API/GitHub run history and Netlify daily build minutes.
-
-### `monitor-ci.yml`
-
-Triggers on push to `main` and on `pull_request`, both path-filtered to `packages/monitor/**` and this workflow file. This is a separate, optional build for repository infrastructure: it runs only the monitor's `node:test` suite and does not run the Spem Player build. It keeps the monitor's tests out of the main `pwa-ci.yml` gate while ensuring monitor changes are exercised before merge.
-
-Steps:
-
-- `actions/checkout@v6` — checkout the repository.
-- `pnpm/action-setup@v4` and `actions/setup-node@v6` from `.nvmrc` — install Node.js and pnpm.
-- `pnpm install --filter monitor` — install monitor dependencies (required for the `canvas` native module used by the burndown renderer).
-- `pnpm --filter monitor test` — run the monitor and burndown tests.
-
-Run locally with `pnpm run test:monitor`.
+The build-resource monitor tracks Netlify and GitHub Actions usage, posts a daily
+burndown chart to Telegram, and opens a critical issue if usage nears quota. See
+[`doc/MONITOR.md`](./MONITOR.md) for the full monitor documentation, including
+status thresholds, workflow permissions, required secrets, and how to run the
+monitor locally.
 
 ## Node.js Version
 

--- a/doc/MONITOR.md
+++ b/doc/MONITOR.md
@@ -1,0 +1,127 @@
+# Build-resource Monitor
+
+The Spem Player repository runs a small Node.js monitor under `packages/monitor/`
+that tracks Netlify and GitHub Actions build-minute usage, posts a daily burndown
+chart to Telegram, and opens a critical issue if usage nears quota.
+
+## Why it exists
+
+Both Netlify (build minutes) and GitHub Actions (workflow minutes) have monthly
+quotas. The monitor gives early warning of an unsustainable burn rate before the
+quota is exhausted.
+
+## Files
+
+- `packages/monitor/monitor-resources.mjs` — fetches usage, decides status,
+  updates `.github/monitor-series.json`, sends the Telegram chart, and opens a
+  critical issue when needed.
+- `packages/monitor/render-burndown.mjs` — renders the two-panel burndown chart
+  as a PNG.
+- `packages/monitor/package.json` — defines the `@spem/monitor` package, its
+  `test` script (`node --test monitor-resources.test.mjs render-burndown.test.mjs`)
+  and its `lint` script.
+- `.github/workflows/monitor-ci.yml` — CI gate for monitor changes.
+- `.github/workflows/monitor-run.yml` — scheduled daily run.
+- `.github/monitor-series.json` — daily cumulative usage series, committed by
+  `monitor-run.yml`.
+
+## Status thresholds
+
+Status is the worse of the Netlify and GitHub statuses, driven by `statusPct`:
+
+- `good` — below 75%.
+- `watch` — 75% or above.
+- `throttle` — 82% or above.
+- `stop` — 90% or above (actual usage only; projection alone cannot open a
+  critical issue).
+
+`computeUsageStatus` projects current usage linearly to the end of the billing
+period, working from the unrounded percentage to avoid scaling the rounding
+error. The status driver is the worse of actual percentage and projected
+percentage, capped at `throttle` unless actual usage already breaches critical.
+
+## Daily report behaviour
+
+The scheduled workflow runs daily at 02:29 UTC. It:
+
+1. Fetches the current billing-period usage from Netlify and GitHub.
+2. Builds a daily summary and appends (or replaces) today's entry in
+   `.github/monitor-series.json`.
+3. Fetches the number of PRs merged in the last 24 hours.
+4. Skips the Telegram post only when no PRs were merged in the last 24 hours
+   **and** both actual and projected usage are below the watch threshold (75%).
+   Watch and worse always send.
+5. Renders and posts the burndown chart to Telegram as a photo with no caption.
+6. Opens a critical issue if the overall status reaches `stop`.
+
+The chart encodes the full signal: green for good, yellow for watch, red for
+throttle, and red with a fire icon for stop.
+
+## Workflows
+
+### `monitor-ci.yml`
+
+Runs on push to `main` and on `pull_request`, path-filtered to
+`packages/monitor/**` and the workflow file. It installs monitor dependencies
+and runs `pnpm --filter @spem/monitor test`. This is a separate, optional gate:
+it does not run the Spem Player build.
+
+Run locally with `pnpm run test:monitor`.
+
+### `monitor-run.yml`
+
+Runs on a daily cron (`29 2 * * *`) and on `workflow_dispatch`. Permissions:
+
+- `actions: read`
+- `issues: write`
+- `contents: write`
+- `pull-requests: read`
+
+Required secrets:
+
+- `MONITOR_PUSH_TOKEN` — used to commit the updated series file.
+- `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` — Netlify API access.
+- `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` — Telegram post.
+- `GITHUB_TOKEN` — GitHub API access for usage and issue creation.
+
+Steps:
+
+1. Check out the repository.
+2. Install dependencies with
+   `pnpm install --frozen-lockfile --filter @spem/monitor`.
+3. Run `pnpm --filter @spem/monitor exec node monitor-resources.mjs`.
+4. If `.github/monitor-series.json` changed, commit it with
+   `chore: update daily resource series [skip ci]` and push.
+
+The workflow triggers only on `schedule` and `workflow_dispatch`, so the
+self-commit cannot loop the workflow. The `[skip ci]` suffix also prevents it
+from consuming a `pwa-ci.yml` run.
+
+## Running locally
+
+- Run monitor tests: `pnpm run test:monitor`
+- Lint the monitor package: `pnpm --filter @spem/monitor lint`
+- Run the monitor script locally: set the environment variables listed in
+  `monitor-resources.mjs` and run
+  `pnpm --filter @spem/monitor exec node monitor-resources.mjs`.
+
+## Notes
+
+- Do not edit `.github/monitor-series.json` by hand; the workflow owns it.
+- Netlify billing periods can start mid-month; the script warns and falls back
+  to a calendar-month assumption if the API omits period dates.
+- GitHub usage is derived from workflow-run durations for the current calendar
+  month.
+
+## Related tickets
+
+- [#536](https://github.com/wainwmr/spem-player/issues/536) — monitor burn-rate
+  projection status model.
+- [#553](https://github.com/wainwmr/spem-player/issues/553) — damp early-period
+  projections.
+- [#564](https://github.com/wainwmr/spem-player/issues/564) — monitor CI wiring.
+- [#581](https://github.com/wainwmr/spem-player/issues/581) — split monitor
+  tests into their own workflow.
+- [#616](https://github.com/wainwmr/spem-player/issues/616) /
+  [#617](https://github.com/wainwmr/spem-player/issues/617) — restore ESLint
+  coverage for monitor `.mjs` files.


### PR DESCRIPTION
## Summary

Adds a dedicated `doc/MONITOR.md` documenting the build-resource monitor
(`packages/monitor/`), and trims the now-duplicated monitor section out of
`doc/CI.md`, so the monitor's documentation lives in one place.

## Changes

- New `doc/MONITOR.md`: what the monitor is, why it exists, its files,
  thresholds, and how it runs.
- `doc/CI.md`: monitor section trimmed to a pointer to `MONITOR.md`.

Docs-only — no code or behaviour change (`[skip ci]`).

Fixes #636

- Tele
