### PR TITLE
fix: value-preserving merge for the monitor series (mergedPRs race)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,8 @@
 *.html text eol=lf
 *.ohm text eol=lf
 .husky/pre-commit text eol=lf
+
+# Value-preserving merge for the accumulated build-usage series (#728): keep the
+# richer per-day mergedPRs rather than last-writer-wins. The driver is registered
+# per checkout by the monitor workflows (git config merge.monitor-series.driver).
+.github/monitor-series.json merge=monitor-series

--- a/.github/scripts/push-with-rebase.sh
+++ b/.github/scripts/push-with-rebase.sh
@@ -33,11 +33,13 @@
 #     does not re-trigger scores-ci, so the catch-up is the next build that
 #     rebuilds the affected score, not necessarily the immediate next run.)
 #   - The monitor series (.github/monitor-series.json) is accumulated, NOT
-#     regenerated -- each run upserts only today's entry. Last-writer-wins can
-#     therefore overwrite a richer entry with a poorer one (a merge-time refresh
-#     writing mergedPRs:0 over the daily run's real count), and it does NOT
-#     self-heal within the day; recovery needs a manual backfill. Tracked as #728
-#     (a value-preserving merge for the series).
+#     regenerated -- each run upserts only today's entry. Last-writer-wins would
+#     overwrite a richer entry with a poorer one (a merge-time refresh writing
+#     mergedPRs:0 over the daily run's real count), so this path is bound to the
+#     `monitor-series` merge driver (.gitattributes + the monitor workflows'
+#     `git config merge.monitor-series.driver`), which reconciles the rebase by
+#     keeping the larger per-day mergedPRs -- last-writer-wins no longer applies
+#     to this file (#728).
 #
 # Why FETCH_HEAD, not origin/main: actions/checkout fetches with a narrow refspec
 # that need not update the origin/main remote-tracking ref, so rebasing onto

--- a/.github/scripts/push-with-rebase.test.sh
+++ b/.github/scripts/push-with-rebase.test.sh
@@ -7,11 +7,14 @@
 # rejected push fails loudly after exactly the retry bound, (4) it rebases onto
 # FETCH_HEAD so it converges even when the origin/main ref is stale (the core
 # fix), (5) --autostash lets it converge with a dirty working tree, (6) a floored
-# PUSH_RETRIES=0 still attempts one push, and (7) a non-integer PUSH_RETRIES
-# normalises rather than falling through to a no-push.
+# PUSH_RETRIES=0 still attempts one push, (7) a non-integer PUSH_RETRIES
+# normalises rather than falling through to a no-push, and (8) the
+# .github/monitor-series.json value-preserving merge driver keeps the richer
+# per-day mergedPRs through the rebase (#728) -- the one case that depends on the
+# .gitattributes binding + driver registration the others do not set.
 #
 # Run by .github/workflows/push-helper-test.yml on any change under
-# .github/scripts/, and locally with:
+# .github/scripts/ or to the monitor merge driver, and locally with:
 #
 #     bash .github/scripts/push-with-rebase.test.sh
 set -euo pipefail
@@ -184,6 +187,41 @@ if ( cd "$d/ci"; PUSH_RETRIES=notanumber bash "$HELPER" ) >/dev/null 2>&1; then
     || bad "case7: regenerated=$r (want vCI)"
 else
   bad "case7: non-integer PUSH_RETRIES did not push (validation missing?)"
+fi
+
+# Case 8: the accumulated monitor series merges by VALUE (#728). A concurrent
+# push of the richer per-day mergedPRs must survive the rebase that writes the
+# poorer 0, instead of being clobbered by -X theirs. Requires the merge driver
+# registered + .gitattributes binding the path, exactly as the monitor workflows
+# configure it -- so this also asserts the driver beats -X theirs.
+DRIVER="$(cd "$(dirname "$0")/../.." && pwd)/packages/monitor/merge-monitor-series.mjs"
+mseries() { printf '[{"date":"2026-06-30","mergedPRs":%s,"summary":{"date":"2026-06-30","mergedPRs":%s}}]\n' "$1" "$1"; }
+
+d="$(setup case8)"
+# Commit the .gitattributes binding + an empty series on origin/main.
+(
+  cd "$d/seed"
+  printf '.github/monitor-series.json merge=monitor-series\n' > .gitattributes
+  mkdir -p .github
+  printf '[]\n' > .github/monitor-series.json
+  git_q add -A; git_q commit -qm "seed series + gitattributes"
+  git_q push -q origin HEAD:main
+) >/dev/null 2>&1
+# Re-clone ci so it carries the gitattributes binding, and register the driver
+# (the monitor workflow's `git config merge.monitor-series.driver`).
+rm -rf "$d/ci"; git_q clone -q "$d/origin.git" "$d/ci" >/dev/null 2>&1
+git_q -C "$d/ci" config merge.monitor-series.driver "node $DRIVER %O %A %B %P"
+# ci writes today with the poorer count (refresh: 0); a concurrent push lands the
+# richer count (daily run: 3) first, so ci must rebase.
+( cd "$d/ci"; mseries 0 > .github/monitor-series.json; git_q add -A; git_q commit -qm "ci refresh 0" ) >/dev/null 2>&1
+rm -rf "$d/other"; git_q clone -q "$d/origin.git" "$d/other" >/dev/null 2>&1
+( cd "$d/other"; mseries 3 > .github/monitor-series.json; git_q add -A; git_q commit -qm "daily run 3"; git_q push -q origin HEAD:main ) >/dev/null 2>&1
+if ( cd "$d/ci"; bash "$HELPER" ) >/dev/null 2>&1; then
+  got="$(origin_show "$d" .github/monitor-series.json | grep -oE '"mergedPRs":[[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
+  [ "$got" = 3 ] && ok "case8: monitor series keeps the richer mergedPRs through the rebase (#728)" \
+    || bad "case8: mergedPRs=$got (want 3 -- driver did not beat -X theirs)"
+else
+  bad "case8: helper exited non-zero on the monitor-series race"
 fi
 
 echo "---"

--- a/.github/workflows/monitor-refresh.yml
+++ b/.github/workflows/monitor-refresh.yml
@@ -65,6 +65,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Value-preserving merge for the series so a concurrent rebase keeps the
+          # richer per-day mergedPRs rather than last-writer-wins (#728).
+          git config merge.monitor-series.driver 'node packages/monitor/merge-monitor-series.mjs %O %A %B %P'
           git add .github/monitor-series.json
           if git diff --cached --quiet; then
             echo "No series changes to commit"

--- a/.github/workflows/monitor-run.yml
+++ b/.github/workflows/monitor-run.yml
@@ -41,6 +41,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Value-preserving merge for the series so a concurrent rebase keeps the
+          # richer per-day mergedPRs rather than last-writer-wins (#728).
+          git config merge.monitor-series.driver 'node packages/monitor/merge-monitor-series.mjs %O %A %B %P'
           git add .github/monitor-series.json
           if git diff --cached --quiet; then
             echo "No series changes to commit"

--- a/.github/workflows/push-helper-test.yml
+++ b/.github/workflows/push-helper-test.yml
@@ -9,10 +9,12 @@ on:
     paths:
       - ".github/scripts/**"
       - ".github/workflows/push-helper-test.yml"
+      - "packages/monitor/merge-monitor-series.mjs"
   pull_request:
     paths:
       - ".github/scripts/**"
       - ".github/workflows/push-helper-test.yml"
+      - "packages/monitor/merge-monitor-series.mjs"
 
 jobs:
   test:

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -124,6 +124,18 @@ Three workflows commit a regenerated file to `main`: `monitor-run.yml`,
 `.github/scripts/push-with-rebase.sh`, which retries with a rebase if a concurrent
 push moved `main` first, so an overlapping run converges instead of failing
 non-fast-forward ([#727](https://github.com/wainwmr/spem-player/issues/727)).
+
+The rebase is content-blind last-writer-wins, which is correct for a
+fully-regenerated file (a dropped score SVG self-heals on the next build). The
+build-usage series (`.github/monitor-series.json`) is the exception: it is
+upserted, not regenerated, so last-writer-wins could overwrite the daily run's
+real `mergedPRs` with a merge-time refresh's `0`. A value-preserving git merge
+driver (`packages/monitor/merge-monitor-series.mjs`, bound by `.gitattributes`
+and registered by the monitor workflows via
+`git config merge.monitor-series.driver`) reconciles a concurrent rebase of that
+file by keeping the larger per-day `mergedPRs`, so neither writer erases the
+other's count ([#728](https://github.com/wainwmr/spem-player/issues/728)).
+
 `push-helper-test.yml` runs the helper's regression test
 (`.github/scripts/push-with-rebase.test.sh`) on any change under
 `.github/scripts/`.

--- a/doc/MONITOR.md
+++ b/doc/MONITOR.md
@@ -139,7 +139,11 @@ It deliberately does **less** than the daily run. It invokes
 `monitor-resources.mjs --refresh`, which updates today's entry only and sends no
 Telegram message, renders no chart, and opens no critical issue. It also leaves
 `mergedPRs` at 0; the daily run sets the real count later, but only on a run that
-does not skip the report (see `shouldSkipReport`).
+does not skip the report (see `shouldSkipReport`). Because both writers upsert
+today's entry, a value-preserving merge driver reconciles a concurrent rebase by
+keeping the larger per-day `mergedPRs`, so a second-finishing refresh cannot erase
+the daily run's real count ([#728](https://github.com/wainwmr/spem-player/issues/728);
+see [`doc/CI.md`](./CI.md) § Pushing regenerated files to `main`).
 
 The hourly cap is a `git log --grep` for the previous refresh commit, so the
 checkout uses `fetch-depth: 0` to make that history visible. Because the cap keys

--- a/packages/monitor/merge-monitor-series.mjs
+++ b/packages/monitor/merge-monitor-series.mjs
@@ -1,0 +1,105 @@
+/**
+ * Value-preserving git merge driver for `.github/monitor-series.json` (#728).
+ *
+ * The series is accumulated, not regenerated: each run upserts only today's
+ * entry. Two writers can target the same day with different `mergedPRs` — the
+ * daily `main()` run writes the real count, the merge-time `refresh()` writes
+ * `0` — and the `-X theirs` rebase in `push-with-rebase.sh` is content-blind,
+ * so whichever push lands second overwrites the other's count (the daily count
+ * lost to a `0`). This driver reconciles by value: for each day it keeps the
+ * entry with the **larger** `mergedPRs`, so the richer count always survives a
+ * concurrent rebase or merge. It is bound to the series path by `.gitattributes`
+ * and registered per-checkout by the monitor workflows
+ * (`git config merge.monitor-series.driver ...`).
+ *
+ * Git invokes it as `node merge-monitor-series.mjs %O %A %B %P`. In the rebase
+ * that triggers it (`git rebase -X theirs FETCH_HEAD`) git replays our commit
+ * onto the upstream tip, so `%A` is the **upstream/onto** side (the run that
+ * landed first) and `%B` is the **replayed** commit (ours) — the inverse of a
+ * plain merge's ours/theirs (see `push-with-rebase.sh`). The reconciliation is a
+ * commutative union+max, so the result does not depend on which side is which;
+ * the only ordering effect is the equal-count tie-break, which keeps the first
+ * argument's entry. The merged result is written back to `%A`, exiting `0`; a
+ * malformed input exits non-zero so the conflict surfaces loudly rather than
+ * silently dropping data.
+ *
+ * Trade-off: the winner is kept **wholesale**, so on a `main`-vs-`refresh`
+ * collision the entry with the real `mergedPRs` wins and the loser's possibly
+ * fresher `overallStatus` is dropped. That is deliberate: a lost `mergedPRs` is
+ * permanent (never backfilled), whereas `overallStatus` self-heals on the next
+ * refresh and the throttle gate already tolerates day-scale staleness, so the
+ * permanent-loss field is the one worth protecting. A field-wise merge would
+ * need a per-entry write-freshness marker the series does not carry.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** @typedef {import("./monitor-resources.mjs").SeriesEntry} SeriesEntry */
+
+/**
+ * Merge two serialised monitor series, keeping the richer `mergedPRs` per day.
+ *
+ * For each `date` present in either side, one entry is emitted. When a date is
+ * in both, the entry with the greater `mergedPRs` wins wholesale (so its
+ * `summary.mergedPRs` stays internally consistent); an equal-count tie keeps the
+ * first argument's entry. A union+max merge needs no common ancestor and never
+ * invents a conflict. The result is sorted by date, matching `saveSeries`. The
+ * producer guarantees one entry per day (`appendOrReplaceDay`); a hypothetical
+ * intra-side duplicate would be deduped to its max here.
+ *
+ * Pure (text in, objects out): `main()` owns the file I/O and the
+ * `JSON.stringify(..., null, 2) + "\n"` formatting that must match `saveSeries`.
+ *
+ * @param {string} oursText - The `%A` side as JSON text (an array of entries).
+ * @param {string} theirsText - The `%B` side as JSON text.
+ * @returns {SeriesEntry[]} The merged series, sorted ascending by `date`.
+ * @throws {Error} If either side is not a JSON array.
+ */
+export function mergeSeries(oursText, theirsText) {
+  const ours = JSON.parse(oursText);
+  const theirs = JSON.parse(theirsText);
+  if (!Array.isArray(ours) || !Array.isArray(theirs)) {
+    throw new Error("monitor-series merge input must be a JSON array");
+  }
+  /** @type {Map<string, SeriesEntry>} */
+  const byDate = new Map();
+  // First argument first, so an equal-count tie keeps its entry (deterministic).
+  for (const e of [...ours, ...theirs]) {
+    const existing = byDate.get(e.date);
+    if (!existing || (e.mergedPRs ?? 0) > (existing.mergedPRs ?? 0)) {
+      byDate.set(e.date, e);
+    }
+  }
+  return Array.from(byDate.values()).sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Git merge-driver entry point. Reads `%A` and `%B`, writes the value-preserving
+ * merge back to `%A`, and returns `0`.
+ *
+ * @param {string[]} argv - `process.argv`: `[node, script, %O, %A, %B, %P]`.
+ * @returns {number} `0` on a clean merge.
+ */
+function main(argv) {
+  const oursFile = argv[3]; // %A — the side merged into, and the output target.
+  const theirsFile = argv[4]; // %B — the other side.
+  // argv[2] is %O (ancestor); a union+max merge needs no base.
+  const merged = mergeSeries(
+    readFileSync(oursFile, "utf8"),
+    readFileSync(theirsFile, "utf8")
+  );
+  writeFileSync(oursFile, JSON.stringify(merged, null, 2) + "\n", "utf8");
+  return 0;
+}
+
+// Run only when invoked directly as the merge driver, not when imported by tests.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exit(main(process.argv));
+  } catch (err) {
+    console.error(`merge-monitor-series: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/packages/monitor/merge-monitor-series.test.mjs
+++ b/packages/monitor/merge-monitor-series.test.mjs
@@ -1,0 +1,96 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { mergeSeries } from "./merge-monitor-series.mjs";
+
+/**
+ * Build a minimal series entry with a self-consistent summary.mergedPRs.
+ */
+function entry(date, mergedPRs, extra = {}) {
+  return {
+    date,
+    netlifyCurrent: 100,
+    githubMinutes: 200,
+    mergedPRs,
+    summary: { date, mergedPRs, overallStatus: "good" },
+    source: "logged",
+    ...extra,
+  };
+}
+
+describe("mergeSeries (#728 value-preserving monitor-series merge)", () => {
+  test("keeps the richer mergedPRs when ours is the poorer (refresh wrote 0)", () => {
+    // The losing ordering: ours = merge-time refresh (0), theirs = daily run (3).
+    const ours = JSON.stringify([entry("2026-06-30", 0)]);
+    const theirs = JSON.stringify([entry("2026-06-30", 3)]);
+    const merged = mergeSeries(ours, theirs);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].mergedPRs, 3);
+    assert.equal(merged[0].summary.mergedPRs, 3);
+  });
+
+  test("keeps the richer mergedPRs when ours is the richer (reverse ordering)", () => {
+    const ours = JSON.stringify([entry("2026-06-30", 5)]);
+    const theirs = JSON.stringify([entry("2026-06-30", 0)]);
+    const merged = mergeSeries(ours, theirs);
+    assert.equal(merged[0].mergedPRs, 5);
+    assert.equal(merged[0].summary.mergedPRs, 5);
+  });
+
+  test("unions distinct days, preserving each side's entries (sorted by date)", () => {
+    const ours = JSON.stringify([entry("2026-06-29", 1), entry("2026-06-30", 0)]);
+    const theirs = JSON.stringify([entry("2026-06-30", 2), entry("2026-07-01", 4)]);
+    const merged = mergeSeries(ours, theirs);
+    assert.deepEqual(
+      merged.map((e) => e.date),
+      ["2026-06-29", "2026-06-30", "2026-07-01"]
+    );
+    assert.equal(merged.find((e) => e.date === "2026-06-30").mergedPRs, 2);
+  });
+
+  test("727-12: a multi-day manual backfill survives a concurrent single-day refresh", () => {
+    // ours = a CI refresh that only knows today (poorer); theirs = a manual
+    // backfill carrying several richer days. The backfill days must survive.
+    const ours = JSON.stringify([entry("2026-06-30", 0)]);
+    const theirs = JSON.stringify([
+      entry("2026-06-27", 2),
+      entry("2026-06-28", 3),
+      entry("2026-06-29", 1),
+      entry("2026-06-30", 4),
+    ]);
+    const merged = mergeSeries(ours, theirs);
+    assert.deepEqual(
+      merged.map((e) => e.date),
+      ["2026-06-27", "2026-06-28", "2026-06-29", "2026-06-30"]
+    );
+    assert.equal(merged.find((e) => e.date === "2026-06-30").mergedPRs, 4);
+  });
+
+  test("treats a missing mergedPRs as 0 without crashing", () => {
+    const ours = JSON.stringify([{ date: "2026-06-30", source: "logged" }]);
+    const theirs = JSON.stringify([entry("2026-06-30", 2)]);
+    const merged = mergeSeries(ours, theirs);
+    assert.equal(merged[0].mergedPRs, 2);
+  });
+
+  test("an equal-count tie keeps the first argument's entry", () => {
+    const ours = JSON.stringify([entry("2026-06-30", 3, { source: "ours" })]);
+    const theirs = JSON.stringify([entry("2026-06-30", 3, { source: "theirs" })]);
+    const merged = mergeSeries(ours, theirs);
+    assert.equal(merged[0].source, "ours");
+    assert.equal(merged[0].mergedPRs, 3);
+  });
+
+  test("keeps the larger count when both same-day sides are non-zero", () => {
+    const ours = JSON.stringify([entry("2026-06-30", 2)]);
+    const theirs = JSON.stringify([entry("2026-06-30", 5)]);
+    const merged = mergeSeries(ours, theirs);
+    assert.equal(merged[0].mergedPRs, 5);
+    assert.equal(merged[0].summary.mergedPRs, 5);
+  });
+
+  test("throws on a non-array side so a malformed merge fails loudly", () => {
+    assert.throws(() => mergeSeries("{}", "[]"), /must be a JSON array/);
+    assert.throws(() => mergeSeries("[]", "5"), /must be a JSON array/);
+  });
+});

--- a/packages/monitor/package.json
+++ b/packages/monitor/package.json
@@ -5,7 +5,7 @@
   "description": "Daily build-resource monitor for Spem Player",
   "type": "module",
   "scripts": {
-    "test": "node --test monitor-resources.test.mjs render-burndown.test.mjs",
+    "test": "node --test merge-monitor-series.test.mjs monitor-resources.test.mjs render-burndown.test.mjs",
     "lint": "eslint . --max-warnings 0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #728

Two monitor workflow runs racing through the rebase-retry push could silently overwrite the day's `mergedPRs` value in `monitor-series.json`: the retry replayed a stale read over the newer entry.

The merge is now value-preserving. A dedicated driver (`packages/monitor/merge-monitor-series.mjs`, with unit tests) merges the series entry by entry instead of replaying the whole file, and the shared push helper (`.github/scripts/push-with-rebase.sh`, with its own test and CI workflow) routes the retry through it. `doc/CI.md` and `doc/MONITOR.md` describe the new pieces.
