### PR TITLE
test: reusable Playwright computed-style assertion helper (#714)

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -92,9 +92,10 @@ Choosing the right layer keeps the suite fast and deterministic.
 - `AudioContext` (not implemented)
 - canvas pixel output (the `canvas` package provides the API but not pixel-perfect browser rendering)
 - CSS-triggered behaviour (no layout engine)
+- computed CSS properties and cascade effects (specificity, inheritance, `!important`) — jsdom stores inline style strings but does not compute the cascade, so `style.*` can pass while the rendered result is wrong; use Playwright `getComputedStyle` / `elementFromPoint` / `toHaveCSS`
 - real timer execution inside DOM event handlers (`vi.useFakeTimers()` does not intercept `setTimeout` scheduled by jsdom's internal event loop)
 
-If a test needs any of the above, it belongs in the E2E layer.
+If a test needs any of the above, it belongs in the E2E layer. For the computed-CSS / cascade case, the reusable assertions in `packages/pwa/e2e/helpers/computed-style.ts` (`expectComputedStyle`, `expectElementFromPointStyle`, `assertReadableInMode`) are the test-of-record pattern — import them rather than re-deriving the `getComputedStyle` boilerplate.
 
 ## CI Behaviour
 

--- a/packages/pwa/e2e/computed-style.spec.ts
+++ b/packages/pwa/e2e/computed-style.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  getComputedStyleValue,
+  expectComputedStyle,
+  expectComputedStyleNot,
+  expectElementFromPointStyle,
+  assertReadableInMode,
+} from "./helpers/computed-style";
+
+// Exercises the reusable computed-style assertion helper (#714). The helper is
+// the test-of-record pattern for the #1074 rule: when a fix turns on a computed
+// CSS property or the cascade, the proof must be a real-browser read, because
+// jsdom does not compute the cascade.
+
+test.describe("computed-style e2e helper", () => {
+  test.beforeEach(async ({ page }: { page: Page }) => {
+    await page.goto("/");
+  });
+
+  test("getComputedStyleValue / expectComputedStyle resolve a computed property", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "cs-fixture";
+      el.style.color = "rgb(1, 2, 3)";
+      document.body.appendChild(el);
+    });
+
+    expect(await getComputedStyleValue(page, "#cs-fixture", "color")).toBe(
+      "rgb(1, 2, 3)"
+    );
+    await expectComputedStyle(page, "#cs-fixture", "color", "rgb(1, 2, 3)");
+    await expectComputedStyleNot(
+      page,
+      "#cs-fixture",
+      "color",
+      "rgb(255, 255, 255)"
+    );
+  });
+
+  test("expectComputedStyle reads a kebab-case property", async ({ page }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "bg-fixture";
+      el.style.backgroundColor = "rgb(4, 5, 6)";
+      document.body.appendChild(el);
+    });
+
+    // The bracket-index form would return undefined here; getPropertyValue
+    // takes the CSS (kebab-case) name and returns the resolved string.
+    await expectComputedStyle(
+      page,
+      "#bg-fixture",
+      "background-color",
+      "rgb(4, 5, 6)"
+    );
+  });
+
+  test("expectElementFromPointStyle resolves the element under a point", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "pt-fixture";
+      el.style.cssText =
+        "position:fixed;left:0;top:0;width:60px;height:60px;" +
+        "background-color:rgb(7, 8, 9);z-index:99999";
+      document.body.appendChild(el);
+    });
+
+    await expectElementFromPointStyle(
+      page,
+      10,
+      10,
+      "background-color",
+      "rgb(7, 8, 9)"
+    );
+  });
+
+  test("assertReadableInMode passes when foreground and background differ in both modes", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "rm-fixture";
+      el.textContent = "readable";
+      el.style.color = "rgb(0, 0, 0)";
+      el.style.backgroundColor = "rgb(255, 255, 255)";
+      document.body.appendChild(el);
+    });
+
+    await assertReadableInMode(page, "#rm-fixture", "light");
+    await assertReadableInMode(page, "#rm-fixture", "dark");
+  });
+
+  // Negative cases — prove the assertions discriminate (a test-of-record helper
+  // that can only pass is worthless). getPropertyValue returns "" for an
+  // unknown/misspelled/wrong-case property, which must be rejected, not let an
+  // assertion pass vacuously.
+
+  test("getComputedStyleValue rejects a misspelled / empty-resolving property", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "typo-fixture";
+      el.style.color = "rgb(1, 2, 3)";
+      document.body.appendChild(el);
+    });
+
+    // "colr" is not a CSS property -> getPropertyValue returns "" -> guard rejects.
+    // Match the guard's message so the test cannot pass on an unrelated throw.
+    await expect(
+      getComputedStyleValue(page, "#typo-fixture", "colr")
+    ).rejects.toThrow(/resolved ""/);
+    // ...unless the caller opts in to an empty result.
+    expect(
+      await getComputedStyleValue(page, "#typo-fixture", "colr", {
+        allowEmpty: true,
+      })
+    ).toBe("");
+  });
+
+  test("assertReadableInMode rejects a transparent background", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "transparent-fixture";
+      el.textContent = "transparent";
+      el.style.color = "rgb(0, 0, 0)";
+      el.style.backgroundColor = "rgba(0, 0, 0, 0)";
+      document.body.appendChild(el);
+    });
+
+    // A transparent background trivially differs from any foreground, so the
+    // bare fg != bg check would pass without proving readability.
+    await expect(
+      assertReadableInMode(page, "#transparent-fixture", "light")
+    ).rejects.toThrow(/transparent/);
+  });
+
+  test("assertReadableInMode rejects when foreground equals background", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "samecolour-fixture";
+      el.textContent = "invisible";
+      el.style.color = "rgb(10, 20, 30)";
+      el.style.backgroundColor = "rgb(10, 20, 30)";
+      document.body.appendChild(el);
+    });
+
+    await expect(
+      assertReadableInMode(page, "#samecolour-fixture", "light")
+    ).rejects.toThrow(/must differ/);
+  });
+
+  test("expectElementFromPointStyle rejects an empty-resolving property", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.createElement("div");
+      el.id = "pt-typo-fixture";
+      el.style.cssText =
+        "position:fixed;left:0;top:0;width:60px;height:60px;" +
+        "background-color:rgb(7, 8, 9);z-index:99999";
+      document.body.appendChild(el);
+    });
+
+    // The point-read has its own getComputedStyle path; it must reject an empty
+    // resolution too, so a typo'd property paired with `expected: ""` cannot
+    // pass vacuously.
+    await expect(
+      expectElementFromPointStyle(page, 10, 10, "bg-colr", "")
+    ).rejects.toThrow(/resolved ""/);
+  });
+});

--- a/packages/pwa/e2e/helpers/computed-style.ts
+++ b/packages/pwa/e2e/helpers/computed-style.ts
@@ -1,0 +1,184 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Reusable Playwright computed-style assertions (#714).
+ *
+ * jsdom stores inline style strings and does not compute the cascade, so
+ * `style.*` assertions can pass while the rendered result is wrong. The only
+ * reliable proof is a real-browser read. This is the test-of-record pattern
+ * for the #1074 rule: when a fix turns on a computed CSS property or the
+ * cascade (specificity, inheritance, `!important`), assert it here, not in a
+ * jsdom unit test.
+ *
+ * All reads go through `getPropertyValue`, which takes the CSS (kebab-case)
+ * property name and returns the resolved string — robust for properties like
+ * `background-color` that the bracket/camelCase form would miss.
+ */
+
+/**
+ * Read a computed CSS property from the first element matching `selector`.
+ *
+ * `getPropertyValue` returns `""` for an unknown, misspelled, or wrong-case
+ * (camelCase) property name, and for a property that is genuinely unset. An
+ * empty read is rejected by default so a typo cannot make an assertion pass
+ * vacuously — the failure that would otherwise give a test-of-record false
+ * confidence. Pass `{ allowEmpty: true }` to assert an empty value on purpose.
+ *
+ * @param page - the Playwright page.
+ * @param selector - CSS selector; the first match is used.
+ * @param property - CSS property name in kebab-case (e.g. `background-color`).
+ * @param options - `allowEmpty` permits an empty (`""`) result.
+ * @returns The resolved computed value as a string.
+ */
+export async function getComputedStyleValue(
+  page: Page,
+  selector: string,
+  property: string,
+  options: { allowEmpty?: boolean } = {}
+): Promise<string> {
+  const value = await page
+    .locator(selector)
+    .first()
+    .evaluate(
+      (el, prop) => window.getComputedStyle(el).getPropertyValue(prop),
+      property
+    );
+  if (!options.allowEmpty) {
+    expect(
+      value,
+      `getComputedStyle resolved "" for "${property}" on "${selector}" — ` +
+        `unknown/misspelled property, wrong case (use kebab-case), or unset; ` +
+        `pass { allowEmpty: true } to assert an empty value deliberately`
+    ).not.toBe("");
+  }
+  return value;
+}
+
+/**
+ * Assert that a computed CSS property equals `expected`.
+ *
+ * @param page - the Playwright page.
+ * @param selector - CSS selector; the first match is used.
+ * @param property - CSS property name in kebab-case.
+ * @param expected - the expected resolved value (e.g. `rgb(0, 0, 0)`).
+ */
+export async function expectComputedStyle(
+  page: Page,
+  selector: string,
+  property: string,
+  expected: string
+): Promise<void> {
+  expect(await getComputedStyleValue(page, selector, property)).toBe(expected);
+}
+
+/**
+ * Assert that a computed CSS property does NOT equal `notExpected`.
+ *
+ * @param page - the Playwright page.
+ * @param selector - CSS selector; the first match is used.
+ * @param property - CSS property name in kebab-case.
+ * @param notExpected - the value the property must not resolve to.
+ */
+export async function expectComputedStyleNot(
+  page: Page,
+  selector: string,
+  property: string,
+  notExpected: string
+): Promise<void> {
+  expect(await getComputedStyleValue(page, selector, property)).not.toBe(
+    notExpected
+  );
+}
+
+/**
+ * Assert the computed CSS property of the element under a viewport point.
+ *
+ * Resolves `document.elementFromPoint(x, y)` in the browser and reads the
+ * property from it — a direct way to prove which element actually receives a
+ * hit at a coordinate (e.g. an overlay covering a control).
+ *
+ * @param page - the Playwright page.
+ * @param x - viewport x coordinate.
+ * @param y - viewport y coordinate.
+ * @param property - CSS property name in kebab-case.
+ * @param expected - the expected resolved value.
+ * @throws If no element is found at the point.
+ */
+export async function expectElementFromPointStyle(
+  page: Page,
+  x: number,
+  y: number,
+  property: string,
+  expected: string
+): Promise<void> {
+  const actual = await page.evaluate(
+    ({ px, py, prop }) => {
+      const el = document.elementFromPoint(px, py);
+      if (!el) throw new Error(`no element at (${px}, ${py})`);
+      return window.getComputedStyle(el).getPropertyValue(prop);
+    },
+    { px: x, py: y, prop: property }
+  );
+  // This read does not flow through getComputedStyleValue, so it carries its
+  // own non-empty guard: a typo'd/wrong-case/unset property resolves to "" and
+  // must not pass vacuously against an `expected` of "".
+  expect(
+    actual,
+    `getComputedStyle resolved "" for "${property}" at (${x}, ${y}) — ` +
+      `unknown/misspelled property, wrong case (use kebab-case), or unset`
+  ).not.toBe("");
+  expect(actual).toBe(expected);
+}
+
+/**
+ * Assert that an element is readable in the given theme: its foreground
+ * `color` and its own (opaque) `background-color` differ. Toggles the theme
+ * via `#darkswitch` if the requested mode is not already active. A fully
+ * transparent background (the canonical `rgba(0, 0, 0, 0)`) is rejected — it
+ * trivially differs from any foreground and so cannot prove readability; target
+ * an element with a resolved opaque background.
+ *
+ * The dark theme is the default (no `light-theme` class on `body`); light mode
+ * adds it. The toggle is bidirectional so the assertion holds regardless of
+ * the mode the page is currently in.
+ *
+ * @param page - the Playwright page.
+ * @param selector - CSS selector for the element to check; the first match is used.
+ * @param mode - `"light"` or `"dark"`.
+ */
+export async function assertReadableInMode(
+  page: Page,
+  selector: string,
+  mode: "light" | "dark"
+): Promise<void> {
+  const body = page.locator("body");
+  const isLight = await body.evaluate((el) =>
+    el.classList.contains("light-theme")
+  );
+  if (mode === "light") {
+    if (!isLight) await page.locator("#darkswitch").click();
+    await expect(body).toHaveClass(/light-theme/);
+  } else {
+    if (isLight) await page.locator("#darkswitch").click();
+    await expect(body).not.toHaveClass(/light-theme/);
+  }
+
+  const foreground = await getComputedStyleValue(page, selector, "color");
+  const background = await getComputedStyleValue(
+    page,
+    selector,
+    "background-color"
+  );
+  // Canonical Chromium serialisation of a fully transparent background; this is
+  // a fully-transparent check, not a general alpha test (a partial alpha would
+  // pass). The suite is Chromium/WebKit and the themes use opaque colours.
+  expect(
+    background,
+    `background is transparent in ${mode} mode — readability cannot be judged ` +
+      `from this element's own background; target an opaque-background element`
+  ).not.toBe("rgba(0, 0, 0, 0)");
+  expect(
+    foreground,
+    `foreground and background must differ in ${mode} mode`
+  ).not.toBe(background);
+}

--- a/packages/pwa/e2e/lightmode-contrast.spec.ts
+++ b/packages/pwa/e2e/lightmode-contrast.spec.ts
@@ -1,4 +1,8 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+import {
+  getComputedStyleValue,
+  expectComputedStyleNot,
+} from "./helpers/computed-style";
 
 const selectors = [
   ["#test-help-link", "help link"],
@@ -6,18 +10,6 @@ const selectors = [
   ['#feedback-cancel[type="button"]', "feedback cancel button"],
   ["label[for='star1']", "star rating label"],
 ] as const;
-
-async function elementColours(page: Page) {
-  return page.evaluate(
-    (sel) =>
-      sel.map((s) => {
-        const el = document.querySelector(s);
-        if (!el) throw new Error(`selector matched nothing: ${s}`);
-        return window.getComputedStyle(el).color;
-      }),
-    selectors.map(([s]) => s)
-  );
-}
 
 test.describe("Light mode contrast", () => {
   test.beforeEach(async ({ page }) => {
@@ -53,15 +45,11 @@ test.describe("Light mode contrast", () => {
     await expect(body).toHaveClass(/light-theme/);
 
     for (const [selector, name] of selectors) {
-      const locator = page.locator(selector).first();
-      await expect(locator).toBeVisible();
-
-      const colour = await locator.evaluate(
-        (el) => window.getComputedStyle(el).color
-      );
-      expect(colour, `${name} colour in light mode`).not.toBe(
-        "rgb(255, 255, 255)"
-      );
+      await expect(page.locator(selector).first()).toBeVisible();
+      // Real-browser computed read (#714 helper): jsdom would not resolve the
+      // `#help a` cascade. `name` scopes the failure in the trace.
+      await test.step(`${name} colour in light mode`, () =>
+        expectComputedStyleNot(page, selector, "color", "rgb(255, 255, 255)"));
     }
   });
 
@@ -69,12 +57,23 @@ test.describe("Light mode contrast", () => {
     page,
   }) => {
     const body = page.locator("body");
-    const darkColours = await elementColours(page);
+    const readColours = () =>
+      Promise.all(
+        selectors.map(([s]) => getComputedStyleValue(page, s, "color"))
+      );
+
+    // Guard before the bulk read so a dropped fixture fails fast and names the
+    // selector, rather than waiting out a generic locator timeout.
+    for (const [selector, name] of selectors) {
+      await expect(page.locator(selector).first(), name).toBeVisible();
+    }
+
+    const darkColours = await readColours();
 
     await page.locator("#darkswitch").click();
     await expect(body).toHaveClass(/light-theme/);
 
-    const lightColours = await elementColours(page);
+    const lightColours = await readColours();
 
     expect(lightColours).toEqual(darkColours);
   });


### PR DESCRIPTION
## What

A reusable Playwright computed-style assertion helper in `packages/pwa/e2e/helpers/computed-style.ts`, so the real-browser computed-style proof the #1074 rule mandates is cheap to write and not re-derived per ticket. jsdom stores inline style strings but does not compute the cascade, so `style.*` assertions can pass while the rendered result is wrong; the only reliable proof is a real-browser read.

- `getComputedStyleValue` — read primitive; all assertions build on it.
- `expectComputedStyle` / `expectComputedStyleNot` — equality / negation.
- `expectElementFromPointStyle` — reads the element under a viewport point.
- `assertReadableInMode` — toggles the theme and asserts the element's `color` and (opaque) `background-color` differ.

All reads use `getComputedStyle().getPropertyValue` (kebab-case names resolve) and reject an empty (`""`) result — a misspelled/wrong-case/unset property — unless `{ allowEmpty: true }`, so a typo cannot make an assertion pass vacuously.

Refactors `lightmode-contrast.spec.ts` onto the helper; adds `computed-style.spec.ts` exercising every function including negative cases that prove the assertions can fail; documents the computed-CSS/cascade class in `doc/TESTING.md`.

Fixes #714

## Tests

`pnpm run e2e` (the new spec + the refactored contrast spec). Type-checked via `check:types:e2e`. No production code changes.

Folds and supersedes Workbench Item #523.

- Claude
