### PR TITLE
fix: pulse sub-1/16 note onsets in canvas (#704)

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/packages/pwa/src/test/canvas.test.ts
+++ b/packages/pwa/src/test/canvas.test.ts
@@ -1,6 +1,7 @@
 import { MusicCanvas } from "../ts/MusicCanvas";
 import config from "../ts/config";
 import type { Position } from "../ts/common";
+import { Duration, Note } from "../ts/music-classes";
 MusicCanvas.define("music-canvas");
 
 var canvas: MusicCanvas | null;
@@ -19,13 +20,17 @@ describe("MusicCanvas custom element", () => {
 
   // seek() tests overwrite choir ranges on the shared beforeAll canvas; snapshot
   // and restore the map per test so a fixture never leaks into a later test (#598).
+  // #704 also mutates notesByQuant, so snapshot that too.
   let savedRanges: NonNullable<typeof canvas>["ranges"];
+  let savedNotesByQuant: NonNullable<typeof canvas>["notesByQuant"];
   beforeEach(() => {
     savedRanges = new Map();
     for (const [key, value] of canvas!.ranges) savedRanges.set(key, [...value]);
+    savedNotesByQuant = canvas!.notesByQuant;
   });
   afterEach(() => {
     canvas!.ranges = savedRanges;
+    canvas!.notesByQuant = savedNotesByQuant;
   });
 
   it("Check that the canvasent contains a canvas", async () => {
@@ -1469,5 +1474,42 @@ describe("MusicCanvas custom element", () => {
     expect(canvas!.playLoopId).toBe(0);
 
     rafSpy.mockRestore();
+  });
+
+  it("pulses a note that onsets off the 1/16 grid (#704)", () => {
+    expect(canvas).not.toBeNull();
+
+    const onset = 0.03125; // 1/32 bar, between 1/16 quant points
+    const note = new Note("a", null, null, new Duration("16"), null);
+    canvas!.notesByQuant = new Map([[onset, [{ c: 0, p: 0, n: note }]]]);
+    canvas!.bar = onset;
+    canvas!.draw();
+
+    expect(canvas!.lastNoteStart[0][0]).toBe(onset);
+    expect(canvas!.lastNoteDuration[0][0]).toBe(4 / 128);
+    expect(canvas!.pulses[0][0]).not.toBe(1);
+  });
+
+  it("still pulses notes on 1/16 and whole-bar boundaries after the finer quant (#704)", () => {
+    expect(canvas).not.toBeNull();
+
+    const note16 = new Note("b", null, null, new Duration("16"), null);
+    const noteWhole = new Note("c", null, null, new Duration("1"), null);
+    canvas!.notesByQuant = new Map([
+      [0.0625, [{ c: 0, p: 1, n: note16 }]],
+      [2.0, [{ c: 1, p: 2, n: noteWhole }]],
+    ]);
+
+    canvas!.bar = 0.0625;
+    canvas!.draw();
+    expect(canvas!.lastNoteStart[0][1]).toBe(0.0625);
+    expect(canvas!.lastNoteDuration[0][1]).toBe(4 / 128);
+    expect(canvas!.pulses[0][1]).not.toBe(1);
+
+    canvas!.bar = 2.0;
+    canvas!.draw();
+    expect(canvas!.lastNoteStart[1][2]).toBe(2.0);
+    expect(canvas!.lastNoteDuration[1][2]).toBe(64 / 128);
+    expect(canvas!.pulses[1][2]).not.toBe(1);
   });
 });

--- a/packages/pwa/src/ts/MusicCanvas.ts
+++ b/packages/pwa/src/ts/MusicCanvas.ts
@@ -389,7 +389,7 @@ export class MusicCanvas extends MusicElement {
     const isLight = this.#isLightMode();
 
     // If there are notes starting now, record their onset and duration
-    const quant = Math.floor(this.bar * 16) / 16;
+    const quant = Math.floor(this.bar * 128) / 128;
     const notes = this.notesByQuant.get(quant);
     if (notes != undefined && notes.length > 0) {
       for (var n of notes) {


### PR DESCRIPTION
## What

`MusicCanvas.#updatePulses()` looked up note onsets on a 1/16-bar grid (`Math.floor(this.bar * 16) / 16`), but `notesByQuant` is keyed at the producer's native 1/128 resolution. Any onset that lands between 1/16 points — the second of a 16th-note pair, e.g. `a16 bes a8` — was never matched, so its canvas pulse never fired. This changes the lookup to 1/128 so those onsets pulse.

```
- const quant = Math.floor(this.bar * 16) / 16;
+ const quant = Math.floor(this.bar * 128) / 128;
```

Fixes #704

## Tests

Two unit tests in `canvas.test.ts`: a note onsetting at 1/32 bar (off the old grid) now pulses (the regression witness — fails on `main`, passes here), and a no-regression check that 1/16 and whole-bar onsets still pulse under the finer quant. `notesByQuant` is snapshot/restored per test, mirroring the existing `ranges` guard (#598). Full `pnpm ci` green.

## Note for review (trade-off)

A Vera review flagged a second-order effect worth your eye: the 1/128 exact-match narrows the playback onset-capture window from ~8 frames to ~1 frame at peak tempo, so an on-grid pulse can be dropped if a frame is lost during the fastest passages (0% at a steady 60fps; the cost is one missing decorative highlight on the overview, not audio or score). It is a net improvement over `main` and was assessed as bounded tech debt rather than a blocking defect. The robust fix — detecting onsets by scanning the bar interval between frames (the `seek()`/`ranges` edge-walk pattern from #598) — is recorded as ride-along tech debt in the MusicCanvas refactor report (it qualifies under our tech-debt test but the harm removed doesn't earn a standalone ticket), to be applied next time this path is worked.

- Claude
