### PR TITLE
fix: correct stale threshold values in monitor-resources.mjs JSDoc (#664)

### DIFF
--- a/packages/monitor/monitor-resources.mjs
+++ b/packages/monitor/monitor-resources.mjs
@@ -12,8 +12,8 @@
  *
  * All thresholds apply to the higher of actual and projected end-of-period
  * usage. Skips the Telegram message on days with no PR merges when both
- * actual and projected usage are below 50%. Watch (≥ 50%), throttle (≥ 75%),
- * and critical (≥ 90%) alerts always send regardless of PR activity.
+ * actual and projected usage are below 75% (the watch threshold). Watch (≥ 75%),
+ * throttle (≥ 82%), and critical (≥ 90%) alerts always send regardless of PR activity.
  *
  * Environment variables (all required):
  *   NETLIFY_AUTH_TOKEN


### PR DESCRIPTION
Corrects stale threshold values cited in the `monitor-resources.mjs` JSDoc so the documented thresholds match the actual constants. Comment-only change in the monitor tooling package; no runtime behaviour and no user-facing (PWA) change.

Fixes #664
