### PR TITLE
refactor: type fireEvent CustomEvent detail (#646)

### DIFF
--- a/packages/pwa/index.ts
+++ b/packages/pwa/index.ts
@@ -5,7 +5,14 @@ import "./src/scss/style.scss";
 
 import config from "./src/ts/config";
 
-import { PartType, State, colors, toNum, toRecordingIndex } from "./src/ts/common";
+import {
+  MusicEventDetail,
+  PartType,
+  State,
+  colors,
+  toNum,
+  toRecordingIndex,
+} from "./src/ts/common";
 import { parseURLSearch } from "./src/ts/url";
 
 import { MusicCanvas } from "./src/ts/MusicCanvas";
@@ -193,7 +200,7 @@ function parseURL() {
 // Field events (chaning choir, part or bar)
 // -----------------------------------------------------
 
-function handleControlChange(e: CustomEvent) {
+function handleControlChange(e: CustomEvent<MusicEventDetail>) {
   const pos = e.detail.position;
   setChoir(Number(pos.choir));
   setPart(pos.part == "all" ? "all" : Number(pos.part));
@@ -522,7 +529,7 @@ function setVH() {
   document.documentElement.style.setProperty("--vh", `${vh}px`);
 }
 
-function handleCanvasClick(e: CustomEvent) {
+function handleCanvasClick(e: CustomEvent<MusicEventDetail>) {
   const pos = e.detail.position;
 
   setChoir(pos.choir);
@@ -555,36 +562,15 @@ function init(): void {
   // read choir, part and bar from the URL
   parseURL();
 
-  score.addEventListener(
-    "music-score-click",
-    handleControlChange as (e: Event) => void
-  );
+  score.addEventListener("music-score-click", handleControlChange);
 
-  controls.addEventListener(
-    "music-controls-changed",
-    handleControlChange as (e: Event) => void
-  );
-  controls.addEventListener(
-    "music-controls-playing",
-    handleAudioPlaying as (e: Event) => void
-  );
-  controls.addEventListener(
-    "music-controls-paused",
-    handleAudioPaused as (e: Event) => void
-  );
+  controls.addEventListener("music-controls-changed", handleControlChange);
+  controls.addEventListener("music-controls-playing", handleAudioPlaying);
+  controls.addEventListener("music-controls-paused", handleAudioPaused);
 
-  canvas.addEventListener(
-    "music-canvas-click",
-    handleCanvasClick as (e: Event) => void
-  );
-  canvas.addEventListener(
-    "music-canvas-touchstart",
-    handleCanvasClick as (e: Event) => void
-  );
-  canvas.addEventListener(
-    "music-canvas-touchend",
-    handleCanvasClick as (e: Event) => void
-  );
+  canvas.addEventListener("music-canvas-click", handleCanvasClick);
+  canvas.addEventListener("music-canvas-touchstart", handleCanvasClick);
+  canvas.addEventListener("music-canvas-touchend", handleCanvasClick);
 
   document.addEventListener(
     "keydown",

--- a/packages/pwa/src/test/musicelement.test.ts
+++ b/packages/pwa/src/test/musicelement.test.ts
@@ -1,5 +1,6 @@
 import { MusicElement } from "../ts/MusicElement";
 import { MusicControls } from "../ts/MusicControls";
+import type { MusicEventDetail } from "../ts/common";
 
 // Create a concrete subclass for testing
 class TestElement extends MusicElement {
@@ -99,5 +100,27 @@ describe("MusicElement", () => {
     ).not.toThrow();
     // First registration wins; the catch swallowed the duplicate.
     expect(customElements.get("test-control-duplicate")).toBe(TestControlFirst);
+  });
+
+  it("types the event name and the detail payload (#646)", () => {
+    // Pins the compile-time event contract that #646 introduces. While it holds,
+    // the @ts-expect-error below suppresses the error a bad event name now
+    // produces; if someone widens `fireEvent`'s type back to `string`, the
+    // directive becomes unused and `tsc` (check:types) fails (same compile-time
+    // guard pattern as the #551 readonly-Range test in spem.test.ts). The listener
+    // body proves the HTMLElementEventMap augmentation narrows `e` so `e.detail` is
+    // typed without a cast.
+    const elem = document.createElement("test-element") as MusicElement;
+    document.body.appendChild(elem);
+    const received: MusicEventDetail[] = [];
+    elem.addEventListener("music-controls-changed", (e) => {
+      received.push(e.detail);
+    });
+    elem.setChoir(3);
+    expect(received).toHaveLength(1);
+    expect(received[0].position.choir).toBe(3);
+    // @ts-expect-error -- fireEvent rejects names outside MusicEventType (#646)
+    elem.fireEvent("not-a-music-event");
+    document.body.removeChild(elem);
   });
 });

--- a/packages/pwa/src/ts/MusicCanvasWatcher.ts
+++ b/packages/pwa/src/ts/MusicCanvasWatcher.ts
@@ -3,6 +3,7 @@
 
 import config from "./config";
 import { MusicElement } from "./MusicElement";
+import { MusicEventDetail } from "./common";
 
 export class MusicCanvasWatcher extends MusicElement {
   choiroutput: HTMLSpanElement | null = null;
@@ -24,18 +25,18 @@ export class MusicCanvasWatcher extends MusicElement {
     this.baroutput.setAttribute("id", "bar-output");
     this.append(this.baroutput);
 
-    const canvi = document.querySelectorAll("music-canvas");
+    const canvi = document.querySelectorAll<HTMLElement>("music-canvas");
     canvi.forEach((c) => {
       c.addEventListener(
         "music-canvas-hover",
-        this.handleCanvasHover.bind(this) as (e: Event) => void
+        this.handleCanvasHover.bind(this)
       );
     });
   }
 
   intId: ReturnType<typeof setTimeout> | null = null;
 
-  handleCanvasHover(e: CustomEvent) {
+  handleCanvasHover(e: CustomEvent<MusicEventDetail>) {
     if (!this.choiroutput || !this.partoutput || !this.baroutput) return;
     const pos = e.detail.position;
 

--- a/packages/pwa/src/ts/MusicElement.ts
+++ b/packages/pwa/src/ts/MusicElement.ts
@@ -3,6 +3,8 @@
 
 import config from "./config";
 import {
+  MusicEventDetail,
+  MusicEventType,
   PartType,
   Position,
   toNum,
@@ -89,15 +91,15 @@ export class MusicElement extends HTMLElement {
     return this.playing;
   }
 
-  fireEvent(type: string, pos?: Position) {
-    var position: Position = pos
+  fireEvent(type: MusicEventType, pos?: Position) {
+    const position: Position = pos
       ? pos
       : {
           choir: this.choir,
           part: this.voicePart,
           bar: this.bar,
         };
-    const myEvent = new CustomEvent(type, {
+    const myEvent = new CustomEvent<MusicEventDetail>(type, {
       detail: { position: position },
       bubbles: true,
       cancelable: true,

--- a/packages/pwa/src/ts/common.ts
+++ b/packages/pwa/src/ts/common.ts
@@ -11,6 +11,24 @@ export interface Position {
   bar: number;
 }
 
+/** The detail payload carried by every `music-*` CustomEvent (#646). */
+export type MusicEventDetail = { position: Position };
+
+/** Every custom event name dispatched by `MusicElement.fireEvent` (#646). */
+export type MusicEventType =
+  | "music-controls-changed"
+  | "music-controls-loading"
+  | "music-controls-playing"
+  | "music-controls-paused"
+  | "music-canvas-click"
+  | "music-canvas-hover"
+  | "music-canvas-touchstart"
+  | "music-canvas-touchmove"
+  | "music-canvas-touchend"
+  | "music-score-click"
+  | "music-score-loaded"
+  | "music-score-ready";
+
 export type Brightness = "dark" | "light";
 export type ScoreType = "early" | "modern";
 
@@ -28,6 +46,25 @@ export type TestSvgLoader = (
 
 declare global {
   var __SPEM_TEST_SVG_LOADER: TestSvgLoader | undefined;
+  // Narrows `addEventListener` and `e.detail` for every music-* event so consumers
+  // get a typed `CustomEvent<MusicEventDetail>` without a cast (#646). Keep these
+  // keys in lockstep with the `MusicEventType` union above; the eslint
+  // `no-empty-object-type` rule rules out the DRYer `extends Record<MusicEventType,
+  // ...>` form, so the two lists are deliberately explicit.
+  interface HTMLElementEventMap {
+    "music-controls-changed": CustomEvent<MusicEventDetail>;
+    "music-controls-loading": CustomEvent<MusicEventDetail>;
+    "music-controls-playing": CustomEvent<MusicEventDetail>;
+    "music-controls-paused": CustomEvent<MusicEventDetail>;
+    "music-canvas-click": CustomEvent<MusicEventDetail>;
+    "music-canvas-hover": CustomEvent<MusicEventDetail>;
+    "music-canvas-touchstart": CustomEvent<MusicEventDetail>;
+    "music-canvas-touchmove": CustomEvent<MusicEventDetail>;
+    "music-canvas-touchend": CustomEvent<MusicEventDetail>;
+    "music-score-click": CustomEvent<MusicEventDetail>;
+    "music-score-loaded": CustomEvent<MusicEventDetail>;
+    "music-score-ready": CustomEvent<MusicEventDetail>;
+  }
 }
 
 export type Status = "playing" | "paused" | "loading";


### PR DESCRIPTION
## Summary

Types the `detail` payload of the custom events flowing through the event system
(`fireEvent` / `CustomEvent`), replacing untyped `detail` access with typed
payloads across the components.

Refactor only — no user-facing behaviour change.

Fixes #646

- Tele
