### PR TITLE
feat: capped merge-time refresh of the build-usage monitor

### DIFF
--- a/.github/workflows/monitor-refresh.yml
+++ b/.github/workflows/monitor-refresh.yml
@@ -1,0 +1,74 @@
+name: Monitor Refresh
+
+# Merge-time refresh of the build-usage series (#699), so the throttle gate
+# (Item #646) reacts to intra-day usage instead of waiting for the 02:29 UTC
+# daily run (monitor-run.yml). The hourly cap keys off the last series-update
+# commit, so it caps refreshes that CHANGE the series to one per hour; in a
+# flat-usage window (no series change, hence no commit) a merge may re-read the
+# APIs, which is cheap (rate-limit only, no build minutes).
+#
+# Loop-safe: the self-commit carries [skip ci], which suppresses the push
+# trigger that would otherwise re-run this workflow. A no-change run makes no
+# commit, so it cannot loop either.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.MONITOR_PUSH_TOKEN }}
+          # Full history so the once-per-hour cap below can find the last
+          # refresh commit with `git log --grep`. The checkout default
+          # (fetch-depth 1) would hide it and defeat the cap.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile --filter @spem/monitor
+
+      - name: Skip if refreshed in the last hour
+        id: recent
+        run: |
+          last=$(git log --format=%ct -1 --grep="chore: refresh build-usage series" || echo 0)
+          last=${last:-0}  # no match -> empty -> 0, so the arithmetic is explicit and set -u-safe
+          now=$(date +%s)
+          if (( now - last < 3600 )); then
+            echo "recent=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping: refreshed within the last hour"
+          else
+            echo "recent=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Refresh usage series
+        if: steps.recent.outputs.recent == 'false'
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: pnpm --filter @spem/monitor exec node monitor-resources.mjs --refresh
+
+      - name: Commit refreshed series
+        if: steps.recent.outputs.recent == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/monitor-series.json
+          if git diff --cached --quiet; then
+            echo "No series changes to commit"
+            exit 0
+          fi
+          git commit --no-verify -m "chore: refresh build-usage series [skip ci]"
+          git push

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -92,13 +92,16 @@ updated SVGs, and the SVG commit then triggers Netlify.
 **Deploy preview:** Netlify posts a preview URL as a comment on each PR
 automatically.
 
-### `monitor-run.yml` and `monitor-ci.yml`
+### `monitor-run.yml`, `monitor-refresh.yml`, and `monitor-ci.yml`
 
 The build-resource monitor tracks Netlify and GitHub Actions usage, posts a daily
-burndown chart to Telegram, and opens a critical issue if usage nears quota. See
-[`doc/MONITOR.md`](./MONITOR.md) for the full monitor documentation, including
-status thresholds, workflow permissions, required secrets, and how to run the
-monitor locally.
+burndown chart to Telegram, and opens a critical issue if usage nears quota.
+`monitor-run.yml` is the daily run; `monitor-refresh.yml` re-reads usage on push
+to `main` (at most one series-changing refresh per hour; no Telegram, chart, or
+critical issue) so the throttle gate reacts to intra-day merges; `monitor-ci.yml`
+is the test gate for monitor changes. See [`doc/MONITOR.md`](./MONITOR.md) for the full monitor documentation,
+including status thresholds, workflow permissions, required secrets, and how to
+run the monitor locally.
 
 ## Node.js Version
 

--- a/doc/MONITOR.md
+++ b/doc/MONITOR.md
@@ -22,8 +22,11 @@ quota is exhausted.
   and its `lint` script.
 - `.github/workflows/monitor-ci.yml` — CI gate for monitor changes.
 - `.github/workflows/monitor-run.yml` — scheduled daily run.
+- `.github/workflows/monitor-refresh.yml` — merge-time refresh that keeps
+  today's series entry current intra-day (at most one series-changing refresh
+  per hour).
 - `.github/monitor-series.json` — daily cumulative usage series, committed by
-  `monitor-run.yml`.
+  `monitor-run.yml` and refreshed intra-day by `monitor-refresh.yml`.
 
 ## Status thresholds
 
@@ -97,6 +100,32 @@ The workflow triggers only on `schedule` and `workflow_dispatch`, so the
 self-commit cannot loop the workflow. The `[skip ci]` suffix also prevents it
 from consuming a `pwa-ci.yml` run.
 
+### `monitor-refresh.yml`
+
+Runs on every push to `main`. It keeps the throttle gate (Item #646) reacting to
+intra-day usage instead of waiting for the next daily run: it re-fetches Netlify
+and GitHub usage, recomputes today's summary, and upserts today's entry in
+`.github/monitor-series.json`.
+
+It deliberately does **less** than the daily run. It invokes
+`monitor-resources.mjs --refresh`, which updates today's entry only and sends no
+Telegram message, renders no chart, and opens no critical issue. It also leaves
+`mergedPRs` at 0; the daily run sets the real count later, but only on a run that
+does not skip the report (see `shouldSkipReport`).
+
+The hourly cap is a `git log --grep` for the previous refresh commit, so the
+checkout uses `fetch-depth: 0` to make that history visible. Because the cap keys
+off the last series-update commit, it caps refreshes that **change** the series
+to one per hour; in a flat-usage window (no series change, hence no commit) a
+merge may re-read the APIs, which is cheap (rate-limit only, no build minutes).
+The workflow is loop-safe: its self-commit (`chore: refresh build-usage series
+[skip ci]`) carries `[skip ci]`, which suppresses the push trigger that would
+otherwise re-run it, and a no-change run makes no commit so it cannot loop.
+
+Required secrets: `MONITOR_PUSH_TOKEN` (to commit the series),
+`NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`, and `GITHUB_TOKEN`. It does not use the
+Telegram secrets.
+
 ## Running locally
 
 - Run monitor tests: `pnpm run test:monitor`
@@ -104,6 +133,9 @@ from consuming a `pwa-ci.yml` run.
 - Run the monitor script locally: set the environment variables listed in
   `monitor-resources.mjs` and run
   `pnpm --filter @spem/monitor exec node monitor-resources.mjs`.
+- Run the merge-time refresh locally: set the same variables minus the Telegram
+  ones, then
+  `pnpm --filter @spem/monitor exec node monitor-resources.mjs --refresh`.
 
 ## Notes
 

--- a/packages/monitor/monitor-resources.mjs
+++ b/packages/monitor/monitor-resources.mjs
@@ -15,7 +15,12 @@
  * actual and projected usage are below 75% (the watch threshold). Watch (≥ 75%),
  * throttle (≥ 82%), and critical (≥ 90%) alerts always send regardless of PR activity.
  *
- * Environment variables (all required):
+ * Run with `--refresh` for the lightweight merge-time path (#699): it refreshes
+ * today's series entry from the live APIs without rendering, Telegram, or
+ * critical-issue logic, so the throttle gate reads up-to-date usage intra-day.
+ * It needs only the Netlify and GitHub credentials, not the Telegram ones.
+ *
+ * Environment variables (all required for the daily run):
  *   NETLIFY_AUTH_TOKEN
  *   NETLIFY_SITE_ID
  *   TELEGRAM_BOT_TOKEN
@@ -936,14 +941,58 @@ export async function main(seriesFile = SERIES_FILE) {
   console.log(`monitor-resources: ${overallStatus} (Netlify ${netlifyPct}%, GitHub ${githubPct}%)`);
 }
 
-// Only run main() when invoked directly, not when imported by tests.
+/**
+ * Merge-time refresh of today's series entry (#699).
+ *
+ * Fetches current Netlify and GitHub usage, rebuilds today's summary, and
+ * upserts it into the series file — and nothing else. Unlike `main` it sends no
+ * Telegram message, renders no chart, opens no critical issue, and does not
+ * re-fetch the merged-PR count (it leaves `mergedPRs` at 0; the daily run sets
+ * the real count later, but only when it does not skip the report — see
+ * `shouldSkipReport`). Its single purpose is to keep the committed
+ * `overallStatus` fresh so the throttle gate reacts intra-day.
+ *
+ * Usage is fetched before the series is touched, so an API failure rejects
+ * without writing the file. Alerts are deliberately not dispatched on failure;
+ * the daily run owns alerting.
+ *
+ * @param {string} [seriesFile] - Series file path; defaults to `SERIES_FILE`.
+ * @returns {Promise<"good"|"watch"|"throttle"|"stop">} The new overall status.
+ */
+export async function refresh(seriesFile = SERIES_FILE) {
+  const netlify = await getNetlifyUsage();
+  const github = await getGitHubUsage();
+  const series = loadSeries(seriesFile);
+  const entry = buildLoggedEntry(todayISO(), netlify, github);
+  saveSeries(appendOrReplaceDay(series, entry), seriesFile);
+  // overallStatusName never returns null and buildLoggedEntry always populates
+  // summary, so overallStatus is one of the four status strings, never null.
+  const overallStatus = entry.summary.overallStatus;
+  console.log(`monitor-resources: refreshed ${overallStatus}`);
+  return overallStatus;
+}
+
+/**
+ * Select the CLI entrypoint from argv. `--refresh` runs the lightweight
+ * merge-time refresh; anything else runs the full daily monitor.
+ *
+ * @param {string[]} argv - Process argv (or any string array).
+ * @returns {"refresh"|"main"} Any argv lacking `--refresh` (including unknown
+ *   flags) routes to `main`.
+ */
+export function selectCommand(argv) {
+  return argv.includes("--refresh") ? "refresh" : "main";
+}
+
+// Only run a command when invoked directly, not when imported by tests.
 // realpathSync on both sides resolves symlinks so the comparison holds
 // when Node is launched via a symlinked path (macOS / nvm common case).
 const __filename = fileURLToPath(import.meta.url);
 const isMain =
   process.argv[1] && realpathSync(process.argv[1]) === realpathSync(__filename);
 if (isMain) {
-  main().catch((err) => {
+  const run = selectCommand(process.argv) === "refresh" ? refresh : main;
+  run().catch((err) => {
     console.error(err.message);
     process.exit(1);
   });

--- a/packages/monitor/monitor-resources.test.mjs
+++ b/packages/monitor/monitor-resources.test.mjs
@@ -1,6 +1,6 @@
 import { test, after, describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -36,6 +36,8 @@ import {
   sendTelegramPhoto,
   openIssue,
   main,
+  refresh,
+  selectCommand,
 } from "./monitor-resources.mjs";
 
 // projectedPct: linear burn-rate projection
@@ -1166,5 +1168,148 @@ describe("main", () => {
       m.restore();
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// --- refresh (#699) --------------------------------------------------------
+// The merge-time refresh path: fetch usage, upsert today's entry, and do
+// nothing else — no Telegram, no chart render, no critical issue, no PR-count
+// fetch. Clock-independent: GitHub usage is pinned to an actual breach (95% of
+// the 2000-minute budget), which is stop-level on any date.
+describe("refresh", () => {
+  test("upserts today's entry and suppresses Telegram/render/critical-issue at stop-level usage", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "monitor-refresh-"));
+    const seriesFile = join(tmp, "series.json");
+    const logs = [];
+    const origLog = console.log;
+    console.log = (msg) => logs.push(msg);
+    const m = startMock([
+      ["/sites/", () => res({ account_slug: "acct" })],
+      ["/builds/status", () =>
+        res({
+          minutes: {
+            current: 10,
+            included_minutes_with_packs: "300",
+            period_start_date: "2026-06-01",
+            period_end_date: "2026-06-30",
+          },
+        }),
+      ],
+      // 114000000 ms = 1900 min = 95% of the 2000-minute budget => stop on any date.
+      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 114000000 }] })],
+    ]);
+    try {
+      const status = await refresh(seriesFile);
+      assert.equal(status, "stop");
+      const series = loadSeries(seriesFile);
+      assert.equal(series.length, 1);
+      assert.equal(series[0].date, todayISO());
+      assert.equal(series[0].summary.overallStatus, "stop");
+      assert.equal(series[0].source, "logged");
+      assert.equal(series[0].mergedPRs, 0); // refresh leaves the PR count for the daily run
+      // No alerting, rendering, critical-issue, or PR-count fetch on the merge path.
+      assert.ok(!m.calls.some((c) => /sendMessage|sendPhoto/.test(c.url)));
+      assert.ok(!m.calls.some((c) => /\/issues$/.test(c.url)));
+      assert.ok(!m.calls.some((c) => /search\/issues/.test(c.url)));
+      assert.ok(logs.some((msg) => /refreshed stop/.test(msg)));
+    } finally {
+      console.log = origLog;
+      m.restore();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects on a Netlify API failure and does not write the series file", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "monitor-refresh-"));
+    const seriesFile = join(tmp, "series.json");
+    const m = startMock([
+      ["/sites/", () => res("netlify down", { ok: false, status: 500 })],
+    ]);
+    try {
+      await assert.rejects(() => refresh(seriesFile), /HTTP 500/);
+      assert.equal(existsSync(seriesFile), false);
+    } finally {
+      m.restore();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects on a GitHub API failure (after Netlify succeeds) without writing the series", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "monitor-refresh-"));
+    const seriesFile = join(tmp, "series.json");
+    const m = startMock([
+      ["/sites/", () => res({ account_slug: "acct" })],
+      ["/builds/status", () =>
+        res({
+          minutes: {
+            current: 10,
+            included_minutes_with_packs: "300",
+            period_start_date: "2026-06-01",
+            period_end_date: "2026-06-30",
+          },
+        }),
+      ],
+      // Netlify has already succeeded; the GitHub leg fails before any write.
+      ["/actions/runs", () => res("gh down", { ok: false, status: 502 })],
+    ]);
+    try {
+      await assert.rejects(() => refresh(seriesFile), /HTTP 502/);
+      assert.equal(existsSync(seriesFile), false);
+    } finally {
+      m.restore();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("replaces an existing same-date entry rather than appending a duplicate", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "monitor-refresh-"));
+    const seriesFile = join(tmp, "series.json");
+    // Seed today's entry with a stale, different (good) status — the intra-day case.
+    const stale = {
+      date: todayISO(),
+      netlifyCurrent: 1,
+      githubMinutes: 1,
+      mergedPRs: 3,
+      summary: {
+        netlifyPct: 0, netlifyProjected: 0, netlifyStatus: "good",
+        githubPct: 0, githubProjected: 0, githubStatus: "good",
+        overallStatus: "good", mergedPRs: 3,
+      },
+      source: "logged",
+    };
+    writeFileSync(seriesFile, JSON.stringify([stale], null, 2) + "\n", "utf8");
+    const m = startMock([
+      ["/sites/", () => res({ account_slug: "acct" })],
+      ["/builds/status", () =>
+        res({
+          minutes: {
+            current: 10,
+            included_minutes_with_packs: "300",
+            period_start_date: "2026-06-01",
+            period_end_date: "2026-06-30",
+          },
+        }),
+      ],
+      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 114000000 }] })],
+    ]);
+    try {
+      await refresh(seriesFile);
+      const series = loadSeries(seriesFile);
+      assert.equal(series.length, 1); // replaced today's entry, not appended
+      assert.equal(series[0].date, todayISO());
+      assert.equal(series[0].summary.overallStatus, "stop"); // overwritten with fresh status
+    } finally {
+      m.restore();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// --- selectCommand (#699) --------------------------------------------------
+describe("selectCommand", () => {
+  test("routes --refresh to refresh and anything else to main", () => {
+    assert.equal(selectCommand(["node", "monitor-resources.mjs", "--refresh"]), "refresh");
+    assert.equal(selectCommand(["node", "monitor-resources.mjs"]), "main");
+    assert.equal(selectCommand(["node", "monitor-resources.mjs", "--other"]), "main");
   });
 });


### PR DESCRIPTION
Fixes #699

Adds a capped, merge-time refresh of the build-usage monitor so the throttle
gate (Item #646) reacts intra-day rather than only on the daily cron.

## What changed

- `packages/monitor/monitor-resources.mjs`: new `refresh()` + `selectCommand()`
  + `isMain` dispatch. `refresh()` suppresses alerting at stop-level and rejects
  without writing on a fetch failure.
- `packages/monitor/monitor-resources.test.mjs`: +3 tests (refresh suppresses
  alerting at stop-level; refresh rejects-without-writing; `selectCommand`
  routing).
- `.github/workflows/monitor-refresh.yml` (new): runs on push-to-`main`, capped
  to once per hour (git-log grep), `fetch-depth: 0`, `[skip ci]` self-commit,
  5-minute timeout, Netlify + GitHub env only.
- `doc/CI.md`, `doc/MONITOR.md`: document the new workflow.

## Tests

- monitor lint clean; `test:monitor` and the monitor-resources suite pass.
- `pnpm run ci` passes (build + unit).

- Vera
