### PR TITLE
refactor: make Note constructor use named parameters

### DIFF
--- a/packages/pwa/src/test/canvas.test.ts
+++ b/packages/pwa/src/test/canvas.test.ts
@@ -1594,7 +1594,13 @@ describe("MusicCanvas custom element", () => {
     expect(canvas).not.toBeNull();
 
     const onset = 0.03125; // 1/32 bar, between 1/16 quant points
-    const note = new Note("a", null, null, new Duration("16"), null);
+    const note = new Note({
+      notename: "a",
+      accidental: null,
+      octave: null,
+      duration: new Duration("16"),
+      slur: null,
+    });
     canvas!.lilyData = {
       ...canvas!.lilyData!,
       notesByQuant: new Map([[onset, [{ c: 0, p: 0, n: note }]]]),
@@ -1610,8 +1616,20 @@ describe("MusicCanvas custom element", () => {
   it("still pulses notes on 1/16 and whole-bar boundaries after the finer quant (#704)", () => {
     expect(canvas).not.toBeNull();
 
-    const note16 = new Note("b", null, null, new Duration("16"), null);
-    const noteWhole = new Note("c", null, null, new Duration("1"), null);
+    const note16 = new Note({
+      notename: "b",
+      accidental: null,
+      octave: null,
+      duration: new Duration("16"),
+      slur: null,
+    });
+    const noteWhole = new Note({
+      notename: "c",
+      accidental: null,
+      octave: null,
+      duration: new Duration("1"),
+      slur: null,
+    });
     canvas!.lilyData = {
       ...canvas!.lilyData!,
       notesByQuant: new Map([

--- a/packages/pwa/src/test/lily.test.ts
+++ b/packages/pwa/src/test/lily.test.ts
@@ -137,54 +137,178 @@ describe("lilypond parsing tests", () => {
 
   it("noteToPitchClass maps natural notes correctly", () => {
     expect(
-      noteToPitchClass(new Note("c", null, null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "c",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(0);
     expect(
-      noteToPitchClass(new Note("d", null, null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "d",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(2);
     expect(
-      noteToPitchClass(new Note("e", null, null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "e",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(4);
     expect(
-      noteToPitchClass(new Note("f", null, null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "f",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(5);
     expect(
-      noteToPitchClass(new Note("g", null, null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "g",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(7);
     expect(
-      noteToPitchClass(new Note("a", null, null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "a",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(9);
     expect(
-      noteToPitchClass(new Note("b", null, null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "b",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(11);
   });
 
   it("noteToPitchClass maps accidentals correctly", () => {
     expect(
-      noteToPitchClass(new Note("c", "is", null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "c",
+          accidental: "is",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(1);
     expect(
-      noteToPitchClass(new Note("c", "es", null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "c",
+          accidental: "es",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(11);
     expect(
-      noteToPitchClass(new Note("c", "isis", null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "c",
+          accidental: "isis",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(2);
     expect(
-      noteToPitchClass(new Note("c", "eses", null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "c",
+          accidental: "eses",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(10);
     expect(
-      noteToPitchClass(new Note("e", "es", null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "e",
+          accidental: "es",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(3); // E flat
     expect(
-      noteToPitchClass(new Note("b", "es", null, new Duration("4"), null))
+      noteToPitchClass(
+        new Note({
+          notename: "b",
+          accidental: "es",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        })
+      )
     ).toBe(10); // B flat
   });
 
   it("detectFalseRelations finds false relations (same letter, different accidental)", () => {
     const activeNotes = new Map<number, ActiveNote[]>();
     activeNotes.set(1.0, [
-      { c: 0, p: 0, n: new Note("f", null, null, new Duration("4"), null) },
-      { c: 1, p: 0, n: new Note("f", "is", null, new Duration("4"), null) },
+      {
+        c: 0,
+        p: 0,
+        n: new Note({
+          notename: "f",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
+      {
+        c: 1,
+        p: 0,
+        n: new Note({
+          notename: "f",
+          accidental: "is",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
     ]);
     const result = detectFalseRelations(activeNotes);
     expect(result.length).toBe(2);
@@ -197,8 +321,28 @@ describe("lilypond parsing tests", () => {
   it("detectFalseRelations ignores same-part clashes", () => {
     const activeNotes = new Map<number, ActiveNote[]>();
     activeNotes.set(1.0, [
-      { c: 0, p: 0, n: new Note("f", null, null, new Duration("4"), null) },
-      { c: 0, p: 0, n: new Note("f", "is", null, new Duration("4"), null) },
+      {
+        c: 0,
+        p: 0,
+        n: new Note({
+          notename: "f",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
+      {
+        c: 0,
+        p: 0,
+        n: new Note({
+          notename: "f",
+          accidental: "is",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
     ]);
     const result = detectFalseRelations(activeNotes);
     expect(result.length).toBe(0);
@@ -207,8 +351,28 @@ describe("lilypond parsing tests", () => {
   it("detectFalseRelations ignores different letters (even if semitone apart)", () => {
     const activeNotes = new Map<number, ActiveNote[]>();
     activeNotes.set(1.0, [
-      { c: 0, p: 0, n: new Note("e", null, null, new Duration("4"), null) },
-      { c: 1, p: 0, n: new Note("f", null, null, new Duration("4"), null) },
+      {
+        c: 0,
+        p: 0,
+        n: new Note({
+          notename: "e",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
+      {
+        c: 1,
+        p: 0,
+        n: new Note({
+          notename: "f",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
     ]);
     const result = detectFalseRelations(activeNotes);
     expect(result.length).toBe(0);
@@ -217,12 +381,52 @@ describe("lilypond parsing tests", () => {
   it("detectFalseRelations merges consecutive positions for same part", () => {
     const activeNotes = new Map<number, ActiveNote[]>();
     activeNotes.set(1.0, [
-      { c: 0, p: 0, n: new Note("b", "es", null, new Duration("4"), null) },
-      { c: 1, p: 0, n: new Note("b", null, null, new Duration("4"), null) },
+      {
+        c: 0,
+        p: 0,
+        n: new Note({
+          notename: "b",
+          accidental: "es",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
+      {
+        c: 1,
+        p: 0,
+        n: new Note({
+          notename: "b",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
     ]);
     activeNotes.set(1.0625, [
-      { c: 0, p: 0, n: new Note("b", "es", null, new Duration("4"), null) },
-      { c: 1, p: 0, n: new Note("b", null, null, new Duration("4"), null) },
+      {
+        c: 0,
+        p: 0,
+        n: new Note({
+          notename: "b",
+          accidental: "es",
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
+      {
+        c: 1,
+        p: 0,
+        n: new Note({
+          notename: "b",
+          accidental: null,
+          octave: null,
+          duration: new Duration("4"),
+          slur: null,
+        }),
+      },
     ]);
     const result = detectFalseRelations(activeNotes);
     expect(result.length).toBe(2);

--- a/packages/pwa/src/test/music-classes.test.ts
+++ b/packages/pwa/src/test/music-classes.test.ts
@@ -57,26 +57,66 @@ describe("Duration", () => {
 describe("Note", () => {
   it("toString formats note correctly", () => {
     const d = new Duration("4");
-    const n = new Note("c", null, null, d, null);
+    const n = new Note({
+      notename: "c",
+      accidental: null,
+      octave: null,
+      duration: d,
+      slur: null,
+    });
     expect(n.toString()).toBe("c4");
   });
 
   it("toString includes accidental and octave", () => {
     const d = new Duration("8");
-    const n = new Note("d", "is", "'", d, null);
+    const n = new Note({
+      notename: "d",
+      accidental: "is",
+      octave: "'",
+      duration: d,
+      slur: null,
+    });
     expect(n.toString()).toBe("dis'8");
   });
 
   it("toString can hide duration", () => {
     const d = new Duration("2");
-    const n = new Note("e", null, null, d, "(");
+    const n = new Note({
+      notename: "e",
+      accidental: null,
+      octave: null,
+      duration: d,
+      slur: "(",
+    });
     expect(n.toString(false)).toBe("e(");
   });
 
   it("toString concatenates all fields in order", () => {
     const d = new Duration("4");
-    const n = new Note("c", "is", "'", d, "(");
+    const n = new Note({
+      notename: "c",
+      accidental: "is",
+      octave: "'",
+      duration: d,
+      slur: "(",
+    });
     expect(n.toString()).toBe("cis'4(");
+  });
+
+  it("assigns each named parameter to the correct property", () => {
+    const d = new Duration("4");
+    const n = new Note({
+      notename: "c",
+      accidental: "is",
+      octave: "'",
+      duration: d,
+      slur: "(",
+    });
+    expect(n.notename).toBe("c");
+    expect(n.accidental).toBe("is");
+    expect(n.octave).toBe("'");
+    expect(n.duration).toBe(d);
+    expect(n.slur).toBe("(");
   });
 });
 

--- a/packages/pwa/src/ts/lily.ts
+++ b/packages/pwa/src/ts/lily.ts
@@ -221,7 +221,13 @@ function setupLilypondParser(): LilypondSemantics {
       const d = duration.parse() as Duration;
       const s = slur.sourceString.length == 0 ? null : slur.sourceString;
 
-      const note = new Note(lastNote.notename, lastNote.accidental, "", d, s);
+      const note = new Note({
+        notename: lastNote.notename,
+        accidental: lastNote.accidental,
+        octave: "",
+        duration: d,
+        slur: s,
+      });
       return note;
     },
     note(notename, accidental, octave, _, duration, _2, slur) {
@@ -232,7 +238,13 @@ function setupLilypondParser(): LilypondSemantics {
       var d = getDuration(duration);
       const s = slur.sourceString.length == 0 ? null : slur.sourceString;
 
-      lastNote = new Note(n, a, o, d, s);
+      lastNote = new Note({
+        notename: n,
+        accidental: a,
+        octave: o,
+        duration: d,
+        slur: s,
+      });
       return lastNote;
     },
     rest(restname, duration) {

--- a/packages/pwa/src/ts/music-classes.ts
+++ b/packages/pwa/src/ts/music-classes.ts
@@ -89,19 +89,21 @@ export class Note extends Component {
   octave: string | null;
   slur: string | null;
 
-  constructor(
-    notename: string,
-    accidental: string | null,
-    octave: string | null,
-    duration: Duration,
-    slur: string | null
-  ) {
-    super(duration);
-    this.notename = notename;
-    this.accidental = accidental;
-    this.octave = octave;
-    this.duration = duration;
-    this.slur = slur;
+  // Named params, not positional: notename/accidental/octave/slur are adjacent
+  // string|null fields that positional args could silently transpose with no
+  // type error. Keep this keyed by name (#705).
+  constructor(params: {
+    notename: string;
+    accidental: string | null;
+    octave: string | null;
+    duration: Duration;
+    slur: string | null;
+  }) {
+    super(params.duration);
+    this.notename = params.notename;
+    this.accidental = params.accidental;
+    this.octave = params.octave;
+    this.slur = params.slur;
   }
 
   toString(showDuration = true) {


### PR DESCRIPTION
Changes the `Note` constructor in `music-classes.ts` to take named parameters instead of positional ones, so call sites read clearly and are harder to get wrong, and updates the callers in `lily.ts`. Refactor, no behaviour change.

Fixes #705
