### PR TITLE
refactor: strengthen LilypondData typing, collapse MusicCanvas fields

### DIFF
--- a/packages/pwa/src/test/canvas.test.ts
+++ b/packages/pwa/src/test/canvas.test.ts
@@ -2,7 +2,21 @@ import { MusicCanvas } from "../ts/MusicCanvas";
 import config from "../ts/config";
 import { colors, type Position } from "../ts/common";
 import { Duration, Note } from "../ts/music-classes";
+import { barCount as lilyBarCount, type Range } from "../ts/lily";
 MusicCanvas.define("music-canvas");
+
+// Install fixture singing-ranges on a canvas by swapping its whole `lilyData`
+// (since #652 `ranges` is a deeply-readonly SingingRanges, so build a fresh
+// mutable map and replace the object rather than mutating it in place).
+function setRanges(
+  c: MusicCanvas,
+  build: (r: Map<string, Range[]>) => void
+): void {
+  const r = new Map<string, Range[]>();
+  for (const [k, v] of c.lilyData!.ranges) r.set(k, [...v]);
+  build(r);
+  c.lilyData = { ...c.lilyData!, ranges: r };
+}
 
 var canvas: MusicCanvas | null;
 describe("MusicCanvas custom element", () => {
@@ -18,19 +32,17 @@ describe("MusicCanvas custom element", () => {
     vi.clearAllMocks();
   });
 
-  // seek() tests overwrite choir ranges on the shared beforeAll canvas; snapshot
-  // and restore the map per test so a fixture never leaks into a later test (#598).
-  // #704 also mutates notesByQuant, so snapshot that too.
-  let savedRanges: NonNullable<typeof canvas>["ranges"];
-  let savedNotesByQuant: NonNullable<typeof canvas>["notesByQuant"];
+  // seek() tests install fixture ranges by swapping the whole `lilyData` object
+  // (its `ranges` is deeply readonly since #652, so the original is never mutated
+  // in place). A shallow snapshot of the reference therefore restores it cleanly
+  // per test, so a fixture never leaks into a later test (#598, #652). The #704
+  // pulse tests also swap lilyData (for notesByQuant), so this snapshot covers them.
+  let savedLilyData: NonNullable<typeof canvas>["lilyData"];
   beforeEach(() => {
-    savedRanges = new Map();
-    for (const [key, value] of canvas!.ranges) savedRanges.set(key, [...value]);
-    savedNotesByQuant = canvas!.notesByQuant;
+    savedLilyData = canvas!.lilyData;
   });
   afterEach(() => {
-    canvas!.ranges = savedRanges;
-    canvas!.notesByQuant = savedNotesByQuant;
+    canvas!.lilyData = savedLilyData;
   });
 
   it("Check that the canvasent contains a canvas", async () => {
@@ -44,13 +56,69 @@ describe("MusicCanvas custom element", () => {
     canvas!.draw();
   });
 
-  it("draw() early returns when dict/ranges are empty", async () => {
-    // Note: this exercises the !this.canvas guard (element not in DOM), not the
-    // ranges.length === 0 guard. See refactor item 15 in wiki/refactor-lily.ts.md.
+  it("collapses parsed data into a single populated lilyData field (#652)", () => {
+    expect(canvas).not.toBeNull();
+    expect(canvas!.lilyData).not.toBeNull();
+    // barCount mirrors the module-level export kept for MusicControls.
+    expect(canvas!.lilyData!.barCount).toBe(lilyBarCount);
+    expect(canvas!.lilyData!.barCount).toBeGreaterThan(0);
+  });
+
+  it("draw() early returns when the element is not in the DOM", async () => {
+    // A created-but-unconnected element never ran #init, so both `canvas` and
+    // `lilyData` are null. draw()'s first guard (`!this.canvas`) returns here;
+    // the `lilyData == null` guard has its own test below (#652).
     const freshCanvas = document.createElement("music-canvas") as MusicCanvas;
-    freshCanvas.notesByQuant = new Map();
-    freshCanvas.ranges = new Map();
     freshCanvas.draw();
+  });
+
+  it("draw() early returns when lilyData is null (#652)", () => {
+    expect(canvas).not.toBeNull();
+    // A connected canvas with its data cleared: the `!this.canvas` guard passes,
+    // so this exercises the new `lilyData == null` guard specifically. afterEach
+    // restores lilyData from the per-test snapshot.
+    canvas!.lilyData = null;
+    expect(() => canvas!.draw()).not.toThrow();
+  });
+
+  it("freezes each singing-range and note array against runtime mutation (#652)", () => {
+    expect(canvas).not.toBeNull();
+    for (const arr of canvas!.lilyData!.ranges.values()) {
+      expect(Object.isFrozen(arr)).toBe(true);
+    }
+    for (const arr of canvas!.lilyData!.notesByQuant.values()) {
+      expect(Object.isFrozen(arr)).toBe(true);
+    }
+    // The freeze must have teeth: a push on a frozen array throws in strict mode
+    // (ES modules are strict), not merely fail silently. Cast past readonly to
+    // attempt the mutation a non-TS consumer could make.
+    const anyRange = [...canvas!.lilyData!.ranges.values()][0] as Range[];
+    expect(() => anyRange.push({ from: 0, to: 1 })).toThrow();
+  });
+
+  it("draw() early returns when notesByQuant is empty (#652)", () => {
+    expect(canvas).not.toBeNull();
+    // A non-null lilyData whose parse yielded no notes must still short-circuit
+    // draw(), preserving the pre-#652 behaviour (the old guard checked
+    // notesByQuant.size). An early return paints nothing, so fillRect is unused.
+    canvas!.lilyData = { ...canvas!.lilyData!, notesByQuant: new Map() };
+    const ctx = canvas!.canvas!.getContext("2d")!;
+    const fillRectSpy = vi.spyOn(ctx, "fillRect");
+    try {
+      canvas!.draw();
+      expect(fillRectSpy).not.toHaveBeenCalled();
+    } finally {
+      fillRectSpy.mockRestore();
+    }
+  });
+
+  it("seek() returns the current bar when lilyData is null (#652)", () => {
+    expect(canvas).not.toBeNull();
+    // seek is public on the custom element; a call before #init must not throw.
+    // afterEach restores lilyData from the per-test snapshot.
+    canvas!.lilyData = null;
+    const pos = { choir: 0, part: "all" as const, bar: 7 };
+    expect(canvas!.seek(pos, +1)).toBe(7);
   });
 
   it("draw() renders every frame at 120Hz during playback (#554)", () => {
@@ -60,8 +128,8 @@ describe("MusicCanvas custom element", () => {
     // notesByQuant is the guard that actually trips on a data-less parse;
     // ranges is seeded per choir-part pair unconditionally (lily.ts), so its
     // size only detects #init never completing.
-    expect(canvas!.ranges.size).toBeGreaterThan(0);
-    expect(canvas!.notesByQuant.size).toBeGreaterThan(0);
+    expect(canvas!.lilyData!.ranges.size).toBeGreaterThan(0);
+    expect(canvas!.lilyData!.notesByQuant.size).toBeGreaterThan(0);
 
     // Simulate a 120Hz display: rAF fires every ~8.3ms. The old #shouldDraw
     // throttle read Date.now() (not the rAF timestamp), so the clock must be
@@ -219,14 +287,16 @@ describe("MusicCanvas custom element", () => {
 
   it("initialises shimmer phases for each FR location", () => {
     expect(canvas).not.toBeNull();
-    expect(canvas!.shimmerPhases.length).toBe(canvas!.frLocations.length);
+    expect(canvas!.shimmerPhases.length).toBe(
+      canvas!.lilyData!.frLocations.length
+    );
     expect(canvas!.shimmerPhases[0]).toBeGreaterThanOrEqual(0);
     expect(canvas!.shimmerPhases[0]).toBeLessThan(Math.PI * 2);
   });
 
   it("draw() renders false-relation shimmer circles when frLocations are populated", async () => {
     expect(canvas).not.toBeNull();
-    expect(canvas!.frLocations.length).toBeGreaterThan(0);
+    expect(canvas!.lilyData!.frLocations.length).toBeGreaterThan(0);
     canvas!.draw();
   });
 
@@ -259,9 +329,9 @@ describe("MusicCanvas custom element", () => {
       // Preconditions: #init completed, the loop will actually run, and draw()
       // will not early-return on empty data (a dead fixture would report 0
       // clears and masquerade as a throttle).
-      expect(fresh.frLocations.length).toBeGreaterThan(0);
-      expect(fresh.ranges.size).toBeGreaterThan(0);
-      expect(fresh.notesByQuant.size).toBeGreaterThan(0);
+      expect(fresh.lilyData!.frLocations.length).toBeGreaterThan(0);
+      expect(fresh.lilyData!.ranges.size).toBeGreaterThan(0);
+      expect(fresh.lilyData!.notesByQuant.size).toBeGreaterThan(0);
       expect(fresh.shimmerLoopId).not.toBe(0);
 
       // Spy after #init so its one-shot draw is not counted.
@@ -315,7 +385,7 @@ describe("MusicCanvas custom element", () => {
     const fresh = document.createElement("music-canvas") as MusicCanvas;
     document.body.appendChild(fresh);
     await new Promise((r) => setTimeout(r, 500)); // real #init populates FR data
-    const populatedFr = fresh.frLocations;
+    const populatedFr = fresh.lilyData!.frLocations;
     expect(populatedFr.length).toBeGreaterThan(0);
 
     const rafSpy = vi
@@ -326,7 +396,7 @@ describe("MusicCanvas custom element", () => {
       // exact flush regime and schedules one rAF.
       fresh.remove();
       expect(fresh.shimmerLoopId).toBe(0);
-      fresh.frLocations = populatedFr;
+      fresh.lilyData = { ...fresh.lilyData!, frLocations: populatedFr };
       document.body.appendChild(fresh);
       await Promise.resolve();
       await Promise.resolve();
@@ -337,7 +407,7 @@ describe("MusicCanvas custom element", () => {
       // Negative: reconnect with NO hotspots -> no further rAF is scheduled.
       fresh.remove();
       expect(fresh.shimmerLoopId).toBe(0);
-      fresh.frLocations = [];
+      fresh.lilyData = { ...fresh.lilyData!, frLocations: [] };
       document.body.appendChild(fresh);
       await Promise.resolve();
       await Promise.resolve();
@@ -357,8 +427,12 @@ describe("MusicCanvas custom element", () => {
 
   it("seek() clamps to upper bound when seeking forward from last bar", () => {
     expect(canvas).not.toBeNull();
-    const pos = { choir: 0, part: "all" as const, bar: canvas!.barCount };
-    expect(canvas!.seek(pos, +1)).toBe(canvas!.barCount);
+    const pos = {
+      choir: 0,
+      part: "all" as const,
+      bar: canvas!.lilyData!.barCount,
+    };
+    expect(canvas!.seek(pos, +1)).toBe(canvas!.lilyData!.barCount);
   });
 
   it("seek() finds next section change forward from bar 1", () => {
@@ -366,7 +440,7 @@ describe("MusicCanvas custom element", () => {
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     const result = canvas!.seek(pos, +1);
     expect(result).toBeGreaterThanOrEqual(0);
-    expect(result).toBeLessThanOrEqual(canvas!.barCount);
+    expect(result).toBeLessThanOrEqual(canvas!.lilyData!.barCount);
   });
 
   it("seek() does not throw when a choir-part range key is absent (#244, now via ranges)", () => {
@@ -374,8 +448,9 @@ describe("MusicCanvas custom element", () => {
     // seek no longer reads notesByQuant (#598); the #244 "no data -> no throw"
     // intent now applies to the `ranges` lookup, which tolerates an absent
     // "choir-part" key (?? []).
-    for (let p = 0; p < config.parts.length; p++)
-      canvas!.ranges.delete(`0-${p}`);
+    setRanges(canvas!, (r) => {
+      for (let p = 0; p < config.parts.length; p++) r.delete(`0-${p}`);
+    });
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     expect(() => canvas!.seek(pos, +1)).not.toThrow();
   });
@@ -384,8 +459,9 @@ describe("MusicCanvas custom element", () => {
     expect(canvas).not.toBeNull();
     // With choir 0 silent (no ranges), backward seek finds no flip edge and
     // clamps to bar 0 — the #244 clamp intent, now asserted against `ranges`.
-    for (let p = 0; p < config.parts.length; p++)
-      canvas!.ranges.set(`0-${p}`, []);
+    setRanges(canvas!, (r) => {
+      for (let p = 0; p < config.parts.length; p++) r.set(`0-${p}`, []);
+    });
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     expect(canvas!.seek(pos, -1)).toBe(0);
   });
@@ -394,9 +470,10 @@ describe("MusicCanvas custom element", () => {
     expect(canvas).not.toBeNull();
     // Choir 0 is silent until 1.5, then sings [1.5, 3.0]; isolate it by clearing
     // every part of choir 0 first, then declaring the one fractional range.
-    for (let p = 0; p < config.parts.length; p++)
-      canvas!.ranges.set(`0-${p}`, []);
-    canvas!.ranges.set("0-0", [{ from: 1.5, to: 3.0 }]);
+    setRanges(canvas!, (r) => {
+      for (let p = 0; p < config.parts.length; p++) r.set(`0-${p}`, []);
+      r.set("0-0", [{ from: 1.5, to: 3.0 }]);
+    });
     const pos = { choir: 0, part: "all" as const, bar: 1 };
     // The old integer scan can only ever return an integer bar; the fractional
     // boundary 1.5 is reachable only by reading `ranges`.
@@ -405,9 +482,10 @@ describe("MusicCanvas custom element", () => {
 
   it("seek() stops at a fractional section boundary, backward (#598)", () => {
     expect(canvas).not.toBeNull();
-    for (let p = 0; p < config.parts.length; p++)
-      canvas!.ranges.set(`0-${p}`, []);
-    canvas!.ranges.set("0-0", [{ from: 1.5, to: 3.0 }]);
+    setRanges(canvas!, (r) => {
+      for (let p = 0; p < config.parts.length; p++) r.set(`0-${p}`, []);
+      r.set("0-0", [{ from: 1.5, to: 3.0 }]);
+    });
     const pos = { choir: 0, part: "all" as const, bar: 2.5 };
     expect(canvas!.seek(pos, -1)).toBe(1.5);
   });
@@ -420,10 +498,11 @@ describe("MusicCanvas custom element", () => {
     // must land on 4.5: if the collective-flip filter regressed, the unsuppressed
     // 3.0 would be returned instead. (A start above 3.0 would not bite — 3.0 is
     // already behind it.)
-    for (let p = 0; p < config.parts.length; p++)
-      canvas!.ranges.set(`0-${p}`, []);
-    canvas!.ranges.set("0-0", [{ from: 1.5, to: 3.0 }]);
-    canvas!.ranges.set("0-1", [{ from: 3.0, to: 4.5 }]);
+    setRanges(canvas!, (r) => {
+      for (let p = 0; p < config.parts.length; p++) r.set(`0-${p}`, []);
+      r.set("0-0", [{ from: 1.5, to: 3.0 }]);
+      r.set("0-1", [{ from: 3.0, to: 4.5 }]);
+    });
     expect(canvas!.seek({ choir: 0, part: "all" as const, bar: 2.0 }, +1)).toBe(
       4.5
     );
@@ -437,9 +516,10 @@ describe("MusicCanvas custom element", () => {
     expect(canvas).not.toBeNull();
     // The only singing part of choir 0 is part 3; its boundary must still be
     // found via the "any part" union, not just part 0.
-    for (let p = 0; p < config.parts.length; p++)
-      canvas!.ranges.set(`0-${p}`, []);
-    canvas!.ranges.set("0-3", [{ from: 2.5, to: 4.0 }]);
+    setRanges(canvas!, (r) => {
+      for (let p = 0; p < config.parts.length; p++) r.set(`0-${p}`, []);
+      r.set("0-3", [{ from: 2.5, to: 4.0 }]);
+    });
     expect(canvas!.seek({ choir: 0, part: "all" as const, bar: 1 }, +1)).toBe(
       2.5
     );
@@ -934,7 +1014,7 @@ describe("MusicCanvas custom element", () => {
     canvas!.querySelector("canvas")!.dispatchEvent(mouseEvent);
     const event = await promise;
     const pos = event.detail.position;
-    expect(pos.bar).toBe(canvas!.barCount);
+    expect(pos.bar).toBe(canvas!.lilyData!.barCount);
   });
 
   it("getMousePos returns mid bar at centre on narrow viewports (#204)", async () => {
@@ -978,7 +1058,7 @@ describe("MusicCanvas custom element", () => {
       canvas!.querySelector("canvas")!.dispatchEvent(mouseEvent);
       const event = await promise;
       const pos = event.detail.position;
-      expect(pos.bar).toBe(Math.floor(canvas!.barCount / 2));
+      expect(pos.bar).toBe(Math.floor(canvas!.lilyData!.barCount / 2));
     }
   });
 
@@ -1073,7 +1153,7 @@ describe("MusicCanvas custom element", () => {
     innerCanvas.dispatchEvent(touchStart);
     const event = await promise;
     const pos = event.detail.position;
-    expect(pos.bar).toBe(canvas!.barCount);
+    expect(pos.bar).toBe(canvas!.lilyData!.barCount);
   });
 
   it("getTouchPos returns mid bar at centre on narrow viewports (#204)", async () => {
@@ -1121,7 +1201,7 @@ describe("MusicCanvas custom element", () => {
       innerCanvas.dispatchEvent(touchStart);
       const event = await promise;
       const pos = event.detail.position;
-      expect(pos.bar).toBe(Math.floor(canvas!.barCount / 2));
+      expect(pos.bar).toBe(Math.floor(canvas!.lilyData!.barCount / 2));
     }
   });
 
@@ -1515,7 +1595,10 @@ describe("MusicCanvas custom element", () => {
 
     const onset = 0.03125; // 1/32 bar, between 1/16 quant points
     const note = new Note("a", null, null, new Duration("16"), null);
-    canvas!.notesByQuant = new Map([[onset, [{ c: 0, p: 0, n: note }]]]);
+    canvas!.lilyData = {
+      ...canvas!.lilyData!,
+      notesByQuant: new Map([[onset, [{ c: 0, p: 0, n: note }]]]),
+    };
     canvas!.bar = onset;
     canvas!.draw();
 
@@ -1529,10 +1612,13 @@ describe("MusicCanvas custom element", () => {
 
     const note16 = new Note("b", null, null, new Duration("16"), null);
     const noteWhole = new Note("c", null, null, new Duration("1"), null);
-    canvas!.notesByQuant = new Map([
-      [0.0625, [{ c: 0, p: 1, n: note16 }]],
-      [2.0, [{ c: 1, p: 2, n: noteWhole }]],
-    ]);
+    canvas!.lilyData = {
+      ...canvas!.lilyData!,
+      notesByQuant: new Map([
+        [0.0625, [{ c: 0, p: 1, n: note16 }]],
+        [2.0, [{ c: 1, p: 2, n: noteWhole }]],
+      ]),
+    };
 
     canvas!.bar = 0.0625;
     canvas!.draw();
@@ -1639,18 +1725,18 @@ describe("MusicCanvas custom element", () => {
     // three points sit at the clamp extremes and a stable interior row, so
     // they are unaffected by the Y-padding scaling — they characterise the
     // de-dup; the short-viewport tests below characterise the Y fix.
-    const mid = Math.floor(canvas!.barCount / 2);
+    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
     expect(await clickAt(0, 2)).toEqual({ choir: 0, part: 0, bar: 0 });
     expect(await clickAt(700, 175)).toEqual({ choir: 3, part: 2, bar: mid });
     expect(await clickAt(1400, 398)).toEqual({
       choir: 7,
       part: 0,
-      bar: canvas!.barCount,
+      bar: canvas!.lilyData!.barCount,
     });
   });
 
   it("projects representative touch coordinates, resolving part to 'all' (#650)", async () => {
-    const mid = Math.floor(canvas!.barCount / 2);
+    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
     expect(await touchAt(0, 2)).toEqual({ choir: 0, part: "all", bar: 0 });
     expect(await touchAt(700, 175)).toEqual({
       choir: 3,
@@ -1660,7 +1746,7 @@ describe("MusicCanvas custom element", () => {
     expect(await touchAt(1400, 398)).toEqual({
       choir: 7,
       part: "all",
-      bar: canvas!.barCount,
+      bar: canvas!.lilyData!.barCount,
     });
   });
 
@@ -1672,7 +1758,7 @@ describe("MusicCanvas custom element", () => {
     // wrong-result toward the top of a short viewport (the two mappings
     // coincide at the exact centre and diverge toward the edges). Scaling Y
     // restores the drawn mapping. (x = width/2 -> floor(barCount/2), unaffected.)
-    const mid = Math.floor(canvas!.barCount / 2);
+    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
     expect(await clickAt(700, 50, 1400, 150)).toEqual({
       choir: 2,
       part: 3,
@@ -1684,7 +1770,7 @@ describe("MusicCanvas custom element", () => {
     // Touch hard-codes part "all" (#327), so the Y fix shows up on the CHOIR
     // here, not the part: on a 150px-tall canvas a tap at y=38 falls on the
     // drawn choir 2, but the old unscaled-Y mapping returned choir 1.
-    const mid = Math.floor(canvas!.barCount / 2);
+    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
     expect(await touchAt(700, 38, 1400, 150)).toEqual({
       choir: 2,
       part: "all",
@@ -1713,7 +1799,7 @@ describe("MusicCanvas custom element", () => {
 
   it("draws both false-relation glows as a 3-stop radial gradient centred on the part row (#650)", () => {
     expect(canvas).not.toBeNull();
-    const frs = canvas!.frLocations;
+    const frs = canvas!.lilyData!.frLocations;
     expect(frs.length).toBeGreaterThan(0);
 
     const ctx = canvas!.canvas!.getContext("2d")!;
@@ -1815,8 +1901,10 @@ describe("MusicCanvas custom element", () => {
     expect(canvas).not.toBeNull();
     // Seed known ranges at two corners so a moveTo is issued at each row's
     // centre (the per-test ranges snapshot is restored by afterEach).
-    canvas!.ranges.set("0-0", [{ from: 10, to: 20 }]);
-    canvas!.ranges.set("7-4", [{ from: 30, to: 40 }]);
+    setRanges(canvas!, (r) => {
+      r.set("0-0", [{ from: 10, to: 20 }]);
+      r.set("7-4", [{ from: 30, to: 40 }]);
+    });
 
     const ctx = canvas!.canvas!.getContext("2d")!;
     const moveYs: number[] = [];

--- a/packages/pwa/src/ts/MusicCanvas.ts
+++ b/packages/pwa/src/ts/MusicCanvas.ts
@@ -5,7 +5,7 @@ import config from "./config";
 import { PartType, Position, colors } from "./common";
 import { MusicElement } from "./MusicElement";
 
-import { NoteEntry, Range, FRlocation, processLilypond } from "./lily";
+import { LilypondData, processLilypond } from "./lily";
 
 export class MusicCanvas extends MusicElement {
   static observedAttributes = ["choir", "part", "bar", "playing"];
@@ -21,10 +21,13 @@ export class MusicCanvas extends MusicElement {
   lastNoteDuration: number[][] = [];
   falseRelationPulses: number[] = [];
   shimmerPhases: number[] = [];
-  notesByQuant: Map<number, NoteEntry[]> = new Map();
-  ranges: Map<string, Range[]> = new Map();
-  barCount: number = 0;
-  frLocations: FRlocation[] = [];
+  // All parsed score data arrives together from one processLilypond() call, so
+  // it is held as one nullable object: null until #init populates it, never
+  // partially filled (#652). The entry points draw(), #startShimmerLoop(), and
+  // the public seek() guard on null; the post-init draw helpers and pointer
+  // handlers read `lilyData!`. (#updatePulses also guards defensively but is
+  // reached only via the already-guarded draw().)
+  lilyData: LilypondData | null = null;
   source: string | null = null;
 
   isOnDevBranch =
@@ -133,7 +136,7 @@ export class MusicCanvas extends MusicElement {
   #startShimmerLoop() {
     // Nothing animates while paused unless there are false-relation hotspots
     // to breathe, so skip the loop entirely when there are none (#649).
-    if (this.frLocations.length === 0) return;
+    if (this.lilyData == null || this.lilyData.frLocations.length === 0) return;
     const loop = (timestamp: number) => {
       if (!this.playing) {
         // Throttle to the idle interval: the breathing hotspot does not need
@@ -214,11 +217,7 @@ export class MusicCanvas extends MusicElement {
     this.#calculateCanvasSize();
     this.#showLoadingOnCanvas();
 
-    const lilyData = processLilypond();
-    this.notesByQuant = lilyData.notesByQuant;
-    this.ranges = lilyData.ranges;
-    this.barCount = lilyData.barCount;
-    this.frLocations = lilyData.frLocations;
+    this.lilyData = processLilypond();
 
     // define array pulses[choir][part] to be min transparency which
     // will be pulsed when the choir is singing a note.
@@ -233,10 +232,9 @@ export class MusicCanvas extends MusicElement {
       }
     }
 
-    this.falseRelationPulses = new Array(this.frLocations.length).fill(0);
-    this.shimmerPhases = this.frLocations.map(
-      () => Math.random() * Math.PI * 2
-    );
+    const { frLocations } = this.lilyData;
+    this.falseRelationPulses = new Array(frLocations.length).fill(0);
+    this.shimmerPhases = frLocations.map(() => Math.random() * Math.PI * 2);
 
     this.draw();
     this.#startShimmerLoop();
@@ -302,9 +300,12 @@ export class MusicCanvas extends MusicElement {
     // positions, so the old integer scan stepped right over them (#598). `ranges`
     // is the boundary-bearing source, and walking its edges is O(sections), not
     // O(bars).
+    // seek is public on the custom element; tolerate a call before #init.
+    if (this.lilyData == null) return pos.bar;
+    const { ranges, barCount } = this.lilyData;
     const singingAt = (bar: number): boolean => {
       for (let p = 0; p < config.parts.length; p++) {
-        const list = this.ranges.get(`${pos.choir}-${p}`);
+        const list = ranges.get(`${pos.choir}-${p}`);
         if (list?.some((r) => bar >= r.from && bar < r.to)) return true;
       }
       return false;
@@ -313,7 +314,7 @@ export class MusicCanvas extends MusicElement {
     // Every part-range edge for this choir, de-duplicated and sorted.
     const edges = new Set<number>();
     for (let p = 0; p < config.parts.length; p++) {
-      for (const r of this.ranges.get(`${pos.choir}-${p}`) ?? []) {
+      for (const r of ranges.get(`${pos.choir}-${p}`) ?? []) {
         edges.add(r.from);
         edges.add(r.to);
       }
@@ -337,7 +338,7 @@ export class MusicCanvas extends MusicElement {
     // current bar.
     if (direction > 0) {
       const next = flips.find((b) => b > pos.bar);
-      return next === undefined ? this.barCount : Math.min(next, this.barCount);
+      return next === undefined ? barCount : Math.min(next, barCount);
     }
     const prev = [...flips].reverse().find((b) => b < pos.bar);
     return prev === undefined ? 0 : Math.max(prev, 0);
@@ -362,7 +363,11 @@ export class MusicCanvas extends MusicElement {
 
   draw() {
     if (!this.canvas) return;
-    if (this.ranges.size === 0 || this.notesByQuant.size === 0) return;
+    if (this.lilyData == null) return;
+    // A non-null lilyData is fully populated, but a degenerate parse can yield
+    // zero notes; preserve the pre-#652 short-circuit so an empty score renders
+    // nothing rather than an empty grid.
+    if (this.lilyData.notesByQuant.size === 0) return;
 
     this.#updatePulses();
 
@@ -379,11 +384,13 @@ export class MusicCanvas extends MusicElement {
   }
 
   #updatePulses() {
+    if (this.lilyData == null) return;
+    const { notesByQuant, frLocations } = this.lilyData;
     const isLight = this.#isLightMode();
 
     // If there are notes starting now, record their onset and duration
     const quant = Math.floor(this.bar * 128) / 128;
-    const notes = this.notesByQuant.get(quant);
+    const notes = notesByQuant.get(quant);
     if (notes != undefined && notes.length > 0) {
       for (var n of notes) {
         if (n.n.duration != null) {
@@ -411,8 +418,8 @@ export class MusicCanvas extends MusicElement {
     }
 
     // Pulse false relations
-    for (let i = 0; i < this.frLocations.length; i++) {
-      const loc = this.frLocations[i];
+    for (let i = 0; i < frLocations.length; i++) {
+      const loc = frLocations[i];
       if (
         this.bar >= loc.from &&
         this.bar < loc.from + MusicCanvas.FR_PULSE_FADE_BARS
@@ -432,7 +439,7 @@ export class MusicCanvas extends MusicElement {
   }
 
   #drawBarHighlight(ctx: CanvasRenderingContext2D) {
-    if (this.bar <= 0 || this.bar > this.barCount) return;
+    if (this.bar <= 0 || this.bar > this.lilyData!.barCount) return;
     ctx.save();
     ctx.beginPath();
     ctx.moveTo(
@@ -487,13 +494,16 @@ export class MusicCanvas extends MusicElement {
       ? MusicCanvas.DULL_BASE_LIGHTNESS_LIGHT
       : MusicCanvas.DULL_BASE_LIGHTNESS_DARK;
 
+    const { ranges, barCount } = this.lilyData!;
     ctx.lineWidth = 0.9 * this.partHeight;
     ctx.lineCap = "round";
     for (var c = 0; c < config.choirs[0].length; c++) {
       for (var p = 0; p < config.parts.length; p++) {
         const Y = this.#partRowCenterY(c, p);
 
-        const list = this.ranges.get(`${c}-${p}`)!;
+        // processLilypond seeds every `${c}-${p}` key, so this lookup is total
+        // here (unlike seek's tolerant `?? []`). #652.
+        const list = ranges.get(`${c}-${p}`)!;
         list.forEach((r) => {
           const from = r.from;
           const to = r.to;
@@ -518,7 +528,7 @@ export class MusicCanvas extends MusicElement {
             saturation = 80;
             lightness = MusicCanvas.SELECTED_BASE_LIGHTNESS - 3 * p;
             transparency = 1;
-          } else if (this.bar === 0 || this.bar > this.barCount) {
+          } else if (this.bar === 0 || this.bar > barCount) {
             saturation = 50;
             lightness = MusicCanvas.SELECTED_BASE_LIGHTNESS - 3 * p;
             transparency = 1;
@@ -594,9 +604,10 @@ export class MusicCanvas extends MusicElement {
   }
 
   #drawFalseRelationHotspot(ctx: CanvasRenderingContext2D) {
+    const { frLocations } = this.lilyData!;
     const shimmerTime = Date.now() / 1000;
-    for (let i = 0; i < this.frLocations.length; i++) {
-      const loc = this.frLocations[i];
+    for (let i = 0; i < frLocations.length; i++) {
+      const loc = frLocations[i];
       const cx = this.canvasPadding + ((loc.from + loc.to) / 2) * this.barWidth;
       const phase = this.shimmerPhases[i];
       const alpha =
@@ -624,11 +635,12 @@ export class MusicCanvas extends MusicElement {
   }
 
   #drawFalseRelationPulses(ctx: CanvasRenderingContext2D) {
-    for (let i = 0; i < this.frLocations.length; i++) {
+    const { frLocations } = this.lilyData!;
+    for (let i = 0; i < frLocations.length; i++) {
       const pulse = this.falseRelationPulses[i];
       if (pulse <= 0) continue;
 
-      const loc = this.frLocations[i];
+      const loc = frLocations[i];
       const cx = this.canvasPadding + ((loc.from + loc.to) / 2) * this.barWidth;
 
       const cy = this.#partRowCenterY(loc.c, loc.p);
@@ -715,7 +727,7 @@ export class MusicCanvas extends MusicElement {
       ),
       part: partResolver(rowFraction),
       bar: Math.floor(
-        ((clampedX - cssPaddingX) * this.barCount) / drawableWidth
+        ((clampedX - cssPaddingX) * this.lilyData!.barCount) / drawableWidth
       ),
     };
   }

--- a/packages/pwa/src/ts/lily.ts
+++ b/packages/pwa/src/ts/lily.ts
@@ -264,20 +264,32 @@ export type Range = {
 // See ticket #107 follow-on.
 export var barCount: number = 0;
 
-// Fields are `readonly` (field-level only) because processLilypond now hands
-// out the same cached reference on every call (see lilypondCache below).
-// `readonly` on the field catches `lilyData.notesByQuant = somethingElse`,
-// the most likely accidental reassignment. The Map itself is not marked
-// readonly because canvas.test.ts deliberately mutates `notesByQuant` to
-// exercise seek()'s defensive path (restoring at end-of-test); deep readonly
-// would force a wider refactor. Callers MUST treat `notesByQuant`, `ranges`,
-// and `frLocations` as immutable in non-test code (Range fields are
-// compiler-enforced readonly since #551; the Map and array levels are not).
+// Quantised bar position -> all notes/rests starting at that position. Readonly
+// to the array level (#652): the Map and its arrays are immutable to consumers,
+// and the arrays are frozen at runtime (see processLilypond). The `NoteEntry`
+// leaf objects are NOT readonly (their fields are mutable), so consumers must
+// treat the entries themselves as immutable by convention.
+export type NotesByQuant = ReadonlyMap<number, readonly NoteEntry[]>;
+
+// "choir-part" key -> the singing ranges for that part. Deeply readonly (#652):
+// the Map, its arrays, and the Range leaves are all immutable to consumers at the
+// type level (processLilypond hands out one cached reference). At runtime only the
+// arrays are frozen (see processLilypond); the Map and Range leaves rely on the
+// compile-time `readonly`, since Object.freeze on a Map does not block Map.set.
+export type SingingRanges = ReadonlyMap<string, readonly Range[]>;
+
+// processLilypond hands out the same cached reference on every call (see
+// lilypondCache below), so every field is `readonly` to catch reassignment.
+// `ranges` is deeply readonly (its `Range` leaves carry `readonly` fields since
+// #551); `notesByQuant` and `frLocations` are readonly only to the array level —
+// their element objects (`NoteEntry`, `FRlocation`) have mutable fields. At
+// runtime the `notesByQuant` and `ranges` arrays are frozen; the `frLocations`
+// array is compile-time readonly only.
 export type LilypondData = {
-  readonly notesByQuant: Map<number, NoteEntry[]>;
-  readonly ranges: Map<string, Range[]>;
+  readonly notesByQuant: NotesByQuant;
+  readonly ranges: SingingRanges;
   readonly barCount: number;
-  readonly frLocations: FRlocation[];
+  readonly frLocations: readonly FRlocation[];
 };
 
 // Module-level cache. processLilypond parses static data (spem.ly + scores),
@@ -385,6 +397,13 @@ export function processLilypond(): LilypondData {
 
   barCount = localBarCount; // side effect: keep global in sync for MusicControls.ts
   const frLocations = detectFalseRelations(activeNotes);
+
+  // Freeze each singing-range and note array so the shared, cached LilypondData
+  // cannot be mutated at the array level by a consumer (the Maps and arrays are
+  // also compiler-enforced readonly via SingingRanges / NotesByQuant). #652.
+  for (const arr of ranges.values()) Object.freeze(arr);
+  for (const arr of notesByQuant.values()) Object.freeze(arr);
+
   lilypondCache = {
     notesByQuant,
     ranges,


### PR DESCRIPTION
Strengthens the `LilypondData` types and collapses redundant `MusicCanvas` fields. Internal typing and refactor work, no user-facing behaviour change.

- `lily.ts`: outer-dimension aliases, a single canonical field, and deep-readonly ranges, so the parsed LilyPond data is harder to misuse and the ranges cannot be mutated in place.
- `MusicCanvas.ts`: collapses fields that duplicated the same state.
- `canvas.test.ts`: updated to the strengthened types.

Fixes #652
