### PR TITLE
refactor: in-house play/pause icons (#643)

### DIFF
--- a/packages/pwa/src/icons/pause.svg
+++ b/packages/pwa/src/icons/pause.svg
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
 <svg id="pause" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8 5V19M16 5V19" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.5 5 V19 M15.5 5 V19" stroke="#000000" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/packages/pwa/src/icons/play.svg
+++ b/packages/pwa/src/icons/play.svg
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
 <svg id="play" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M16.6582 9.28638C18.098 10.1862 18.8178 10.6361 19.0647 11.2122C19.2803 11.7152 19.2803 12.2847 19.0647 12.7878C18.8178 13.3638 18.098 13.8137 16.6582 14.7136L9.896 18.94C8.29805 19.9387 7.49907 20.4381 6.83973 20.385C6.26501 20.3388 5.73818 20.0469 5.3944 19.584C5 19.053 5 18.1108 5 16.2264V7.77357C5 5.88919 5 4.94701 5.3944 4.41598C5.73818 3.9531 6.26501 3.66111 6.83973 3.6149C7.49907 3.5619 8.29805 4.06126 9.896 5.05998L16.6582 9.28638Z" stroke="#000000" stroke-width="2" stroke-linejoin="round"/>
+<path d="M8 5 L8 19 L19 12 Z" stroke="#000000" stroke-width="2" stroke-linejoin="round"/>
 </svg>

--- a/packages/pwa/src/test/controls.test.ts
+++ b/packages/pwa/src/test/controls.test.ts
@@ -1,6 +1,8 @@
 import { MusicControls } from "../ts/MusicControls";
 import config from "../ts/config";
 import { processLilypond, barCount } from "../ts/lily";
+import playSVG from "../icons/play.svg?raw";
+import pauseSVG from "../icons/pause.svg?raw";
 import {
   expectedBar,
   expectedChoir,
@@ -142,6 +144,22 @@ describe("MusicControls custom element", () => {
     const pause = document.getElementById("pause");
     expect(pause, document.body.innerHTML).not.toBeNull();
     expect(pause?.style.display, document.body.innerHTML).toBe("none");
+  });
+
+  it("play and pause icons are in-house, with no third-party attribution (#643)", () => {
+    for (const [name, svg] of [
+      ["play", playSVG],
+      ["pause", pauseSVG],
+    ] as const) {
+      // Compliance: the source icons must not carry third-party (SVG Repo) provenance.
+      expect(svg.toLowerCase(), `${name} attribution`).not.toContain("svgrepo");
+      expect(svg.toLowerCase(), `${name} attribution`).not.toContain(
+        "svg repo"
+      );
+      // The sibling DOM tests locate these via getElementById("play"/"pause"), so
+      // the id must survive (MusicControls itself toggles the parsed <svg> refs).
+      expect(svg, `${name} id`).toContain(`id="${name}"`);
+    }
   });
 
   const handleAudioStarted = async (event: Event) => {


### PR DESCRIPTION
## Summary

Replaces the `play.svg` / `pause.svg` icons with clearly-licensed in-house
graphics, removing the licensing ambiguity of the previous icons.

Refactor only — no user-facing behaviour change.

Fixes #643

- Tele
