### PR TITLE
fix: drive monitor throttle status from a rate-relative curve

### DIFF
--- a/doc/MONITOR.md
+++ b/doc/MONITOR.md
@@ -30,18 +30,46 @@ quota is exhausted.
 
 ## Status thresholds
 
-Status is the worse of the Netlify and GitHub statuses, driven by `statusPct`:
+Status is the worse of the Netlify and GitHub statuses, and it is
+**rate-relative** (#724). Rather than projecting usage to the end of the period
+and comparing against absolute percentages, the monitor compares each service's
+actual **remaining** budget against a family of sustainable-pace curves.
 
-- `good` — below 75%.
-- `watch` — 75% or above.
-- `throttle` — 82% or above.
-- `stop` — 90% or above (actual usage only; projection alone cannot open a
-  critical issue).
+The sustainable-remaining curve is `R(t) = (1 - t) ^ alpha`, where `t` is the
+fraction of the billing period elapsed (0 at the start, 1 at the end) and `alpha`
+is the burn-pace exponent. A higher `alpha` burns faster, so a lower `alpha`
+curve sits higher (more remaining is still sustainable). Each band is a curve; a
+service's status is the most severe band whose curve its remaining budget has
+fallen to or below:
 
-`computeUsageStatus` projects current usage linearly to the end of the billing
-period, working from the unrounded percentage to avoid scaling the rounding
-error. The status driver is the worse of actual percentage and projected
-percentage, capped at `throttle` unless actual usage already breaches critical.
+- `good` — remaining above the watch curve.
+- `watch` — remaining at or below the watch curve (`alpha = 0.85`).
+- `throttle` — remaining at or below the throttle curve (`alpha = 0.90`).
+- `stop` — remaining at or below the stop curve (`alpha = 1.00`): on track to
+  exhaust the budget by period end.
+
+The burndown chart draws the throttle curve (`alpha = 0.90`) as its dashed
+reference line, replacing the old straight critical-pace diagonal.
+
+Because the curves all converge to full budget as `t` approaches 0, the bands are
+tightest at the start of the period, so a small early-period burst can reach the
+stop curve on a forward projection alone. To stop that re-opening the #553
+cry-wolf failure, a curve-driven `stop` is **capped to `throttle` unless actual
+usage has breached the critical threshold (90%)** — the #553 guard, retained.
+
+Conversely the bands relax toward period end: the stop curve falls to zero as `t`
+approaches 1, so high late-period usage that is still on a sustainable pace is
+**deliberately not escalated to `stop`**. This is intended, not a gap — it lets
+the surplus be spent down late in the period rather than stranded. The only
+condition that always reports `stop` is genuine exhaustion (remaining at or below
+zero, i.e. usage at or above 100%). The platform itself is the hard, zero-cost
+ceiling for the end case: on the free tier Netlify pauses builds when the monthly
+limit is reached (it does not charge), so tipping over costs build availability
+until the cycle resets, not money.
+
+`computeUsageStatus` still returns the linear end-of-period projection
+(`projected`) for display, working from the unrounded percentage to avoid scaling
+the rounding error, but the projection no longer drives the status.
 
 ## Daily report behaviour
 

--- a/packages/monitor/constants.mjs
+++ b/packages/monitor/constants.mjs
@@ -1,0 +1,21 @@
+// Copyright (c) 2024-2026 Mark Wainwright
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shared monitor constants: the rate-relative band-pace exponents (#724). They
+ * live in their own module so the status logic (`monitor-resources.mjs`, which
+ * uses all three) and the chart renderer (`render-burndown.mjs`, which draws the
+ * throttle curve) share one source of truth — `monitor-resources` already
+ * imports from `render-burndown`, so a constant shared the other way would be a
+ * circular import.
+ *
+ * @module constants
+ */
+
+// Status is driven by where a service's actual remaining budget falls against
+// the sustainable-remaining curve R(t) = (1 - t)^alpha at the elapsed fraction t.
+// A lower alpha sits higher, so the bands nest watch > throttle > stop in
+// remaining.
+export const THROTTLE_ALPHA = 0.9;
+export const WATCH_ALPHA = THROTTLE_ALPHA - 0.05; // 0.85
+export const STOP_ALPHA = THROTTLE_ALPHA + 0.1; // 1.0

--- a/packages/monitor/monitor-resources.mjs
+++ b/packages/monitor/monitor-resources.mjs
@@ -6,14 +6,17 @@
  * Daily build-resource monitor.
  *
  * Queries Netlify and GitHub APIs for current-period build-minute usage,
- * posts a one-line summary to Telegram, and opens a critical issue if
- * either service reaches — or is linearly projected to reach by the end of
- * its billing period — 90% of quota.
+ * posts a one-line summary to Telegram, and opens a critical issue when a
+ * service's status reaches `stop`.
  *
- * All thresholds apply to the higher of actual and projected end-of-period
- * usage. Skips the Telegram message on days with no PR merges when both
- * actual and projected usage are below 75% (the watch threshold). Watch (≥ 75%),
- * throttle (≥ 82%), and critical (≥ 90%) alerts always send regardless of PR activity.
+ * Status is rate-relative (#724): actual remaining budget is classified against
+ * the sustainable-remaining curve R(t) = (1 - t)^alpha for the elapsed fraction
+ * of the period, yielding good / watch / throttle / stop. A curve-driven `stop`
+ * is capped to `throttle` unless actual usage already breaches the critical
+ * threshold (90%), so an early-period burst cannot open a critical issue on a
+ * projection alone (#553 guard). The Telegram message is skipped on days with no
+ * PR merges when both actual and projected usage are below the 75% watch
+ * threshold; watch and worse always send regardless of PR activity.
  *
  * Run with `--refresh` for the lightweight merge-time path (#699): it refreshes
  * today's series entry from the live APIs without rendering, Telegram, or
@@ -33,13 +36,14 @@ import { fileURLToPath } from "url";
 import { realpathSync, readFileSync, writeFileSync, existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { renderBurndown, dayDiff } from "./render-burndown.mjs";
+// Rate-relative throttle alphas (#724) live in their own module so the status
+// logic and the chart renderer share one source of truth (see constants.mjs).
+import { WATCH_ALPHA, THROTTLE_ALPHA, STOP_ALPHA } from "./constants.mjs";
 
 const NETLIFY_API = "https://api.netlify.com/api/v1";
 const TELEGRAM_API = "https://api.telegram.org/bot";
 const WATCH_THRESHOLD_PCT = 75;
-const THROTTLE_THRESHOLD_PCT = 82;
 const CRITICAL_THRESHOLD_PCT = 90;
-const PROJECTION_CAP_PCT = THROTTLE_THRESHOLD_PCT;
 const SERIES_FILE = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../..",
@@ -62,9 +66,49 @@ export function projectedPct(current, daysElapsed, daysInPeriod) {
 }
 
 /**
+ * The sustainable-remaining curve R(t) = (1 - t)^alpha (#724): the fraction of
+ * budget a service may still hold at elapsed-fraction `t`, where remaining falls
+ * as the `alpha`-power of the remaining time. `alpha = 1` is the linear
+ * burn-to-zero pace; `alpha < 1` keeps more in reserve early and defers spending
+ * to period end (less early, more late); `alpha > 1` front-loads. Clamped
+ * outside the open interval — full budget at or before the start (`t <= 0`),
+ * none at or after the end (`t >= 1`) — so an out-of-range `t` (a reference date
+ * past period end) is handled rather than extrapolated.
+ *
+ * @param {number} t - Elapsed fraction of the billing period; clamped outside [0, 1].
+ * @param {number} alpha - Pace exponent; higher burns faster.
+ * @returns {number} Remaining-budget fraction on the curve (0-1).
+ */
+export function curveRemaining(t, alpha) {
+  if (t <= 0) return 1;
+  if (t >= 1) return 0;
+  return Math.pow(1 - t, alpha);
+}
+
+/**
+ * Classify a service's actual remaining-budget fraction against the family of
+ * pace curves at elapsed-fraction `t` (#724). The cascade checks the
+ * most-severe (lowest) curve first; a lower alpha sits higher, so the bands
+ * nest watch > throttle > stop in remaining. This nesting relies on
+ * WATCH_ALPHA < THROTTLE_ALPHA < STOP_ALPHA (derived from THROTTLE_ALPHA in
+ * constants.mjs, so it holds by construction).
+ *
+ * @param {number} actualRemaining - Remaining-budget fraction; may be negative
+ *   when usage exceeds 100% (handled by the `<=` comparisons).
+ * @param {number} t - Elapsed fraction of the billing period; clamped in curveRemaining.
+ * @returns {"good"|"watch"|"throttle"|"stop"}
+ */
+export function statusFromCurve(actualRemaining, t) {
+  if (actualRemaining <= curveRemaining(t, STOP_ALPHA)) return "stop";
+  if (actualRemaining <= curveRemaining(t, THROTTLE_ALPHA)) return "throttle";
+  if (actualRemaining <= curveRemaining(t, WATCH_ALPHA)) return "watch";
+  return "good";
+}
+
+/**
  * Classify a projected end-of-period percentage against the critical-pace
- * diagonal (100% at period-end). Distinct from the watch/throttle/critical
- * budget thresholds.
+ * diagonal (100% at period-end). Distinct from the rate-relative status curve
+ * and the watch/critical budget thresholds.
  *
  * @param {number} projectedPct - Projected end-of-period usage percentage.
  * @returns {"green"|"yellow"|"red"}
@@ -172,55 +216,40 @@ export function calendarMonthPeriod(now = new Date()) {
 }
 
 /**
- * Compute actual, projected, and status percentages for one service from
- * its raw usage record. The single place raw minutes are converted to
- * percentages before projection — the projection always operates on a
- * percentage (Vera 536-01).
+ * Compute actual percentage, the linear projection, and the named status for
+ * one service from its raw usage record. Status is driven by the rate-relative
+ * curve (#724): the actual remaining-budget fraction is classified against the
+ * pace curves at the elapsed fraction `t`. A curve-driven `stop` is capped to
+ * `throttle` unless actual usage already breaches the critical threshold, so an
+ * early-period burst — where the curve bands are tightest — cannot open a
+ * critical issue on a projection alone (the #553 guard, kept under #724). The
+ * projection always operates on a percentage, never raw minutes (Vera 536-01).
+ * `projected` no longer drives status, but it is not inert: `main` feeds it into
+ * `shouldSkipReport` (gating whether the daily Telegram report is suppressed)
+ * and `formatCriticalIssue` uses it for the issue wording.
  *
  * @param {UsageRecord} usage
  * @param {Date} [now] - Reference date; defaults to `new Date()`.
- * @returns {{pct: number, projected: number, statusPct: number}} Actual
- *   percentage, linearly projected end-of-period percentage, and the driver
- *   of status. Projection-driven STOP is capped at throttle (75%) unless
- *   actual usage already breaches the critical threshold (90%).
+ * @returns {{pct: number, projected: number, status: "good"|"watch"|"throttle"|"stop"}}
+ *   Actual percentage, the linear end-of-period projection (still gates report
+ *   suppression and the critical-issue wording), and the named status.
  */
 export function computeUsageStatus(usage, now = new Date()) {
-  // Project from the unrounded percentage: rounding first would scale the
-  // rounding error by period/elapsed (up to 30x on day one).
+  // Work from the unrounded percentage: rounding first would scale the rounding
+  // error by period/elapsed (up to 30x on day one).
   const rawPct = usage.limit > 0 ? (usage.current / usage.limit) * 100 : 0;
   const pct = Math.round(rawPct);
   const elapsed = daysSince(usage.periodStartDate, now);
   const period = daysInPeriod(usage.periodStartDate, usage.periodEndDate);
   const projected = projectedPct(rawPct, elapsed, period);
-  const statusPct =
-    pct >= CRITICAL_THRESHOLD_PCT
-      ? pct
-      : projected >= CRITICAL_THRESHOLD_PCT
-        ? PROJECTION_CAP_PCT
-        : Math.max(pct, projected);
-  return { pct, projected, statusPct };
-}
-
-/**
- * Build a daily summary snapshot from the already-fetched usage records.
- *
- * @param {string} date - ISO date (YYYY-MM-DD).
- * @param {UsageRecord} netlify
- * @param {UsageRecord} github
- * @param {number} mergedPRs
- * @returns {Summary}
- */
-/**
- * Map a status percentage to the named monitor signal.
- *
- * @param {number} statusPct
- * @returns {"good"|"watch"|"throttle"|"stop"}
- */
-export function statusName(statusPct) {
-  if (statusPct >= CRITICAL_THRESHOLD_PCT) return "stop";
-  if (statusPct >= THROTTLE_THRESHOLD_PCT) return "throttle";
-  if (statusPct >= WATCH_THRESHOLD_PCT) return "watch";
-  return "good";
+  const curveStatus = statusFromCurve(1 - rawPct / 100, elapsed / period);
+  // #553 guard: a curve-driven stop is a forward projection, so cap it to
+  // throttle unless actual usage has genuinely breached the critical threshold.
+  const status =
+    curveStatus === "stop" && pct < CRITICAL_THRESHOLD_PCT
+      ? "throttle"
+      : curveStatus;
+  return { pct, projected, status };
 }
 
 /**
@@ -238,13 +267,22 @@ export function overallStatusName(a, b) {
   return worst === 3 ? "stop" : worst === 2 ? "throttle" : worst === 1 ? "watch" : "good";
 }
 
+/**
+ * Build a daily summary snapshot from the already-fetched usage records.
+ *
+ * @param {string} date - ISO date (YYYY-MM-DD).
+ * @param {UsageRecord} netlify
+ * @param {UsageRecord} github
+ * @param {number} mergedPRs
+ * @returns {Summary}
+ */
 export function buildSummary(date, netlify, github, mergedPRs) {
   const day = new Date(date);
   const githubStatus = computeUsageStatus(github, day);
   const netlifyStatus =
     netlify.current == null ? null : computeUsageStatus(netlify, day);
-  const githubStatusName = statusName(githubStatus.statusPct);
-  const netlifyStatusName = netlifyStatus ? statusName(netlifyStatus.statusPct) : null;
+  const githubStatusName = githubStatus.status;
+  const netlifyStatusName = netlifyStatus ? netlifyStatus.status : null;
   return {
     netlifyPct: netlifyStatus?.pct ?? null,
     netlifyProjected: netlifyStatus?.projected ?? null,
@@ -358,16 +396,16 @@ export function shouldSkipReport(mergedCount, maxActualPct, maxProjectedPct) {
 
 /**
  * Build the critical-issue title and body from the two services' status
- * records. The service is named by the quantity that drove the STOP
- * (statusPct, the worse of actual and projected), and the wording
- * distinguishes an actual breach from a projection (Vera 536-04/536-07).
+ * records. The service is named by the one whose status is `stop` (Netlify
+ * takes precedence when both are), and the wording distinguishes an actual
+ * breach from a projection (Vera 536-04/536-07, #724).
  *
- * @param {{pct: number, projected: number, statusPct: number}} netlifyStatus
- * @param {{pct: number, projected: number, statusPct: number}} githubStatus
+ * @param {{pct: number, projected: number, status: "good"|"watch"|"throttle"|"stop"}} netlifyStatus
+ * @param {{pct: number, projected: number, status: "good"|"watch"|"throttle"|"stop"}} githubStatus
  * @returns {{title: string, body: string}}
  */
 export function formatCriticalIssue(netlifyStatus, githubStatus) {
-  const svc = netlifyStatus.statusPct >= 90 ? "Netlify" : "GitHub";
+  const svc = netlifyStatus.status === "stop" ? "Netlify" : "GitHub";
   const svcStatus = svc === "Netlify" ? netlifyStatus : githubStatus;
   const actualBreach = svcStatus.pct >= 90;
   const headline = actualBreach
@@ -867,8 +905,8 @@ export async function main(seriesFile = SERIES_FILE) {
   const githubPct = githubStatus.pct;
   const maxActual = Math.max(netlifyPct, githubPct);
   const maxProjected = Math.max(netlifyStatus.projected, githubStatus.projected);
-  const netlifyStatusName = statusName(netlifyStatus.statusPct);
-  const githubStatusName = statusName(githubStatus.statusPct);
+  const netlifyStatusName = netlifyStatus.status;
+  const githubStatusName = githubStatus.status;
   const overallStatus = overallStatusName(netlifyStatusName, githubStatusName);
 
   const since = getReportingSince();

--- a/packages/monitor/monitor-resources.test.mjs
+++ b/packages/monitor/monitor-resources.test.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   projectedPct,
+  curveRemaining,
+  statusFromCurve,
   computeUsageStatus,
   formatCriticalIssue,
   validatePeriod,
@@ -15,7 +17,6 @@ import {
   parseRepo,
   todayISO,
   paceBucket,
-  statusName,
   overallStatusName,
   loadSeries,
   saveSeries,
@@ -61,9 +62,54 @@ test("projectedPct clamps daysElapsed to 1", () => {
   assert.equal(projectedPct(10, 0, 30), 300);
 });
 
-// computeUsageStatus: binds the projection to API-shaped raw values — the
-// regression net for the units bug (Vera 536-01): the helper must divide by
-// the limit before projecting, never project raw minutes.
+// curveRemaining: the sustainable-remaining curve R(t) = (1 - t)^alpha (#724).
+// Clamped outside the open interval: full budget at/before the start, none
+// at/after the end.
+test("curveRemaining returns 1 at or before the period start", () => {
+  assert.equal(curveRemaining(0, 0.9), 1);
+  assert.equal(curveRemaining(-0.5, 0.9), 1);
+});
+
+test("curveRemaining returns 0 at or after the period end", () => {
+  assert.equal(curveRemaining(1, 0.9), 0);
+  assert.equal(curveRemaining(1.5, 0.9), 0);
+});
+
+test("curveRemaining is (1 - t)^alpha inside the period", () => {
+  assert.ok(Math.abs(curveRemaining(0.5, 0.9) - 0.535887) < 1e-6);
+  assert.ok(Math.abs(curveRemaining(0.5, 1.0) - 0.5) < 1e-9);
+  assert.ok(Math.abs(curveRemaining(0.5, 0.85) - 0.554785) < 1e-6);
+});
+
+// statusFromCurve: classify actual remaining against the family of curves
+// (#724). Lower alpha sits higher, so the bands nest watch > throttle > stop
+// in remaining; the cascade checks the most-severe (lowest) curve first.
+test("statusFromCurve is good above the watch curve", () => {
+  // t = 0.5: watch 0.5548, throttle 0.5359, stop 0.5.
+  assert.equal(statusFromCurve(0.6, 0.5), "good");
+});
+
+test("statusFromCurve is watch between the watch and throttle curves", () => {
+  assert.equal(statusFromCurve(0.545, 0.5), "watch");
+});
+
+test("statusFromCurve is throttle between the throttle and stop curves", () => {
+  assert.equal(statusFromCurve(0.52, 0.5), "throttle");
+});
+
+test("statusFromCurve is stop at or below the stop curve", () => {
+  assert.equal(statusFromCurve(0.5, 0.5), "stop");
+  assert.equal(statusFromCurve(0.4, 0.5), "stop");
+});
+
+test("statusFromCurve leaves late-period remaining good (curves collapse to 0)", () => {
+  // At t = 1 every curve is 0, so any positive remaining is good.
+  assert.equal(statusFromCurve(0.05, 1), "good");
+});
+
+// computeUsageStatus: drives status from the rate curve, keeping pct/projected
+// for display. The units regression net stands (Vera 536-01): the helper must
+// divide by the limit before projecting, never project raw minutes.
 test("computeUsageStatus projects percentages, not minutes (Vera 536-01)", () => {
   const usage = {
     current: 60,
@@ -72,14 +118,33 @@ test("computeUsageStatus projects percentages, not minutes (Vera 536-01)", () =>
     periodEndDate: "2026-06-30",
   };
   const now = new Date("2026-06-15T12:00:00Z");
+  // 20% used at t = 0.5 → remaining 0.8, above the watch curve → good.
   assert.deepEqual(computeUsageStatus(usage, now), {
     pct: 20,
     projected: 40,
-    statusPct: 40,
+    status: "good",
   });
 });
 
-test("computeUsageStatus on-budget usage is capped at throttle", () => {
+test("computeUsageStatus mid-period stranded budget is now good (#724)", () => {
+  // The headline #724 case: 40% used at t = 0.5 is comfortably sustainable.
+  const usage = {
+    current: 120,
+    limit: 300,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+  };
+  const now = new Date("2026-06-15T12:00:00Z");
+  assert.deepEqual(computeUsageStatus(usage, now), {
+    pct: 40,
+    projected: 80,
+    status: "good",
+  });
+});
+
+test("computeUsageStatus at the linear-exhaust pace caps to throttle (#553 guard)", () => {
+  // 50% used at t = 0.5 → remaining 0.5 = stop curve, but actual < 90%, so the
+  // #553 guard caps the curve-stop down to throttle.
   const usage = {
     current: 150,
     limit: 300,
@@ -90,7 +155,7 @@ test("computeUsageStatus on-budget usage is capped at throttle", () => {
   assert.deepEqual(computeUsageStatus(usage, now), {
     pct: 50,
     projected: 100,
-    statusPct: 82,
+    status: "throttle",
   });
 });
 
@@ -106,7 +171,7 @@ test("computeUsageStatus converges on the period's last day", () => {
   assert.equal(result.projected, result.pct);
 });
 
-test("computeUsageStatus day-one spike is capped at throttle (#553)", () => {
+test("computeUsageStatus day-one spike caps to throttle, not stop (#553 guard kept under #724)", () => {
   const usage = {
     current: 20,
     limit: 300,
@@ -115,27 +180,14 @@ test("computeUsageStatus day-one spike is capped at throttle (#553)", () => {
   };
   const now = new Date("2026-06-01T12:00:00Z");
   const result = computeUsageStatus(usage, now);
+  // 7% used on day 1 is over the rate curve (stop), but actual < 90%, so the
+  // guard caps it to throttle — no critical issue on an early-period spike.
   assert.equal(result.pct, 7);
   assert.equal(result.projected, 200);
-  assert.equal(result.statusPct, 82);
+  assert.equal(result.status, "throttle");
 });
 
-// Projection-damping policy (#553): projection-driven STOP is capped at
-// throttle unless actual usage already breaches the critical threshold.
-test("computeUsageStatus caps day-1 spike at throttle", () => {
-  const usage = {
-    current: 30,
-    limit: 100,
-    periodStartDate: "2026-06-01",
-    periodEndDate: "2026-06-30",
-  };
-  const result = computeUsageStatus(usage, new Date("2026-06-01T12:00:00Z"));
-  assert.equal(result.pct, 30);
-  assert.equal(result.projected, 900);
-  assert.equal(result.statusPct, 82);
-});
-
-test("computeUsageStatus actual breach overrides projection cap", () => {
+test("computeUsageStatus actual breach overrides the #553 guard", () => {
   const usage = {
     current: 92,
     limit: 100,
@@ -143,12 +195,13 @@ test("computeUsageStatus actual breach overrides projection cap", () => {
     periodEndDate: "2026-06-30",
   };
   const result = computeUsageStatus(usage, new Date("2026-06-01T12:00:00Z"));
+  // Actual usage ≥ 90% lifts the guard: a genuine breach is stop.
   assert.equal(result.pct, 92);
   assert.equal(result.projected, 2760);
-  assert.equal(result.statusPct, 92);
+  assert.equal(result.status, "stop");
 });
 
-test("computeUsageStatus caps mid-period projection at throttle", () => {
+test("computeUsageStatus caps a mid-period over-pace to throttle", () => {
   const usage = {
     current: 100,
     limit: 200,
@@ -158,10 +211,12 @@ test("computeUsageStatus caps mid-period projection at throttle", () => {
   const result = computeUsageStatus(usage, new Date("2026-06-15T12:00:00Z"));
   assert.equal(result.pct, 50);
   assert.equal(result.projected, 100);
-  assert.equal(result.statusPct, 82);
+  assert.equal(result.status, "throttle");
 });
 
-test("computeUsageStatus leaves late-period normal usage unchanged", () => {
+test("computeUsageStatus leaves late-period high usage good if on the rate curve (#724)", () => {
+  // 85% used at t ≈ 0.967 is still consistent with the rate curve → good,
+  // where the old absolute-threshold model flagged it watch.
   const usage = {
     current: 170,
     limit: 200,
@@ -171,10 +226,55 @@ test("computeUsageStatus leaves late-period normal usage unchanged", () => {
   const result = computeUsageStatus(usage, new Date("2026-06-29T12:00:00Z"));
   assert.equal(result.pct, 85);
   assert.equal(result.projected, 88);
-  assert.equal(result.statusPct, 88);
+  assert.equal(result.status, "good");
 });
 
-test("computeUsageStatus caps projection at the 90% boundary", () => {
+test("computeUsageStatus does not escalate high late-period usage to stop (#724 surplus use)", () => {
+  // 95% used on day 29 of 30 is still on a sustainable end-of-period pace, so it
+  // is deliberately NOT escalated to stop — this is the point of #724: spend the
+  // surplus down late rather than strand it. The platform pause at 100% is the
+  // real hard ceiling. This guards the intent against a future
+  // "actual >= 90% always stops" regression (which all reviewers, reasonably,
+  // first read as the correct behaviour).
+  const usage = {
+    current: 190,
+    limit: 200,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+  };
+  const result = computeUsageStatus(usage, new Date("2026-06-29T12:00:00Z"));
+  assert.equal(result.pct, 95);
+  // Only "not stop" is asserted: that is the robust #724 intent and survives
+  // alpha tuning. The exact band (watch vs throttle) is pinned by the dedicated
+  // curve-band tests above, so this guard rail stays decoupled from the tuning.
+  assert.notEqual(result.status, "stop");
+});
+
+test("computeUsageStatus is a genuine curve-throttle, not via the #553 guard (#724)", () => {
+  // 48% used at t=0.5 -> remaining 0.52, between the stop and throttle curves.
+  const usage = {
+    current: 96,
+    limit: 200,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+  };
+  const result = computeUsageStatus(usage, new Date("2026-06-15T12:00:00Z"));
+  assert.deepEqual(result, { pct: 48, projected: 96, status: "throttle" });
+});
+
+test("computeUsageStatus produces a genuine curve-watch (#724)", () => {
+  // 45.5% used at t=0.5 -> remaining 0.545, between the throttle and watch curves.
+  const usage = {
+    current: 91,
+    limit: 200,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+  };
+  const result = computeUsageStatus(usage, new Date("2026-06-15T12:00:00Z"));
+  assert.deepEqual(result, { pct: 46, projected: 91, status: "watch" });
+});
+
+test("computeUsageStatus pins the 90% guard boundary: 89% caps to throttle (#553)", () => {
   const usage = {
     current: 89,
     limit: 100,
@@ -183,11 +283,22 @@ test("computeUsageStatus caps projection at the 90% boundary", () => {
   };
   const result = computeUsageStatus(usage, new Date("2026-06-01T12:00:00Z"));
   assert.equal(result.pct, 89);
-  assert.equal(result.projected, 2670);
-  assert.equal(result.statusPct, 82);
+  assert.equal(result.status, "throttle");
 });
 
-test("computeUsageStatus zero limit yields zeros, no division error", () => {
+test("computeUsageStatus pins the 90% guard boundary: 90% reports stop", () => {
+  const usage = {
+    current: 90,
+    limit: 100,
+    periodStartDate: "2026-06-01",
+    periodEndDate: "2026-06-30",
+  };
+  const result = computeUsageStatus(usage, new Date("2026-06-01T12:00:00Z"));
+  assert.equal(result.pct, 90);
+  assert.equal(result.status, "stop");
+});
+
+test("computeUsageStatus zero limit yields zeros and good status", () => {
   const usage = {
     current: 10,
     limit: 0,
@@ -195,16 +306,16 @@ test("computeUsageStatus zero limit yields zeros, no division error", () => {
     periodEndDate: "2026-06-30",
   };
   const result = computeUsageStatus(usage, new Date("2026-06-10T00:00:00Z"));
-  assert.deepEqual(result, { pct: 0, projected: 0, statusPct: 0 });
+  assert.deepEqual(result, { pct: 0, projected: 0, status: "good" });
 });
 
 // formatCriticalIssue: binds the critical-issue attribution and wording —
-// the service is named by the quantity that drove the STOP (statusPct), and
-// the title distinguishes an actual breach from a projection (Vera 536-07).
+// the service is named by the one whose status drove the STOP, and the title
+// distinguishes an actual breach from a projection (Vera 536-07, #724).
 test("formatCriticalIssue names the actual-breach service with at-N% wording", () => {
   const { title, body } = formatCriticalIssue(
-    { pct: 92, projected: 95, statusPct: 95 },
-    { pct: 10, projected: 12, statusPct: 12 }
+    { pct: 92, projected: 95, status: "stop" },
+    { pct: 10, projected: 12, status: "good" }
   );
   assert.equal(title, "BUILD MINUTES CRITICAL: Netlify at 92%");
   assert.match(body, /Netlify build minutes at 92% of quota\./);
@@ -212,8 +323,8 @@ test("formatCriticalIssue names the actual-breach service with at-N% wording", (
 
 test("formatCriticalIssue names the projection-driven service with projected wording", () => {
   const { title, body } = formatCriticalIssue(
-    { pct: 30, projected: 120, statusPct: 120 },
-    { pct: 10, projected: 12, statusPct: 12 }
+    { pct: 30, projected: 120, status: "stop" },
+    { pct: 10, projected: 12, status: "good" }
   );
   assert.equal(title, "BUILD MINUTES CRITICAL: Netlify projected 120%");
   assert.match(
@@ -222,12 +333,22 @@ test("formatCriticalIssue names the projection-driven service with projected wor
   );
 });
 
-test("formatCriticalIssue attributes a GitHub-projection STOP to GitHub (Vera 536-04 regression pin)", () => {
+test("formatCriticalIssue attributes a GitHub STOP to GitHub (Vera 536-04 regression pin)", () => {
   const { title } = formatCriticalIssue(
-    { pct: 20, projected: 40, statusPct: 40 },
-    { pct: 15, projected: 110, statusPct: 110 }
+    { pct: 20, projected: 40, status: "good" },
+    { pct: 15, projected: 110, status: "stop" }
   );
   assert.equal(title, "BUILD MINUTES CRITICAL: GitHub projected 110%");
+});
+
+test("formatCriticalIssue gives Netlify precedence when both services are stop (#724)", () => {
+  // The reworded selector is `netlifyStatus.status === "stop" ? "Netlify" : ...`,
+  // so when both are stop Netlify is named. Pins the new predicate's tie-break.
+  const { title } = formatCriticalIssue(
+    { pct: 95, projected: 130, status: "stop" },
+    { pct: 92, projected: 120, status: "stop" }
+  );
+  assert.equal(title, "BUILD MINUTES CRITICAL: Netlify at 95%");
 });
 
 // validatePeriod: malformed billing dates must fail loudly in the getters
@@ -381,18 +502,6 @@ test("paceBucket returns red when over critical pace", () => {
   assert.equal(paceBucket(101), "red");
   assert.equal(paceBucket(150), "red");
 });
-
-// statusName: map status percentage to named signal
- test("statusName maps thresholds to the correct signal", () => {
-   assert.equal(statusName(0), "good");
-   assert.equal(statusName(74), "good");
-   assert.equal(statusName(75), "watch");
-   assert.equal(statusName(81), "watch");
-   assert.equal(statusName(82), "throttle");
-   assert.equal(statusName(89), "throttle");
-   assert.equal(statusName(90), "stop");
-   assert.equal(statusName(120), "stop");
- });
 
  // overallStatusName: worse of two service statuses wins
  test("overallStatusName returns the worse service status", () => {
@@ -1041,9 +1150,10 @@ describe("Telegram and issue posting", () => {
 // These tests are clock-independent by construction, even though `main` reads
 // the real clock internally (todayISO/getReportingSince): the skip case forces
 // `current: 0` and `total_count: 0`, so usage is 0 regardless of the date, and
-// the stop case pins `run_duration_ms` to 95% of the budget, which is stop-level
-// on any date. Keep that property if you raise the fixture numbers, or inject a
-// fixed reference date instead.
+// the stop case pins `run_duration_ms` to ≥ 100% of the budget. Under the rate
+// curve (#724) a sub-100% usage is good at period end, so stop-on-any-date now
+// requires remaining ≤ 0 (used ≥ 100%); 126000000 ms = 2100 min = 105%. Keep
+// that property if you change the fixture, or inject a fixed reference date.
 describe("main", () => {
   test("skips the report when no PRs merged and usage is zero", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "monitor-main-"));
@@ -1112,7 +1222,7 @@ describe("main", () => {
           },
         }),
       ],
-      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 114000000 }] })],
+      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 126000000 }] })],
       ["/search/issues", () => res({ total_count: 2 })],
       ["/sendPhoto", () => res({ ok: true })],
       ["/issues", () => res({ id: 1 })],
@@ -1174,8 +1284,8 @@ describe("main", () => {
 // --- refresh (#699) --------------------------------------------------------
 // The merge-time refresh path: fetch usage, upsert today's entry, and do
 // nothing else — no Telegram, no chart render, no critical issue, no PR-count
-// fetch. Clock-independent: GitHub usage is pinned to an actual breach (95% of
-// the 2000-minute budget), which is stop-level on any date.
+// fetch. Clock-independent: GitHub usage is pinned to ≥ 100% of the 2000-minute
+// budget (remaining ≤ 0), which is stop-level on any date under the rate curve.
 describe("refresh", () => {
   test("upserts today's entry and suppresses Telegram/render/critical-issue at stop-level usage", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "monitor-refresh-"));
@@ -1195,8 +1305,9 @@ describe("refresh", () => {
           },
         }),
       ],
-      // 114000000 ms = 1900 min = 95% of the 2000-minute budget => stop on any date.
-      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 114000000 }] })],
+      // 126000000 ms = 2100 min = 105% of the 2000-minute budget => remaining ≤ 0,
+      // so stop on any date under the rate curve (#724).
+      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 126000000 }] })],
     ]);
     try {
       const status = await refresh(seriesFile);
@@ -1290,7 +1401,7 @@ describe("refresh", () => {
           },
         }),
       ],
-      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 114000000 }] })],
+      ["/actions/runs", () => res({ workflow_runs: [{ run_duration_ms: 126000000 }] })],
     ]);
     try {
       await refresh(seriesFile);

--- a/packages/monitor/render-burndown.mjs
+++ b/packages/monitor/render-burndown.mjs
@@ -13,6 +13,7 @@
 import { createCanvas, loadImage } from "canvas";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
+import { THROTTLE_ALPHA } from "./constants.mjs";
 
 /**
  * @typedef {import("./monitor-resources.mjs").UsageRecord} UsageRecord
@@ -181,6 +182,31 @@ function roundRect(ctx, x, y, w, h, r) {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Draw the throttle-pace reference curve for one panel: the sustainable-pace
+ * line used(t) = 1 - (1 - t)^THROTTLE_ALPHA, sampled as a smooth polyline from
+ * the chart's top-left (t = 0, 0% used) to its bottom-right (t = 1, 100% used).
+ * Replaces the straight critical-pace diagonal (#724). This builds and strokes
+ * the path; the caller owns the stroke style and dash.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} ox - Chart origin x.
+ * @param {number} oy - Chart origin y.
+ */
+function drawThrottleCurve(ctx, ox, oy) {
+  const SAMPLES = 100;
+  ctx.beginPath();
+  for (let i = 0; i <= SAMPLES; i++) {
+    const t = i / SAMPLES;
+    const used = 1 - Math.pow(1 - t, THROTTLE_ALPHA);
+    const x = ox + t * CHART_WIDTH;
+    const y = oy + CHART_HEIGHT * used;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+/**
  * Draw one panel.
  *
  * @param {CanvasRenderingContext2D} ctx
@@ -252,14 +278,13 @@ function drawPanel(ctx, originX, icon, fireIcon, usage, points, now, status) {
     ctx.stroke();
   }
 
-  // Critical-pace diagonal (0% used → 100% used)
+  // Throttle-pace reference curve (#724): replaces the straight critical-pace
+  // diagonal. Same dashed style and colour; the curve bows above the old
+  // diagonal, marking the sustainable burn pace at each point in the period.
   ctx.strokeStyle = COLORS.diagonal;
   ctx.lineWidth = 4;
   ctx.setLineDash([8, 6]);
-  ctx.beginPath();
-  ctx.moveTo(ox, oy);
-  ctx.lineTo(ox + CHART_WIDTH, oy + CHART_HEIGHT);
-  ctx.stroke();
+  drawThrottleCurve(ctx, ox, oy);
   ctx.setLineDash([]);
 
   // Actual usage line, coloured per segment
@@ -450,4 +475,7 @@ export async function renderBurndown(
 export const exportedForTesting = {
   drawHistogram,
   statusColor,
+  drawThrottleCurve,
+  CHART_WIDTH,
+  CHART_HEIGHT,
 };

--- a/packages/monitor/render-burndown.test.mjs
+++ b/packages/monitor/render-burndown.test.mjs
@@ -2,7 +2,8 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { renderBurndown, exportedForTesting } from "./render-burndown.mjs";
 
-const { drawHistogram, statusColor } = exportedForTesting;
+const { drawHistogram, statusColor, drawThrottleCurve, CHART_WIDTH, CHART_HEIGHT } =
+  exportedForTesting;
 
 const statuses = { github: "good", netlify: "watch", overall: "watch" };
 
@@ -78,6 +79,41 @@ function createMockCtx() {
     },
   };
 }
+
+// drawThrottleCurve: the rate-relative pace reference (#724), replacing the
+// straight critical-pace diagonal.
+test("drawThrottleCurve draws a sampled polyline from top-left to bottom-right", () => {
+  const ctx = createMockCtx();
+  const ox = 100;
+  const oy = 50;
+  drawThrottleCurve(ctx, ox, oy);
+
+  const moves = ctx.operations.filter((op) => op.type === "moveTo");
+  const lines = ctx.operations.filter((op) => op.type === "lineTo");
+  assert.equal(moves.length, 1, "one moveTo starts the polyline");
+  assert.ok(
+    lines.length > 2,
+    "a sampled curve has many segments, not one diagonal segment"
+  );
+
+  // Starts at the chart origin (top-left).
+  assert.equal(moves[0].x, ox);
+  assert.equal(moves[0].y, oy);
+
+  // Ends at the bottom-right corner of the chart area.
+  const last = lines[lines.length - 1];
+  assert.ok(Math.abs(last.x - (ox + CHART_WIDTH)) < 1e-9);
+  assert.ok(Math.abs(last.y - (oy + CHART_HEIGHT)) < 1e-9);
+
+  // Bows above the diagonal: at the horizontal midpoint the curve sits above the
+  // straight diagonal (less used than the linear pace), so its y is above the midline.
+  const mid = lines.find((op) => Math.abs(op.x - (ox + CHART_WIDTH / 2)) < 1e-9);
+  assert.ok(mid, "a sample sits at the horizontal midpoint");
+  assert.ok(
+    mid.y < oy + CHART_HEIGHT / 2,
+    "curve bows above the diagonal midpoint"
+  );
+});
 
 test("drawHistogram draws a baseline and bars for past days with PRs", () => {
   const ctx = createMockCtx();


### PR DESCRIPTION
Replaces the build-resource monitor's linear end-of-period throttle projection with a rate-relative status model.

## What

Status is now driven by where each service's actual **remaining** budget falls against the sustainable-remaining curve `R(t) = (1 - t)^alpha` at the elapsed fraction `t`: watch `alpha = 0.85`, throttle `0.90`, stop `1.00` (the linear-to-zero pace). This stops the old model stranding budget early in the period and lets the surplus be spent down late.

## Behaviour notes

- The #553 guard is kept: a curve-driven `stop` caps to `throttle` unless actual usage has breached the critical threshold (90%), so an early-period burst cannot open a critical issue on a projection alone.
- Late-period high usage that is still on a sustainable pace is **deliberately not** escalated to `stop` — that is the point (use the surplus late rather than strand it). The only always-stop condition is genuine exhaustion (remaining ≤ 0, usage ≥ 100%); the platform itself is the hard zero-cost ceiling (Netlify pauses builds on the free tier, it does not charge).
- The burndown chart now draws the throttle curve as its dashed reference line, replacing the straight critical-pace diagonal.
- The linear projection is retained in the summary for display and still gates report suppression and the critical-issue wording; it no longer drives status.

## Tests and docs

- `pnpm --filter @spem/monitor test` (112) and `pnpm --filter @spem/monitor lint` green; `pnpm run ci` green.
- `doc/MONITOR.md` "Status thresholds" rewritten to match.
- The throttle alphas live in a new `packages/monitor/constants.mjs` shared by the status logic and the chart (one source of truth).

Fixes #724

- Tele
