### PR TITLE
ci: push regenerated files to main via a rebase-retry helper

### DIFF
--- a/.github/scripts/push-with-rebase.sh
+++ b/.github/scripts/push-with-rebase.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Push the current HEAD commit to main with bounded rebase-retry (#727).
+#
+# A bot commit step regenerates a file, commits it, and pushes to main. A bare
+# `git push` from a checkout that has fallen behind origin/main fails
+# non-fast-forward whenever another push landed in between -- non-fast-forward is
+# a property of the ref, not the file. The symptom is a spurious red CI run; the
+# data still lands via the winning run.
+#
+# This helper makes the push converge: on a rejection it replays our commit onto
+# the freshly-fetched main and retries, bounded.
+#
+# Caller contract: HEAD is the single commit to push (already `git add` +
+# `git commit`ed). Run it in place of the final `git push`:
+#
+#     bash .github/scripts/push-with-rebase.sh
+#
+# Why rebase, not `git reset --soft origin/main`: reset would re-stage our whole
+# tree, which still holds the OLD version of any file another push changed in
+# parallel -- re-committing that would silently REVERT their change. Rebase
+# replays only our commit's delta, so concurrent changes to other files are
+# preserved.
+#
+# Why `-X theirs`: the only files that can conflict are the one(s) our commit
+# rewrote (when a parallel run rewrote them too). `-X theirs` resolves that
+# conflict deterministically in favour of the commit being replayed -- ours -- so
+# the push always converges with no manual step. ("theirs" in a rebase means the
+# commit being replayed, i.e. ours.) Picking ours is last-writer-wins on the
+# file's contents; the consequence differs by caller:
+#   - The score SVGs (scores-ci) are fully derived from source, so a dropped
+#     parallel regeneration is re-created by a later source-driven build: it
+#     self-heals. (The score build is mtime-incremental and the bot's SVG commit
+#     does not re-trigger scores-ci, so the catch-up is the next build that
+#     rebuilds the affected score, not necessarily the immediate next run.)
+#   - The monitor series (.github/monitor-series.json) is accumulated, NOT
+#     regenerated -- each run upserts only today's entry. Last-writer-wins can
+#     therefore overwrite a richer entry with a poorer one (a merge-time refresh
+#     writing mergedPRs:0 over the daily run's real count), and it does NOT
+#     self-heal within the day; recovery needs a manual backfill. Tracked as #728
+#     (a value-preserving merge for the series).
+#
+# Why FETCH_HEAD, not origin/main: actions/checkout fetches with a narrow refspec
+# that need not update the origin/main remote-tracking ref, so rebasing onto
+# origin/main can replay onto a stale tip and never converge in CI though it
+# passes locally. FETCH_HEAD is whatever `git fetch origin main` just fetched, so
+# it is always the live tip.
+#
+# Why --autostash: a non-frozen `pnpm install` earlier in the job can leave the
+# tree dirty (e.g. a lockfile touch), which would abort the rebase; --autostash
+# stashes and restores it around the replay.
+#
+# Scope of the retry: only `git push` is retried. A fetch or rebase failure (a
+# real delete/modify conflict, a network error) is a hard error -- set -e exits
+# with git's own code, surfacing loudly rather than looping. Correct on an
+# ephemeral runner.
+#
+# Bounded: after PUSH_RETRIES attempts we fail loudly. A persistent rejection is
+# a real problem (protected branch, permissions), not the spurious flake this
+# fixes, and must surface as a red run rather than loop forever.
+set -euo pipefail
+
+retries="${PUSH_RETRIES:-5}"
+# Normalise then floor. A non-integer PUSH_RETRIES would slip past the numeric
+# floor (the `[` test errors on it, and set -e ignores that as the left of an &&
+# list), leaving a bad value: a non-numeric string makes `seq` yield nothing so
+# the loop never runs and the script exits 1 without pushing, and a float like 3.5
+# would run the wrong number of times. The regex rejects both. The floor likewise
+# stops PUSH_RETRIES=0 skipping the loop. Both guards ensure at least one attempt
+# runs; the failure they remove is a guaranteed red run that never attempts a push.
+[[ "$retries" =~ ^[0-9]+$ ]] || retries=5
+[ "$retries" -lt 1 ] && retries=1
+
+for attempt in $(seq 1 "$retries"); do
+  if git push; then
+    exit 0
+  fi
+  # No rebase after the final failed attempt: we are about to fail loudly.
+  if [ "$attempt" -lt "$retries" ]; then
+    echo "push rejected (attempt ${attempt}/${retries}); rebasing our commit onto fetched main and retrying"
+    git fetch origin main
+    git rebase --autostash -X theirs FETCH_HEAD
+  fi
+done
+
+echo "push to main still rejected after ${retries} attempts; failing loudly" >&2
+exit 1

--- a/.github/scripts/push-with-rebase.test.sh
+++ b/.github/scripts/push-with-rebase.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Regression test for push-with-rebase.sh (#727).
+#
+# Pure bash + git sandbox, no network. Reproduces the concurrent-push race the
+# helper absorbs and asserts: (1) same-file conflict converges with ours winning,
+# (2) a concurrent change to another file is preserved, (3) a persistently
+# rejected push fails loudly after exactly the retry bound, (4) it rebases onto
+# FETCH_HEAD so it converges even when the origin/main ref is stale (the core
+# fix), (5) --autostash lets it converge with a dirty working tree, (6) a floored
+# PUSH_RETRIES=0 still attempts one push, and (7) a non-integer PUSH_RETRIES
+# normalises rather than falling through to a no-push.
+#
+# Run by .github/workflows/push-helper-test.yml on any change under
+# .github/scripts/, and locally with:
+#
+#     bash .github/scripts/push-with-rebase.test.sh
+set -euo pipefail
+
+HELPER="$(cd "$(dirname "$0")" && pwd)/push-with-rebase.sh"
+[ -f "$HELPER" ] || { echo "helper not found: $HELPER" >&2; exit 1; }
+
+# Provide a committer identity so the helper's plain `git rebase` is hermetic: the
+# sandbox `ci` clone configures none and the helper sets none, so without this the
+# test would rely on the runner auto-deriving user@host.
+export GIT_AUTHOR_NAME=ci GIT_AUTHOR_EMAIL=ci@test
+export GIT_COMMITTER_NAME=ci GIT_COMMITTER_EMAIL=ci@test
+
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+
+pass=0
+fail=0
+ok()  { echo "ok   - $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL - $1" >&2; fail=$((fail + 1)); }
+
+# Run git with a fixed identity so the sandbox never reads the caller's config.
+git_q() { git -c user.email=ci@test -c user.name=ci -c init.defaultBranch=main "$@"; }
+
+# Seed a bare origin (main = regenerated.txt:v0 + sibling.txt:s0) and a "ci"
+# checkout cloned from it. Echoes the sandbox dir; all git noise is suppressed so
+# only the path reaches stdout.
+setup() {
+  local d="$ROOT/$1"
+  rm -rf "$d"; mkdir -p "$d"
+  git_q init -q --bare "$d/origin.git" >/dev/null 2>&1
+  git_q clone -q "$d/origin.git" "$d/seed" >/dev/null 2>&1
+  (
+    cd "$d/seed"
+    echo v0 > regenerated.txt
+    echo s0 > sibling.txt
+    git_q add -A
+    git_q commit -qm seed
+    git_q push -q origin HEAD:main
+  ) >/dev/null 2>&1
+  git_q clone -q "$d/origin.git" "$d/ci" >/dev/null 2>&1
+  echo "$d"
+}
+
+# Land a concurrent commit on origin/main from a throwaway clone. $1 dir $2 file $3 content.
+concurrent_push() {
+  local d="$1" file="$2" content="$3"
+  rm -rf "$d/other"
+  git_q clone -q "$d/origin.git" "$d/other" >/dev/null 2>&1
+  (
+    cd "$d/other"
+    echo "$content" > "$file"
+    git_q add -A
+    git_q commit -qm "concurrent $file"
+    git_q push -q origin HEAD:main
+  ) >/dev/null 2>&1
+}
+
+origin_show() { git_q -C "$1/origin.git" show "main:$2"; }
+
+# Case 1: same-file conflict -- ours (the just-regenerated file) wins.
+d="$(setup case1)"
+( cd "$d/ci"; echo vCI > regenerated.txt; git_q add -A; git_q commit -qm "ci regen" ) >/dev/null 2>&1
+concurrent_push "$d" regenerated.txt vOTHER
+if ( cd "$d/ci"; bash "$HELPER" ) >/dev/null 2>&1; then
+  r="$(origin_show "$d" regenerated.txt)"; s="$(origin_show "$d" sibling.txt)"
+  if [ "$r" = vCI ] && [ "$s" = s0 ]; then
+    ok "case1: same-file conflict converges, ours wins"
+  else
+    bad "case1: regenerated=$r sibling=$s (want vCI/s0)"
+  fi
+else
+  bad "case1: helper exited non-zero on a recoverable race"
+fi
+
+# Case 2: concurrent change to a different file is preserved.
+d="$(setup case2)"
+( cd "$d/ci"; echo vCI > regenerated.txt; git_q add -A; git_q commit -qm "ci regen" ) >/dev/null 2>&1
+concurrent_push "$d" sibling.txt sOTHER
+if ( cd "$d/ci"; bash "$HELPER" ) >/dev/null 2>&1; then
+  r="$(origin_show "$d" regenerated.txt)"; s="$(origin_show "$d" sibling.txt)"
+  if [ "$r" = vCI ] && [ "$s" = sOTHER ]; then
+    ok "case2: concurrent sibling change preserved"
+  else
+    bad "case2: regenerated=$r sibling=$s (want vCI/sOTHER)"
+  fi
+else
+  bad "case2: helper exited non-zero on a recoverable race"
+fi
+
+# Case 3: a persistently rejected push fails loudly after the bound.
+d="$(setup case3)"
+cat > "$d/origin.git/hooks/pre-receive" <<'HOOK'
+#!/bin/sh
+echo "rejecting (test)" >&2
+exit 1
+HOOK
+chmod +x "$d/origin.git/hooks/pre-receive"
+( cd "$d/ci"; echo vCI > regenerated.txt; git_q add -A; git_q commit -qm "ci regen" ) >/dev/null 2>&1
+set +e
+out="$( cd "$d/ci"; PUSH_RETRIES=2 bash "$HELPER" 2>&1 )"
+rc=$?
+set -e
+if [ "$rc" -ne 0 ] \
+  && printf '%s' "$out" | grep -q "failing loudly" \
+  && printf '%s' "$out" | grep -q "attempt 1/2" \
+  && ! printf '%s' "$out" | grep -q "attempt 2/2"; then
+  ok "case3: bounded loud-fail after exactly the retry bound (exit $rc)"
+else
+  bad "case3: rc=$rc, expected loud-fail with 'attempt 1/2' and no 'attempt 2/2'"
+fi
+
+# Case 4: the rebase targets FETCH_HEAD, not the (possibly stale) origin/main ref.
+# Mimic actions/checkout's narrow refspec by unsetting the ci clone's fetch
+# refspec, so `git fetch origin main` advances only FETCH_HEAD and leaves
+# origin/main stale. The helper must still converge; a rebase onto origin/main
+# would replay onto the stale tip, never converge, and loud-fail at the bound.
+d="$(setup case4)"
+git_q -C "$d/ci" config --unset-all remote.origin.fetch 2>/dev/null || true
+( cd "$d/ci"; echo vCI > regenerated.txt; git_q add -A; git_q commit -qm "ci regen" ) >/dev/null 2>&1
+concurrent_push "$d" regenerated.txt vOTHER
+if ( cd "$d/ci"; bash "$HELPER" ) >/dev/null 2>&1; then
+  r="$(origin_show "$d" regenerated.txt)"
+  if [ "$r" = vCI ]; then
+    ok "case4: converges onto FETCH_HEAD when the origin/main ref is stale"
+  else
+    bad "case4: regenerated=$r (want vCI)"
+  fi
+else
+  bad "case4: helper did not converge with a stale origin/main ref (FETCH_HEAD lost?)"
+fi
+
+# Case 5: --autostash survives a dirty working tree (e.g. a non-frozen install's
+# lockfile touch). Leave a tracked file modified before invoking the helper;
+# assert convergence and that the dirty change is restored locally. Without
+# --autostash the rebase aborts and the helper exits non-zero.
+d="$(setup case5)"
+( cd "$d/ci"; echo vCI > regenerated.txt; git_q add -A; git_q commit -qm "ci regen" ) >/dev/null 2>&1
+concurrent_push "$d" regenerated.txt vOTHER
+echo dirty >> "$d/ci/sibling.txt"
+if ( cd "$d/ci"; bash "$HELPER" ) >/dev/null 2>&1; then
+  r="$(origin_show "$d" regenerated.txt)"
+  if [ "$r" = vCI ] && grep -q dirty "$d/ci/sibling.txt"; then
+    ok "case5: --autostash converges with a dirty tree and restores the change"
+  else
+    bad "case5: regenerated=$r; dirty restored=$(grep -c dirty "$d/ci/sibling.txt")"
+  fi
+else
+  bad "case5: helper aborted on a dirty tree (--autostash missing?)"
+fi
+
+# Case 6: PUSH_RETRIES=0 floors to one attempt -- it still pushes, never a no-push.
+d="$(setup case6)"
+( cd "$d/ci"; echo vCI > regenerated.txt; git_q add -A; git_q commit -qm "ci regen" ) >/dev/null 2>&1
+if ( cd "$d/ci"; PUSH_RETRIES=0 bash "$HELPER" ) >/dev/null 2>&1; then
+  r="$(origin_show "$d" regenerated.txt)"
+  [ "$r" = vCI ] && ok "case6: PUSH_RETRIES=0 floors to one attempt and pushes" \
+    || bad "case6: regenerated=$r (want vCI)"
+else
+  bad "case6: PUSH_RETRIES=0 did not push (floor missing?)"
+fi
+
+# Case 7: a non-integer PUSH_RETRIES normalises to the default and still pushes,
+# rather than falling through to a no-push.
+d="$(setup case7)"
+( cd "$d/ci"; echo vCI > regenerated.txt; git_q add -A; git_q commit -qm "ci regen" ) >/dev/null 2>&1
+if ( cd "$d/ci"; PUSH_RETRIES=notanumber bash "$HELPER" ) >/dev/null 2>&1; then
+  r="$(origin_show "$d" regenerated.txt)"
+  [ "$r" = vCI ] && ok "case7: non-integer PUSH_RETRIES normalises and pushes" \
+    || bad "case7: regenerated=$r (want vCI)"
+else
+  bad "case7: non-integer PUSH_RETRIES did not push (validation missing?)"
+fi
+
+echo "---"
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/.github/workflows/monitor-refresh.yml
+++ b/.github/workflows/monitor-refresh.yml
@@ -71,4 +71,4 @@ jobs:
             exit 0
           fi
           git commit --no-verify -m "chore: refresh build-usage series [skip ci]"
-          git push
+          bash .github/scripts/push-with-rebase.sh

--- a/.github/workflows/monitor-run.yml
+++ b/.github/workflows/monitor-run.yml
@@ -47,4 +47,4 @@ jobs:
             exit 0
           fi
           git commit --no-verify -m "chore: update daily resource series [skip ci]"
-          git push
+          bash .github/scripts/push-with-rebase.sh

--- a/.github/workflows/push-helper-test.yml
+++ b/.github/workflows/push-helper-test.yml
@@ -1,0 +1,23 @@
+name: Push-helper test
+
+# Runs the push-with-rebase regression test on any change to the helper or its
+# test. Without this, changes under .github/scripts/ only hit test-noop, so
+# nothing exercised the script (#727).
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/push-helper-test.yml"
+  pull_request:
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/push-helper-test.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run push-with-rebase regression test
+        run: bash .github/scripts/push-with-rebase.test.sh

--- a/.github/workflows/scores-ci.yml
+++ b/.github/workflows/scores-ci.yml
@@ -60,4 +60,4 @@ jobs:
             exit 0
           fi
           git commit -m "chore: regenerate SVGs"
-          git push
+          bash .github/scripts/push-with-rebase.sh

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -117,6 +117,17 @@ is the test gate for monitor changes. See [`doc/MONITOR.md`](./MONITOR.md) for t
 including status thresholds, workflow permissions, required secrets, and how to
 run the monitor locally.
 
+### Pushing regenerated files to `main`
+
+Three workflows commit a regenerated file to `main`: `monitor-run.yml`,
+`monitor-refresh.yml`, and `scores-ci.yml`. Each pushes via the shared helper
+`.github/scripts/push-with-rebase.sh`, which retries with a rebase if a concurrent
+push moved `main` first, so an overlapping run converges instead of failing
+non-fast-forward ([#727](https://github.com/wainwmr/spem-player/issues/727)).
+`push-helper-test.yml` runs the helper's regression test
+(`.github/scripts/push-with-rebase.test.sh`) on any change under
+`.github/scripts/`.
+
 ## Node.js Version
 
 The Node.js version is pinned in `.nvmrc`. All GitHub Actions workflows read this file via `node-version-file` in `actions/setup-node`. Netlify should be configured to use the same version.


### PR DESCRIPTION
Adds a shared push helper so the three workflows that commit regenerated files to `main` (monitor-run, monitor-refresh, scores-ci) retry with a rebase when a concurrent push moves `main` first, instead of failing non-fast-forward.

- `.github/scripts/push-with-rebase.sh`: the shared helper. It tries the push, and on a non-fast-forward it fetches and rebases onto the new tip (resolving same-file conflicts in favour of the freshly regenerated content) and retries, bounded, failing loud if it cannot converge.
- The three push sites call the helper in place of a bare `git push`.
- `.github/scripts/push-with-rebase.test.sh`: a bash regression test covering the convergence cases and the loud-fail exhaustion case.
- `.github/workflows/push-helper-test.yml`: runs the test on any change under `.github/scripts/`.
- `doc/CI.md`: documents the mechanism.

This closes the race that produced spurious non-fast-forward failures on the monitor and scores pushes, one source being our own PR merges moving `main` under an in-flight bot push.

Data semantics: for a same-file conflict the helper keeps the later, freshly regenerated content. The score SVGs self-heal (regenerated each run); `monitor-series.json` is accumulated, so a merge-time refresh racing the daily run can briefly overwrite that day's mergedPRs (low odds, recoverable). The value-preserving merge for the series is tracked separately as #728.

Fixes #727
