### PR TITLE
refactor: extract shared integration test setup helper

### DIFF
--- a/packages/pwa/src/test/darkmode.test.ts
+++ b/packages/pwa/src/test/darkmode.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { setupIntegrationFixture } from "./helpers";
 
 describe("Dark/light mode toggle", () => {
   // Captured after the load event, before any beforeEach reset can touch the
@@ -6,48 +7,7 @@ describe("Dark/light mode toggle", () => {
   let defaultHadLightTheme: boolean;
 
   beforeAll(async () => {
-    vi.resetModules();
-
-    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
-    if (!HTMLElement.prototype.scrollTo) {
-      HTMLElement.prototype.scrollTo = () => {};
-    }
-
-    document.body.innerHTML = `
-      <div class="viewportDiv">
-        <div id="backdrop"></div>
-        <header class="header">
-          <span class="title">Spem Player</span>
-          <span id="info" class="tooltip"><span id="help-icon"></span></span>
-          <div class="header-spacer"></div>
-          <span id="recordinglabel"></span>
-          <span id="recordingswitch"></span>
-          <span id="scoreswitch"></span>
-          <span id="darkswitch"></span>
-        </header>
-        <div id="help"></div>
-        <div class="split-container">
-          <music-score></music-score>
-          <div class="splitter"></div>
-          <music-canvas></music-canvas>
-        </div>
-        <div class="footer">
-          <music-controls></music-controls>
-          <music-canvas-watcher class="hide"></music-canvas-watcher>
-        </div>
-      </div>
-    `;
-
-    await import("../ts/MusicCanvas");
-    await import("../ts/MusicScore");
-    await import("../ts/MusicControls");
-    await import("../ts/MusicCanvasWatcher");
-
-    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
-    vi.spyOn(HTMLMediaElement.prototype, "pause").mockReturnThis();
-
-    await import("../../index.ts");
-    window.dispatchEvent(new Event("load"));
+    await setupIntegrationFixture();
     // Flush one macrotask so a future tick-deferred theme application is
     // still captured rather than silently missed (Vera 542 pass 2).
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/packages/pwa/src/test/feedback.test.ts
+++ b/packages/pwa/src/test/feedback.test.ts
@@ -1,36 +1,24 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { MusicControls } from "../ts/MusicControls";
+import { setupIntegrationFixture } from "./helpers";
 
 describe("Feedback modal", () => {
   beforeAll(async () => {
-    vi.resetModules();
+    await setupIntegrationFixture(() => {
+      const info = document.getElementById("info")!;
+      info.insertAdjacentHTML(
+        "afterend",
+        `<span id="feedback-trigger" class="tooltip">
+          <span id="feedback-icon"></span>
+          <span class="tooltiptext">Send feedback</span>
+        </span>`
+      );
 
-    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
-    if (!HTMLElement.prototype.scrollTo) {
-      HTMLElement.prototype.scrollTo = () => {};
-    }
-
-    document.body.innerHTML = `
-      <div class="viewportDiv">
-        <div id="backdrop"></div>
-        <header class="header">
-          <span class="title">Spem Player</span>
-          <span id="info" class="tooltip">
-            <span id="help-icon"></span>
-            <span class="tooltiptext">Display help information</span>
-          </span>
-          <span id="feedback-trigger" class="tooltip">
-            <span id="feedback-icon"></span>
-            <span class="tooltiptext">Send feedback</span>
-          </span>
-          <div class="header-spacer"></div>
-          <span id="recordinglabel"></span>
-          <span id="recordingswitch"></span>
-          <span id="scoreswitch"></span>
-          <span id="darkswitch"></span>
-        </header>
-        <div id="help" style="display: none;"></div>
-        <div id="feedback-modal" style="display: none;">
+      const help = document.getElementById("help")!;
+      help.setAttribute("style", "display: none;");
+      help.insertAdjacentHTML(
+        "afterend",
+        `<div id="feedback-modal" style="display: none;">
           <h2>Feedback</h2>
           <form id="feedback-form">
             <div id="feedback-rating">
@@ -47,35 +35,19 @@ describe("Feedback modal", () => {
             </div>
           </form>
           <div id="feedback-result" style="display: none;"></div>
-        </div>
-        <div class="split-container">
-          <music-score></music-score>
-          <div class="splitter"></div>
-          <music-canvas></music-canvas>
-        </div>
-        <div class="footer">
-          <music-controls></music-controls>
-          <music-canvas-watcher class="hide"></music-canvas-watcher>
-        </div>
-      </div>
-      <form name="feedback" netlify netlify-honeypot="bot-field" hidden>
-        <input type="hidden" name="bot-field" />
-        <input type="number" name="rating" />
-        <input type="hidden" name="context" />
-        <textarea name="message"></textarea>
-      </form>
-    `;
+        </div>`
+      );
 
-    await import("../ts/MusicCanvas");
-    await import("../ts/MusicScore");
-    await import("../ts/MusicControls");
-    await import("../ts/MusicCanvasWatcher");
-
-    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
-    vi.spyOn(HTMLMediaElement.prototype, "pause").mockReturnThis();
-
-    await import("../../index.ts");
-    window.dispatchEvent(new Event("load"));
+      document.body.insertAdjacentHTML(
+        "beforeend",
+        `<form name="feedback" netlify netlify-honeypot="bot-field" hidden>
+          <input type="hidden" name="bot-field" />
+          <input type="number" name="rating" />
+          <input type="hidden" name="context" />
+          <textarea name="message"></textarea>
+        </form>`
+      );
+    });
   }, 30000);
 
   afterAll(async () => {

--- a/packages/pwa/src/test/helpers.ts
+++ b/packages/pwa/src/test/helpers.ts
@@ -1,8 +1,83 @@
 // Shared test utilities
 
+import { vi } from "vitest";
+
 export var expectedBar: any;
 export var expectedChoir: any;
 export var expectedPart: any;
+
+const BASE_INTEGRATION_FIXTURE = `
+  <div class="viewportDiv">
+    <div id="backdrop"></div>
+    <header class="header">
+      <span class="title">Spem Player</span>
+      <span id="info" class="tooltip"><span id="help-icon"></span></span>
+      <div class="header-spacer"></div>
+      <span id="recordinglabel"></span>
+      <span id="recordingswitch"></span>
+      <span id="scoreswitch"></span>
+      <span id="darkswitch"></span>
+    </header>
+    <div id="help"></div>
+    <div id="feedback-modal"></div>
+    <div class="split-container">
+      <music-score></music-score>
+      <div class="splitter"></div>
+      <music-canvas></music-canvas>
+    </div>
+    <div class="footer">
+      <music-controls></music-controls>
+      <music-canvas-watcher class="hide"></music-canvas-watcher>
+    </div>
+  </div>
+`;
+
+/**
+ * Set up the shared jsdom fixture and bootstrap the app for integration tests.
+ *
+ * The optional `configure` callback runs after the base fixture is injected and
+ * the custom-element *modules* are imported, but before `index.ts` is imported
+ * (which is what registers the elements, via their static `define()`, and wires
+ * the app) and before the load event is dispatched. The `<music-*>` elements are
+ * therefore not yet upgraded when `configure` runs, so inject plain DOM here (for
+ * example the feedback modal), not interactions with the custom elements. Keeps
+ * the shared bootstrap in one place.
+ */
+export async function setupIntegrationFixture(
+  configure?: () => void | Promise<void>
+): Promise<void> {
+  // Re-evaluate index.ts and the element modules fresh for this test file: their
+  // top-level define() and app wiring must run again, not reuse a cached module
+  // graph left by a prior file in the same worker.
+  vi.resetModules();
+
+  // jsdom implements neither a real requestAnimationFrame scheduler nor
+  // scrollTo; stub both so app code that schedules a frame or scrolls during
+  // bootstrap does not throw.
+  vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
+  if (!HTMLElement.prototype.scrollTo) {
+    HTMLElement.prototype.scrollTo = () => {};
+  }
+
+  document.body.innerHTML = BASE_INTEGRATION_FIXTURE;
+
+  await import("../ts/MusicCanvas");
+  await import("../ts/MusicScore");
+  await import("../ts/MusicControls");
+  await import("../ts/MusicCanvasWatcher");
+
+  if (configure) {
+    await configure();
+  }
+
+  // jsdom has no real media playback; stub play/pause before index.ts runs on
+  // the load event, so app code and tests can drive playback without errors.
+  vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+  vi.spyOn(HTMLMediaElement.prototype, "pause").mockReturnThis();
+
+  await import("../../index.ts");
+  window.dispatchEvent(new Event("load"));
+}
 
 /**
  * Wait for a custom event on an element, run a handler, and resolve

--- a/packages/pwa/src/test/keyboard.test.ts
+++ b/packages/pwa/src/test/keyboard.test.ts
@@ -1,51 +1,10 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { MusicControls } from "../ts/MusicControls";
+import { setupIntegrationFixture } from "./helpers";
 
 describe("keyboard shortcuts", () => {
   beforeAll(async () => {
-    vi.resetModules();
-
-    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
-    if (!HTMLElement.prototype.scrollTo) {
-      HTMLElement.prototype.scrollTo = () => {};
-    }
-
-    document.body.innerHTML = `
-      <div class="viewportDiv">
-        <div id="backdrop"></div>
-        <header class="header">
-          <span class="title">Spem Player</span>
-          <span id="info" class="tooltip"><span id="help-icon"></span></span>
-          <div class="header-spacer"></div>
-          <span id="recordinglabel"></span>
-          <span id="recordingswitch"></span>
-          <span id="scoreswitch"></span>
-          <span id="darkswitch"></span>
-        </header>
-        <div id="help"></div>
-        <div id="feedback-modal"></div>
-        <div class="split-container">
-          <music-score></music-score>
-          <div class="splitter"></div>
-          <music-canvas></music-canvas>
-        </div>
-        <div class="footer">
-          <music-controls></music-controls>
-          <music-canvas-watcher class="hide"></music-canvas-watcher>
-        </div>
-      </div>
-    `;
-
-    await import("../ts/MusicCanvas");
-    await import("../ts/MusicScore");
-    await import("../ts/MusicControls");
-    await import("../ts/MusicCanvasWatcher");
-
-    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
-    vi.spyOn(HTMLMediaElement.prototype, "pause").mockReturnThis();
-
-    await import("../../index.ts");
-    window.dispatchEvent(new Event("load"));
+    await setupIntegrationFixture();
   }, 30000);
 
   afterAll(async () => {

--- a/packages/pwa/src/test/setbar.test.ts
+++ b/packages/pwa/src/test/setbar.test.ts
@@ -2,51 +2,11 @@ import { describe, it, expect, beforeAll, vi } from "vitest";
 import { MusicControls } from "../ts/MusicControls";
 import { MusicScore } from "../ts/MusicScore";
 import { MusicCanvas } from "../ts/MusicCanvas";
+import { setupIntegrationFixture } from "./helpers";
 
 describe("setBar boundary wrapping", () => {
   beforeAll(async () => {
-    vi.resetModules();
-
-    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(0);
-    if (!HTMLElement.prototype.scrollTo) {
-      HTMLElement.prototype.scrollTo = () => {};
-    }
-
-    document.body.innerHTML = `
-      <div class="viewportDiv">
-        <div id="backdrop"></div>
-        <header class="header">
-          <span class="title">Spem Player</span>
-          <span id="info" class="tooltip"><span id="help-icon"></span></span>
-          <div class="header-spacer"></div>
-          <span id="recordinglabel"></span>
-          <span id="recordingswitch"></span>
-          <span id="scoreswitch"></span>
-          <span id="darkswitch"></span>
-        </header>
-        <div id="help"></div>
-        <div class="split-container">
-          <music-score></music-score>
-          <div class="splitter"></div>
-          <music-canvas></music-canvas>
-        </div>
-        <div class="footer">
-          <music-controls></music-controls>
-          <music-canvas-watcher class="hide"></music-canvas-watcher>
-        </div>
-      </div>
-    `;
-
-    await import("../ts/MusicCanvas");
-    await import("../ts/MusicScore");
-    await import("../ts/MusicControls");
-    await import("../ts/MusicCanvasWatcher");
-
-    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
-    vi.spyOn(HTMLMediaElement.prototype, "pause").mockReturnThis();
-
-    await import("../../index.ts");
-    window.dispatchEvent(new Event("load"));
+    await setupIntegrationFixture();
   }, 30000);
 
   afterAll(async () => {


### PR DESCRIPTION
Extracts the shared integration-test setup into a helper (`packages/pwa/src/test/helpers.ts`) so the integration test files stop duplicating the same setup boilerplate. Test-only refactor, no production code change.

Updated: `darkmode.test.ts`, `feedback.test.ts`, `keyboard.test.ts`, `setbar.test.ts` now use the shared helper.

Fixes #694
