### PR TITLE
refactor: add compile-time exhaustiveness guard for music event typing

### DIFF
--- a/packages/pwa/src/test/musicelement.test.ts
+++ b/packages/pwa/src/test/musicelement.test.ts
@@ -1,6 +1,21 @@
 import { MusicElement } from "../ts/MusicElement";
 import { MusicControls } from "../ts/MusicControls";
-import type { MusicEventDetail } from "../ts/common";
+import type { AssertNever, MusicEventDetail } from "../ts/common";
+
+// Compile-time exhaustiveness guard for the music-event typing (#716).
+// `AssertNever<T>` (common.ts) errors unless `T` is `never`. Applied here to a
+// local union and a local event map with a deliberately MISSING key, the
+// `Exclude` resolves to that missing key, the assertion errors, and the
+// suppression directive below absorbs it. If the guard mechanism ever stops
+// rejecting a missing key, that directive becomes unused and `tsc`
+// (check:types) fails -- the same compile-time-guard pattern as the #646
+// fireEvent test below and the #551 readonly-Range test in spem.test.ts. This
+// pins the mechanism that protects the real `MusicEventType` /
+// `HTMLElementEventMap` lockstep in common.ts.
+type _ProbeMap = { "music-mapped": CustomEvent<MusicEventDetail> };
+type _ProbeUnion = "music-mapped" | "music-unmapped";
+// @ts-expect-error -- "music-unmapped" has no _ProbeMap key, so Exclude is "music-unmapped", which violates AssertNever's `never` constraint (#716)
+type _ProbeExhaustive = AssertNever<Exclude<_ProbeUnion, keyof _ProbeMap>>;
 
 // Create a concrete subclass for testing
 class TestElement extends MusicElement {

--- a/packages/pwa/src/ts/common.ts
+++ b/packages/pwa/src/ts/common.ts
@@ -67,6 +67,34 @@ declare global {
   }
 }
 
+/**
+ * Compile-time assertion that `T` is `never`. A non-`never` `T` fails the
+ * `extends never` constraint, so `tsc` errors at the instantiation site. It is a
+ * `type` alias (resolving to `void`), so it emits no runtime code. Shared so
+ * type-level guards (and their tests) can express "this set must be empty".
+ */
+export type AssertNever<_T extends never> = void;
+
+/**
+ * Compile-time exhaustiveness guard (#716): every `MusicEventType` member must
+ * have a matching key in the `HTMLElementEventMap` augmentation above, so a new
+ * event name cannot silently untype its listeners. If a member is added to the
+ * union without a map entry, `Exclude<...>` is that member (a string literal, not
+ * `never`) and `AssertNever` fails its `never` constraint, so `tsc`
+ * (check:types) errors here at the definition site. Type-only: no runtime output.
+ * The reverse direction (a map key with no union member) is not checkable here:
+ * `HTMLElementEventMap` is the global DOM event map, so `keyof` it spans every
+ * native event and the reverse `Exclude` is not an assertable-empty set. It is
+ * also low-harm, because `fireEvent`'s `MusicEventType` parameter rejects
+ * dispatching any name outside the union, so an orphan map key can never be fired.
+ *
+ * Exported (not a local alias) only so `noUnusedLocals` does not flag it; it is a
+ * guard, not a value to consume.
+ */
+export type MusicEventMapIsExhaustive = AssertNever<
+  Exclude<MusicEventType, keyof HTMLElementEventMap>
+>;
+
 export type Status = "playing" | "paused" | "loading";
 export type RecordingIndex = 0 | 1;
 


### PR DESCRIPTION
Adds a zero-runtime, compile-time exhaustiveness guard so a `MusicEventType`
union member added without a matching `HTMLElementEventMap` key fails `tsc`,
instead of silently untyping its listeners (the listener falls back to the
generic `Event` and loses `e.detail`'s `MusicEventDetail` type, with no build
error).

Changes:

- `packages/pwa/src/ts/common.ts`: `AssertNever<_T extends never>` plus
  `MusicEventMapIsExhaustive = AssertNever<Exclude<MusicEventType, keyof HTMLElementEventMap>>`.
  Both are type-only (no runtime output). When a union member lacks a map key,
  `Exclude<...>` is that member (a string literal, not `never`) and the
  `extends never` constraint fails at `tsc` (check:types), at the definition site.
- `packages/pwa/src/test/musicelement.test.ts`: a self-contained `@ts-expect-error`
  type probe pinning the guard mechanism, matching the #646 fireEvent test and the
  #551 readonly-Range test.

Only the union-member-without-map-key direction is type-checkable: `HTMLElementEventMap`
is the global DOM event map, so the reverse (an orphan map key) can't be isolated
as an assertable-empty set; it is also low-harm, since `fireEvent`'s `MusicEventType`
parameter rejects dispatching any name outside the union. This is the silent-failure
direction the guard closes.

Promotes refactor-report item 20 (previously RR-only). Verified by a throwaway
canary (an unmapped union member produced `TS2344`, then reverted) and the
committed probe. Vera gate passed; `pnpm run ci` green.

Fixes #716

- Vera
