### PR TITLE
test: remove dead window.matchMedia mock from four integration tests (#683)

### DIFF
--- a/packages/pwa/src/test/darkmode.test.ts
+++ b/packages/pwa/src/test/darkmode.test.ts
@@ -8,15 +8,6 @@ describe("Dark/light mode toggle", () => {
   beforeAll(async () => {
     vi.resetModules();
 
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-
     vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
     if (!HTMLElement.prototype.scrollTo) {
       HTMLElement.prototype.scrollTo = () => {};

--- a/packages/pwa/src/test/feedback.test.ts
+++ b/packages/pwa/src/test/feedback.test.ts
@@ -5,15 +5,6 @@ describe("Feedback modal", () => {
   beforeAll(async () => {
     vi.resetModules();
 
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-
     vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
     if (!HTMLElement.prototype.scrollTo) {
       HTMLElement.prototype.scrollTo = () => {};

--- a/packages/pwa/src/test/keyboard.test.ts
+++ b/packages/pwa/src/test/keyboard.test.ts
@@ -5,15 +5,6 @@ describe("Space bar play/pause", () => {
   beforeAll(async () => {
     vi.resetModules();
 
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-
     vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
     if (!HTMLElement.prototype.scrollTo) {
       HTMLElement.prototype.scrollTo = () => {};

--- a/packages/pwa/src/test/setbar.test.ts
+++ b/packages/pwa/src/test/setbar.test.ts
@@ -7,15 +7,6 @@ describe("setBar boundary wrapping", () => {
   beforeAll(async () => {
     vi.resetModules();
 
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-
     vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
     if (!HTMLElement.prototype.scrollTo) {
       HTMLElement.prototype.scrollTo = () => {};


### PR DESCRIPTION
Fixes #683

Removes the dead `window.matchMedia` mock from four integration tests (darkmode, feedback, keyboard, setbar).
