### PR TITLE
build: pin github-actions dependabot to weekly Monday slot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,5 +46,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
     open-pull-requests-limit: 2

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -67,7 +67,7 @@ If no SVGs changed, the job exits cleanly without committing.
 `.github/dependabot.yml` configures automated dependency update PRs:
 
 - **pnpm:** Weekly on Mondays at 09:00 UTC, targeting `main`. Related dependencies are grouped into single PRs (vite, vitest, build-tools, types-and-testing, ohm).
-- **GitHub Actions:** Monthly, targeting `main`.
+- **GitHub Actions:** Weekly on Mondays at 09:00 UTC, targeting `main`.
 
 Dependabot PRs are subject to the same `test` status check and ruleset requirements as human-authored PRs.
 


### PR DESCRIPTION
Fixes #641

## Summary

Aligns the `github-actions` Dependabot update to the same predictable weekly slot as the npm block, so the existing weekly pre-dependabot suppression window (Item #579) covers both ecosystems.

In `.github/dependabot.yml`, the `github-actions` block's schedule changes from `interval: "monthly"` (no day/time) to:

- `interval: "weekly"`
- `day: "monday"`
- `time: "09:00"` (no `timezone` ⇒ UTC, matching the npm block)

`open-pull-requests-limit: 2` is unchanged. The two blocks now share an identical schedule shape.

## Notes

- This raises the actions check frequency from monthly to weekly, but Dependabot only opens a PR when an action actually has an update, and the open set is capped at 2 — so real PR volume is essentially unchanged.
- `doc/CI.md`'s Dependabot section is updated to match (GitHub Actions: Weekly on Mondays at 09:00 UTC).
- Best-effort coercion into the weekly slot; if Dependabot does not honour it cleanly, no harm — the Item #579 window proceeds regardless.

## Verification

No unit test applies — a Dependabot schedule is declarative CI config, not executable code (same class as #637). Verified by: the file parses as valid YAML, the `github-actions` `schedule` block is shape-identical to the npm block, and GitHub validates the config server-side (no "dependabot config invalid" annotation on this PR). Full `pnpm run ci` passes (build + lint/format/types/knip/depcruise + 293 unit tests). The Vera gate ran (five reviewers) and passed clean — zero defects introduced.

- Vera
