### PR TITLE
perf(scores): split rebuild invalidation and parallelise LilyPond renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 .worktree-offset
 node_modules
 dist
+# Kept raw LilyPond renders (#760): the un-postprocessed source of each SVG,
+# used to re-postprocess without re-rendering. An intermediate build artifact,
+# not committed — only the postprocessed SVGs under scores/ are tracked.
+packages/pwa/src/scores/**/.raw/
 *.ipynb
 *.pdf
 # Local Netlify folder

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -58,9 +58,11 @@ Serves the contents of `dist/` locally.
 ## Regenerate SVG Scores
 
 The SVG files in `packages/pwa/src/scores/` are generated from LilyPond source files in
-`packages/scores/src/`. They are committed to git as source assets. `pnpm run build`
-regenerates them automatically via the `prebuild` step when `.ly` sources are
-newer than the generated SVGs.
+`packages/scores/src/` and committed to git as source assets. Regenerate them with
+`pnpm run build:scores` locally, or let the **Scores CI** workflow
+(`.github/workflows/scores-ci.yml`) rebuild and commit them when a push changes
+`packages/scores/**`. The app build (`pnpm run build`, and Netlify) uses the committed
+SVGs and does not regenerate them.
 
 To build scores manually:
 
@@ -75,13 +77,15 @@ pnpm run build:scores -- --choir="I A"
 pnpm run build:scores -- --version="Hugh Keyte" --notation=early --choir="II B"
 ```
 
-This iterates over matching `Choir*.ly` files under `packages/scores/src/` and runs `lilypond --svg` for each, then post-processes the generated SVG with `packages/scores/build/postprocessSvg.mjs`.
+This iterates over matching `Choir*.ly` files under `packages/scores/src/`, runs `lilypond --svg` for each in a small parallel pool, and post-processes each render with `packages/scores/build/postprocessSvg.mjs`. The raw LilyPond render is kept alongside the final SVG under a gitignored `.raw/` directory, so a change to the postprocessor re-applies by re-postprocessing the kept raw in seconds instead of re-running LilyPond.
 
-LilyPond is invoked via `execFileSync` (no shell), so no option value — `--version`, `--notation`, `--outDir`, the resolved `.ly` path, or `LILYPOND_CMD` — can inject shell commands: each is passed as a literal argument. Separately, `--version` and `--notation` are whitelisted to their known values because they become output-directory path segments. By default the `lilypond` binary on `PATH` is used; set the `LILYPOND_CMD` environment variable to a JSON array to point at a wrapped install — for example `LILYPOND_CMD='["flatpak","run","org.lilypond.LilyPond"]'` or `LILYPOND_CMD='["wsl","lilypond"]'` (POSIX shell syntax; in PowerShell use `$env:LILYPOND_CMD='[...]'`). The array is `[binary, ...prefixArgs]`; the build appends LilyPond's own arguments.
+LilyPond is invoked via the `execFile` family (no shell) — promisified `execFile` for each render, `execFileSync` for the `--version` probe — so no option value — `--version`, `--notation`, `--outDir`, the resolved `.ly` path, or `LILYPOND_CMD` — can inject shell commands: each is passed as a literal argument. Separately, `--version` and `--notation` are whitelisted to their known values because they become output-directory path segments. By default the `lilypond` binary on `PATH` is used; set the `LILYPOND_CMD` environment variable to a JSON array to point at a wrapped install — for example `LILYPOND_CMD='["flatpak","run","org.lilypond.LilyPond"]'` or `LILYPOND_CMD='["wsl","lilypond"]'` (POSIX shell syntax; in PowerShell use `$env:LILYPOND_CMD='[...]'`). The array is `[binary, ...prefixArgs]`; the build appends LilyPond's own arguments.
 
 ### Timing
 
-LilyPond is the slow part: roughly 60 seconds per choir, 16 choirs across early + modern notations. When `.ly` sources are current, `pnpm run build:scores` (and the `prebuild` step inside `pnpm run build`) completes in a few seconds because `needsRebuild` compares mtimes and skips unchanged files. After a batch edit of `.ly` files — particularly shared includes (`basic.ly`, `layout.ly`) — expect the next full `pnpm run ci` to take 10+ minutes as the affected SVGs regenerate. This is a one-off; the next build after that is fast again.
+LilyPond is the slow part: roughly 60 seconds per choir, 16 choirs across early + modern notations, run in a bounded parallel pool (`availableParallelism()`, capped). When `.ly` sources are current, `pnpm run build:scores` completes in a few seconds because it compares mtimes and skips unchanged renders. A change to `postprocessSvg.mjs` alone re-postprocesses the kept `.raw/` renders (seconds) rather than re-running LilyPond. After a batch edit of `.ly` sources — particularly shared includes (`basic.ly`, `layout.ly`) — a full `pnpm run build:scores` (or the Scores CI rebuild) re-renders the affected SVGs; expect several minutes. This is a one-off; the next build is fast again.
+
+The kept-raw fast path is local-only: `.raw/` is gitignored, so a fresh checkout (including every Scores CI run) has none. CI still skips scores whose sources and the postprocessor are unchanged (the skip compares the committed SVG), and renders only the affected ones — but a change to `postprocessSvg.mjs` re-renders every score on CI, since there is no kept raw to re-postprocess from.
 
 To force a clean regeneration, delete the directory
 (`rm -rf packages/pwa/src/scores/`) and re-run `pnpm run build:scores`.

--- a/packages/scores/build/buildScores.mjs
+++ b/packages/scores/build/buildScores.mjs
@@ -2,11 +2,90 @@
 // Copyright (c) 2024-2026 Mark Wainwright
 // SPDX-License-Identifier: MIT
 
-import { execFileSync } from "child_process";
-import { existsSync, globSync, mkdirSync, realpathSync, rmSync, statSync } from "fs";
+import { execFile, execFileSync } from "child_process";
+import {
+  copyFileSync,
+  existsSync,
+  globSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+} from "fs";
+import { availableParallelism } from "os";
 import { basename, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
-import { postprocessSvg } from "./postprocessSvg.mjs";
+import { promisify } from "util";
+import { isMainModule, postprocessSvg } from "./postprocessSvg.mjs";
+
+const execFileAsync = promisify(execFile);
+
+// LilyPond renders are independent (distinct input and output) and the binary is
+// single-threaded, so the renders run through a bounded pool instead of a serial
+// loop (#760, part 2). Capped so memory stays bounded on a many-core host; the
+// render is the bottleneck, so a small pool recovers most of the idle cores.
+// `SCORES_CONCURRENCY` (a positive integer) overrides the pool size; it exists
+// mainly so a test can force serial vs parallel and compare output.
+function renderConcurrency() {
+  const raw = process.env.SCORES_CONCURRENCY;
+  if (raw !== undefined && raw !== "") {
+    const override = Number(raw);
+    if (Number.isInteger(override) && override > 0) {
+      return override;
+    }
+    console.error(
+      `Warning: ignoring invalid SCORES_CONCURRENCY=${raw} (want a positive integer).`
+    );
+  }
+  try {
+    return Math.max(1, Math.min(availableParallelism(), 4));
+  } catch (error) {
+    console.error(
+      `Warning: could not detect CPU count (${error?.message ?? error}); building scores serially.`
+    );
+    return 1;
+  }
+}
+
+/**
+ * One render job passed through the pool. `maxLyMtime` is per-notation and rides
+ * in the job; `version` and `outDirBase` are run-global and closed over.
+ * @typedef {{ ly: string, notation: string, maxLyMtime: number }} RenderJob
+ */
+
+/**
+ * Run `worker` over `items` with at most `concurrency` in flight. `concurrency`
+ * must be a positive integer. Fail-fast: on the first worker error, no further
+ * items are started; in-flight workers finish, then the first error is rethrown.
+ * Later concurrent errors are logged to stderr (only the first is rethrown), so
+ * a multi-failure run surfaces every root cause in one pass.
+ *
+ * @template T
+ * @param {T[]} items
+ * @param {(item: T) => Promise<void>} worker
+ * @param {number} concurrency
+ * @returns {Promise<void>}
+ */
+async function runPool(items, worker, concurrency) {
+  let index = 0;
+  let firstError = null;
+  async function runNext() {
+    while (index < items.length && !firstError) {
+      const item = items[index++];
+      try {
+        await worker(item);
+      } catch (error) {
+        if (!firstError) {
+          firstError = error;
+        } else {
+          console.error(`\n${error?.message ?? String(error)}`);
+        }
+      }
+    }
+  }
+  const lanes = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(Array.from({ length: lanes }, runNext));
+  if (firstError) throw firstError;
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = resolve(__dirname, "..");
@@ -14,8 +93,14 @@ const PACKAGE_ROOT = resolve(__dirname, "..");
 const POSTPROCESS_SVG_MTIME = (() => {
   try {
     return statSync(new URL("./postprocessSvg.mjs", import.meta.url)).mtimeMs;
-  } catch {
-    return 0;
+  } catch (error) {
+    // Fail safe, not open. finalNeedsRebuild gates the whole build on this value,
+    // so a `0` sentinel would silently skip a postprocessor change and ship stale
+    // finals. `Infinity` forces a rebuild instead (Vera 760, silent-failure pass 2).
+    console.error(
+      `Warning: could not read postprocessSvg.mjs mtime (${error?.message ?? error}); forcing a full rebuild.`
+    );
+    return Infinity;
   }
 })();
 
@@ -78,7 +163,7 @@ function validateOptions(options) {
 
   // Whitelist version/notation because they become directory-path segments in
   // the build output (resolve(outDirBase, version, notation)); this bounds them
-  // to known values. It is NOT the shell-injection defence — execFileSync (no
+  // to known values. It is NOT the shell-injection defence — execFile (no
   // shell) is, and that covers every argument regardless of this list. Omitted
   // (undefined/null) is fine — the defaults are applied later; bare flags (true)
   // are handled above (#624).
@@ -117,8 +202,10 @@ function compareVersions(a, b) {
  * Defaults to `["lilypond"]`. Override with the `LILYPOND_CMD` env var (a JSON
  * array of strings) to point at a wrapped install — e.g.
  * `["flatpak","run","org.lilypond.LilyPond"]`, `["wsl","lilypond"]`, or a test
- * fake `["node","/path/to/fake.js"]`. The command is always invoked via
- * `execFileSync` (no shell), so the override is not a shell-injection surface.
+ * fake `["node","/path/to/fake.js"]`. The command is always invoked via the
+ * `execFile` family (no shell) — `execFileSync` for the `--version` probe,
+ * promisified `execFile` for the render — so the override is not a
+ * shell-injection surface.
  */
 function lilypondCommand() {
   const raw = process.env.LILYPOND_CMD;
@@ -201,23 +288,57 @@ function maxLyMtimeFor(lyDir, versionDir) {
   return Math.max(...lyFiles.map((p) => statSync(p).mtimeMs));
 }
 
+// Rebuild is decided in two questions (#760). The expensive stage is the
+// LilyPond render; postprocessing the render is cheap. We keep the raw render
+// under `<outDir>/.raw/` (gitignored) so the two can invalidate independently:
+//   1. finalNeedsRebuild — is the committed final SVG stale vs its `.ly` sources
+//      or the postprocessor? If not, skip entirely. This keys off the FINAL,
+//      which is committed and present on a CI checkout, so an unchanged tree
+//      renders nothing even when no `.raw/` is present.
+//   2. rawNeedsRender — given the final must be (re)produced, are the sources
+//      newer than the kept raw? If so re-render, then postprocess; if the raw is
+//      already current, postprocess it in place with no render. A
+//      postprocessor-only change therefore re-postprocesses in seconds (locally,
+//      where `.raw/` persists) instead of re-running LilyPond 16 times.
+// Both gates use `>=` so an equal mtime forces the work: a strict `>` skips a
+// genuine change on coarse-granularity filesystems (the project's own W05
+// anti-pattern; RR item 4 folded in here).
+
 /**
- * Decide whether an SVG needs rebuilding.
+ * Decide whether the raw LilyPond render needs (re)producing.
  *
- * @param {number} maxLyMtime - the precomputed max mtime of the .ly files
- *   in scope for this SVG. Must be produced by `maxLyMtimeFor(lyDir,
- *   versionDir)` where `lyDir` is the notation directory containing the
- *   choir's `.ly` and `versionDir` is the edition root. Passing an
- *   out-of-scope mtime (e.g. another notation's) silently violates the
- *   over-approximation strategy described above `maxLyMtimeFor`.
- * @param {string} svgPath - path to the candidate SVG.
+ * @param {number} maxLyMtime - the precomputed max mtime of the .ly files in
+ *   scope for this SVG, from `maxLyMtimeFor(lyDir, versionDir)`. Passing an
+ *   out-of-scope mtime silently violates the over-approximation strategy above
+ *   `maxLyMtimeFor`.
+ * @param {string} rawPath - path to the candidate raw render.
+ * @returns {boolean} true when the raw is missing or older-or-equal than its sources.
  */
-function needsRebuild(maxLyMtime, svgPath) {
-  if (!existsSync(svgPath)) {
+function rawNeedsRender(maxLyMtime, rawPath) {
+  if (!existsSync(rawPath)) {
     return true;
   }
-  const svgMtime = statSync(svgPath).mtimeMs;
-  return maxLyMtime > svgMtime || POSTPROCESS_SVG_MTIME > svgMtime;
+  return maxLyMtime >= statSync(rawPath).mtimeMs;
+}
+
+/**
+ * Decide whether the final SVG needs (re)producing at all. It is stale when
+ * missing, older-or-equal than its `.ly` sources, or older-or-equal than the
+ * postprocessor. Keyed off the committed final so it holds on a CI checkout that
+ * has no `.raw/`, and it catches a final left stale by an interrupted build.
+ *
+ * @param {number} maxLyMtime - max mtime of the in-scope .ly files (see `rawNeedsRender`).
+ * @param {string} finalPath - path to the candidate final SVG.
+ * @param {number} [postprocessMtime] - mtime of the postprocessor script;
+ *   defaults to the module-load snapshot. Injectable for unit testing.
+ * @returns {boolean} true when the final is missing or stale.
+ */
+function finalNeedsRebuild(maxLyMtime, finalPath, postprocessMtime = POSTPROCESS_SVG_MTIME) {
+  if (!existsSync(finalPath)) {
+    return true;
+  }
+  const finalMtime = statSync(finalPath).mtimeMs;
+  return maxLyMtime >= finalMtime || postprocessMtime >= finalMtime;
 }
 
 /**
@@ -229,51 +350,103 @@ function buildPattern(lyDir, choir) {
   return choir ? `${lyDir}/Choir ${choir}.ly` : `${lyDir}/Choir*.ly`;
 }
 
-function buildScore(ly, version, notation, maxLyMtime, outDirBase) {
+/**
+ * Build one score: render its `.ly` to a kept raw SVG (only when stale), then
+ * postprocess the raw into the final SVG the app consumes. `async` because the
+ * render runs through promisified `execFile`. Mutates the filesystem: creates
+ * `.raw/` and the final SVG, and on failure removes the affected outputs.
+ * **Throws** an `Error` on a render or postprocess failure rather than calling
+ * `process.exit` — the caller (`runPool`/`main`) owns the exit, so the pool can
+ * fail-fast.
+ *
+ * @param {string} ly - path to the choir's `.ly` source.
+ * @param {string} version - edition name (a directory segment, e.g. "Hugh Keyte").
+ * @param {string} notation - notation name (a directory segment, e.g. "early").
+ * @param {number} maxLyMtime - max mtime of the in-scope `.ly` files for this notation.
+ * @param {string} outDirBase - the scores output root.
+ * @returns {Promise<void>}
+ */
+async function buildScore(ly, version, notation, maxLyMtime, outDirBase) {
   const choirName = basename(ly, ".ly");
   const outDir = resolve(outDirBase, version, notation);
-  const svg = resolve(outDir, `${choirName}.svg`);
+  const rawDir = resolve(outDir, ".raw");
+  const rawSvg = resolve(rawDir, `${choirName}.svg`);
+  const finalSvg = resolve(outDir, `${choirName}.svg`);
 
-  if (!needsRebuild(maxLyMtime, svg)) {
+  // Skip when the committed final is already current (works on CI, which has no
+  // `.raw/`). Otherwise re-render only when the raw is stale; a fresh raw is
+  // postprocessed in place.
+  if (!finalNeedsRebuild(maxLyMtime, finalSvg)) {
     console.log(
       `Skipping ${choirName} (edition: ${version}, notation: ${notation}): SVG is up to date.`
     );
     return;
   }
 
-  console.log(
-    `\nBuilding ${choirName} (edition: ${version}, notation: ${notation})...`
-  );
-  try {
-    // LilyPond does not create its output directory; on a clean checkout
-    // (src/scores/ is gitignored post-#318) it aborts. Create it first.
-    mkdirSync(outDir, { recursive: true });
-    // execFileSync (no shell) so user-controlled path segments in `outDir`
-    // (from --version/--notation/--outDir) and `ly` cannot break out of a quoted
-    // argument and inject shell commands (#624). Each value is passed literally.
-    const [bin, ...prefix] = lilypondCommand();
-    execFileSync(bin, [...prefix, "--svg", "-o", `${outDir}/`, ly], { stdio: "inherit" });
-  } catch (error) {
-    rmSync(svg, { force: true });
-    console.error(`\nError building ${choirName}:\n${error.message}`);
-    process.exit(1);
+  const render = rawNeedsRender(maxLyMtime, rawSvg);
+  if (render) {
+    console.log(
+      `Building ${choirName} (edition: ${version}, notation: ${notation})...`
+    );
+    try {
+      // LilyPond does not create its output directory (it aborts on a missing
+      // one), so create the raw dir first. execFile (no shell) so
+      // user-controlled path segments in `rawDir` (from --version/--notation/
+      // --outDir) and `ly` cannot break out of a quoted argument and inject
+      // shell commands (#624). Each value is passed literally. Output is
+      // buffered and printed on completion (below) so LilyPond's own output does
+      // not interleave between concurrent renders.
+      mkdirSync(rawDir, { recursive: true });
+      const [bin, ...prefix] = lilypondCommand();
+      const { stdout, stderr } = await execFileAsync(
+        bin,
+        [...prefix, "--svg", "-o", `${rawDir}/`, ly],
+        { maxBuffer: 32 * 1024 * 1024 }
+      );
+      if (stdout) process.stdout.write(stdout);
+      if (stderr) process.stderr.write(stderr);
+    } catch (error) {
+      // Build the diagnostic BEFORE cleanup: a cleanup rmSync that itself throws
+      // (an EBUSY/EPERM lock during a parallel build on Windows) must not clobber
+      // LilyPond's stderr, which is the actionable detail. Throw rather than exit
+      // so the pool can fail-fast; main() reports and exits.
+      const detail = [error.message, error.stderr, error.stdout]
+        .filter(Boolean)
+        .join("\n");
+      // The raw render failed, so both the partial raw and any stale final are
+      // now untrustworthy — remove both (the pre-#760 behaviour deleted the final
+      // on a failed render). Guarded so a cleanup fault cannot mask `detail`.
+      try {
+        rmSync(rawSvg, { force: true });
+        rmSync(finalSvg, { force: true });
+      } catch {
+        // ignore cleanup failure; the render error is what matters
+      }
+      throw new Error(`Error building ${choirName}:\n${detail}`);
+    }
   }
 
-  console.log(`Post-processing ${svg}...`);
+  // Postprocess the kept raw into the final path: copy raw -> final, then run
+  // the in-place postprocessor on the copy. The raw is preserved so a later
+  // postprocessor-only change re-postprocesses without re-rendering.
+  console.log(`Post-processing ${finalSvg}...`);
   try {
-    postprocessSvg(svg);
+    mkdirSync(outDir, { recursive: true });
+    copyFileSync(rawSvg, finalSvg);
+    postprocessSvg(finalSvg);
   } catch (error) {
     try {
-      rmSync(svg, { force: true });
+      rmSync(finalSvg, { force: true });
     } catch {
       // ignore cleanup failure
     }
-    console.error(`\nError post-processing ${svg}:\n${error.message}`);
-    process.exit(1);
+    throw new Error(
+      `Error post-processing ${finalSvg}:\n${error?.message ?? String(error)}`
+    );
   }
 }
 
-function main() {
+async function main() {
   const options = parseArgs();
   validateOptions(options);
 
@@ -285,6 +458,9 @@ function main() {
     ? [options.notation]
     : ["early", "modern"];
 
+  // Gather every (choir, notation) render into one flat job list, then run them
+  // through a bounded pool. maxLyMtime is still computed once per notation.
+  const jobs = [];
   for (const notation of notations) {
     const lyDir = resolve(srcRoot, version, notation);
     const versionDir = resolve(srcRoot, version);
@@ -307,20 +483,41 @@ function main() {
     }
 
     for (const ly of files.sort()) {
-      buildScore(ly, version, notation, maxLyMtime, outDirBase);
+      jobs.push({ ly, notation, maxLyMtime });
     }
+  }
+
+  try {
+    await runPool(
+      jobs,
+      (job) => buildScore(job.ly, version, job.notation, job.maxLyMtime, outDirBase),
+      renderConcurrency()
+    );
+  } catch (error) {
+    console.error(`\n${error.message ?? String(error)}`);
+    process.exit(1);
   }
 
   console.log("\nDone.");
 }
 
 // Only run main() when this file is invoked directly from the CLI, not when
-// imported by tests. `process.argv[1]` is undefined under some embed contexts;
-// treat that as "not main".
-const __filename = fileURLToPath(import.meta.url);
-const isMain = process.argv[1] && realpathSync(process.argv[1]) === realpathSync(__filename);
-if (isMain) {
-  main();
+// imported by tests. `isMainModule` (reused from the sibling postprocessSvg.mjs,
+// #555) treats a missing or non-existent `argv[1]` as "not main" rather than
+// throwing ENOENT at module scope.
+if (isMainModule(process.argv[1], import.meta.url)) {
+  main().catch((error) => {
+    console.error(`\n${error?.message ?? String(error)}`);
+    process.exit(1);
+  });
 }
 
-export { parseArgs, buildPattern, validateOptions, buildScore, lilypondCommand };
+export {
+  parseArgs,
+  buildPattern,
+  validateOptions,
+  buildScore,
+  lilypondCommand,
+  rawNeedsRender,
+  finalNeedsRebuild,
+};

--- a/packages/scores/build/postprocessSvg.mjs
+++ b/packages/scores/build/postprocessSvg.mjs
@@ -11,7 +11,7 @@
  * deduplicates repeated path shapes via <defs> and <use>.
  */
 
-import { readFileSync, realpathSync, writeFileSync } from "fs";
+import { readFileSync, realpathSync, statSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
@@ -26,6 +26,13 @@ const PART_INDICES = {
   Bass: 4,
 };
 
+// A build postprocesses all 16 SVGs in one process, each parsing the same two
+// large .ly files with identical arguments (#760 ride-along). Memoise the parse
+// keyed on path + pattern + mtime: a build reads each source once instead of 16
+// times, and the mtime in the key means an in-place edit is picked up rather
+// than served stale. The cached partMap is read-only for callers.
+const parseVariablesCache = new Map();
+
 /**
  * Parse a LilyPond file and return a list of [start_line, end_line, part_index].
  * @param {string} path
@@ -33,6 +40,12 @@ const PART_INDICES = {
  * @returns {[number, number, number][]}
  */
 function parseVariables(path, pattern) {
+  const key = JSON.stringify([path, pattern.source, statSync(path).mtimeMs]);
+  const cached = parseVariablesCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
   const text = readFileSync(path, "utf-8");
   const lines = text.split(/\r?\n/);
 
@@ -54,6 +67,11 @@ function parseVariables(path, pattern) {
     partMap.push([start, end, PART_INDICES[partName]]);
   }
 
+  // Freeze before caching: every caller shares this one reference, so a stray
+  // mutation would poison the cache for the rest of the build. Freeze turns the
+  // "read-only for callers" convention into a guarantee.
+  Object.freeze(partMap);
+  parseVariablesCache.set(key, partMap);
   return partMap;
 }
 

--- a/packages/scores/test/buildScores.integration.test.ts
+++ b/packages/scores/test/buildScores.integration.test.ts
@@ -92,6 +92,49 @@ fs.appendFileSync(logFile, args.join(" ") + "\\n", "utf-8");
 }
 
 /**
+ * Create a fake lilypond that logs every render (so invocations can be counted)
+ * and fails the render: for every choir when `failChoir` is undefined, or for
+ * the one whose input basename matches `failChoir`. Returns [node, helper] for
+ * LILYPOND_CMD. Used to exercise the pool's fail-fast and partial-failure paths.
+ */
+function createLoggingFailLilypond(failChoir?: string): string[] {
+  const fakeDir = mkdtempSync(join(tmpdir(), "spem-fail-lilypond-"));
+  const helperJs = join(fakeDir, "_fail_lilypond.js");
+  writeFileSync(
+    helperJs,
+    `const fs = require("fs");
+const path = require("path");
+const args = process.argv.slice(2);
+if (args.includes("--version")) {
+  console.log("GNU LilyPond 2.26.0 (running Guile 3.0)");
+  process.exit(0);
+}
+const outdirIdx = args.indexOf("-o");
+const outdir = outdirIdx >= 0 ? args[outdirIdx + 1] : ".";
+const infile = args[args.length - 1];
+const name = path.basename(infile, ".ly");
+const logFile = ${JSON.stringify(FAKE_LILYPOND_LOG)};
+fs.mkdirSync(path.dirname(logFile), { recursive: true });
+fs.appendFileSync(logFile, args.join(" ") + "\\n", "utf-8");
+const failChoir = ${JSON.stringify(failChoir ?? null)};
+if (failChoir === null || name === failChoir) {
+  process.stderr.write("fatal error: simulated failure for " + name + "\\n");
+  process.exit(2);
+}
+if (fs.existsSync(outdir)) {
+  fs.writeFileSync(
+    path.join(outdir, name + ".svg"),
+    '<?xml version="1.0" encoding="UTF-8"?>\\n<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"></svg>\\n',
+    "utf-8"
+  );
+}
+`,
+    "utf-8"
+  );
+  return [process.execPath, helperJs];
+}
+
+/**
  * Return an environment object that points LILYPOND_CMD at the fake lilypond
  * (driven as [node, helper], no shell) and makes node_modules visible via
  * NODE_PATH. The fake is no longer placed on PATH (#624).
@@ -612,7 +655,11 @@ describe("buildScores.mjs integration", () => {
     expect(result.stderr).toContain("--choir requires a value");
   });
 
-  it("rebuilds when postprocessSvg.mjs is newer (#393)", () => {
+  it("re-postprocesses without re-rendering when only postprocessSvg.mjs is newer (#760)", () => {
+    // Before #760 a postprocessor edit forced a full LilyPond re-render (all 16
+    // scores), because postprocessing overwrote the raw render in place. Now the
+    // raw render is kept under `.raw/`, so a postprocessor-only change is
+    // re-applied by postprocessing the kept raw — no lilypond invocation.
     const ws = createWorkspace();
     try {
       if (existsSync(FAKE_LILYPOND_LOG)) {
@@ -620,6 +667,10 @@ describe("buildScores.mjs integration", () => {
       }
 
       const script = join(ws, "packages", "scores", "build", "buildScores.mjs");
+      const finalSvg = join(
+        ws,
+        "packages", "pwa", "src", "scores", "Hugh Keyte", "early", "Choir I A.svg"
+      );
 
       // First run
       const result1 = spawnSync(process.execPath, [script], {
@@ -630,6 +681,7 @@ describe("buildScores.mjs integration", () => {
       expect(result1.status).toBe(0);
       const afterFirst = countScoreInvocations();
       expect(afterFirst).toBe(16);
+      const finalMtimeBefore = statSync(finalSvg).mtimeMs;
 
       // Touch postprocessSvg.mjs two seconds in the future
       const postprocessPath = join(ws, "packages", "scores", "build", "postprocessSvg.mjs");
@@ -644,8 +696,225 @@ describe("buildScores.mjs integration", () => {
       expect(result2.status).toBe(0);
       const afterSecond = countScoreInvocations();
 
-      // All scores should rebuild because postprocessor changed.
-      expect(afterSecond).toBe(afterFirst + 16);
+      // No new lilypond invocations: the kept raw is re-postprocessed only.
+      expect(afterSecond).toBe(afterFirst);
+      // The final SVG was rewritten (re-postprocessed), so its mtime advanced.
+      expect(statSync(finalSvg).mtimeMs).toBeGreaterThan(finalMtimeBefore);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("produces byte-identical output at serial and parallel concurrency (#760)", () => {
+    // Vera 760-11: SCORES_CONCURRENCY lets the test force serial (1) vs parallel
+    // (4) and compare. If the pool shared mutable state across lanes, the two
+    // would diverge; equality is the concurrency-safety guarantee. (The fake's
+    // bytes are fixed, so this pins pool safety, not LilyPond determinism — the
+    // latter is checked manually with real LilyPond.)
+    function buildAndCollect(concurrency: string): Map<string, string> {
+      const ws = createWorkspace();
+      try {
+        const result = spawnSync(
+          process.execPath,
+          [join(ws, "packages", "scores", "build", "buildScores.mjs")],
+          { cwd: ws, env: { ...env, SCORES_CONCURRENCY: concurrency }, encoding: "utf-8" }
+        );
+        expect(result.status).toBe(0);
+        const svgs = new Map<string, string>();
+        for (const notation of ["early", "modern"]) {
+          const dir = join(ws, "packages", "pwa", "src", "scores", "Hugh Keyte", notation);
+          for (const f of readdirSync(dir).filter((n) => n.endsWith(".svg"))) {
+            svgs.set(`${notation}/${f}`, readFileSync(join(dir, f), "utf-8"));
+          }
+        }
+        return svgs;
+      } finally {
+        rmSync(ws, { recursive: true, force: true });
+      }
+    }
+
+    const serial = buildAndCollect("1");
+    const parallel = buildAndCollect("4");
+    expect(serial.size).toBe(16);
+    expect([...parallel.keys()].sort()).toEqual([...serial.keys()].sort());
+    for (const [name, bytes] of serial) {
+      expect(parallel.get(name)).toBe(bytes);
+    }
+  }, 60000);
+
+  it("skips unchanged scores when only the final SVG is present (no .raw/, as on CI) (#760)", () => {
+    // Regression guard (Vera 760-01): CI checks out committed final SVGs but not
+    // the gitignored .raw/. The rebuild skip must key off the committed final vs
+    // its sources, not off .raw/ presence, or CI full-renders all 16 every run.
+    const ws = createWorkspace();
+    try {
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+      const script = join(ws, "packages", "scores", "build", "buildScores.mjs");
+
+      const r1 = spawnSync(process.execPath, [script], { cwd: ws, env, encoding: "utf-8" });
+      expect(r1.status).toBe(0);
+      expect(countScoreInvocations()).toBe(16);
+
+      // Simulate a fresh CI checkout: remove every .raw/ dir, keep the finals.
+      for (const notation of ["early", "modern"]) {
+        rmSync(join(ws, "packages", "pwa", "src", "scores", "Hugh Keyte", notation, ".raw"), {
+          recursive: true,
+          force: true,
+        });
+      }
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+
+      const r2 = spawnSync(process.execPath, [script], { cwd: ws, env, encoding: "utf-8" });
+      expect(r2.status).toBe(0);
+      // Sources unchanged and finals current, so nothing renders.
+      expect(countScoreInvocations()).toBe(0);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("re-postprocesses (not skips) a fresh raw left by an interrupted build (#760)", () => {
+    // Vera 760-02: a build killed after a lane renders its raw but before it
+    // copies/postprocesses leaves a fresh raw and a stale final. The next run
+    // must re-postprocess that score (final is stale vs its now-newer source),
+    // not skip it, and must do so without re-rendering (the raw is current).
+    const ws = createWorkspace();
+    try {
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+      const script = join(ws, "packages", "scores", "build", "buildScores.mjs");
+
+      const r1 = spawnSync(process.execPath, [script], { cwd: ws, env, encoding: "utf-8" });
+      expect(r1.status).toBe(0);
+      expect(countScoreInvocations()).toBe(16);
+
+      const earlyDir = join(ws, "packages", "pwa", "src", "scores", "Hugh Keyte", "early");
+      const finalSvg = join(earlyDir, "Choir I A.svg");
+      const rawSvg = join(earlyDir, ".raw", "Choir I A.svg");
+      const finalMtimeBefore = statSync(finalSvg).mtimeMs;
+
+      // Edit the choir's source (T+2s), then simulate its render having completed
+      // (raw at T+3s) with the copy/postprocess never run (final untouched).
+      const src = join(ws, "packages", "scores", "src", "Hugh Keyte", "early", "Choir I A.ly");
+      utimesSync(src, new Date(Date.now() + 2000), new Date(Date.now() + 2000));
+      utimesSync(rawSvg, new Date(Date.now() + 3000), new Date(Date.now() + 3000));
+
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+      const r2 = spawnSync(process.execPath, [script], { cwd: ws, env, encoding: "utf-8" });
+      expect(r2.status).toBe(0);
+
+      // Choir I A had a fresh raw, so it re-postprocesses with no render; the
+      // other 7 early scores have stale raws and do render.
+      expect(statSync(finalSvg).mtimeMs).toBeGreaterThan(finalMtimeBefore);
+      expect(countScoreInvocations()).toBe(7);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("fails fast: a failing render stops the pool before every job starts (#760)", () => {
+    // Vera 760-04: pin the pool's defining property. With concurrency forced to
+    // 2 and every render failing, fail-fast must start no more than the first
+    // wave; a serial run-everything loop would start all 16.
+    const ws = createWorkspace();
+    try {
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+      const script = join(ws, "packages", "scores", "build", "buildScores.mjs");
+      const failEnv = {
+        ...env,
+        SCORES_CONCURRENCY: "2",
+        LILYPOND_CMD: JSON.stringify(createLoggingFailLilypond()),
+      };
+
+      const result = spawnSync(process.execPath, [script], {
+        cwd: ws,
+        env: failEnv,
+        encoding: "utf-8",
+      });
+
+      expect(result.status).not.toBe(0);
+      // Fail-fast: at most the two in-flight lanes ran, not all 16.
+      expect(countScoreInvocations()).toBeLessThanOrEqual(2);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("surfaces the failure and spares good siblings on a partial failure (#760)", () => {
+    // Vera 760-05: one bad choir among good ones. The build exits non-zero and
+    // the failed choir's final is cleaned up, but a sibling that rendered before
+    // the abort keeps its output (its cleanup must not touch another job's file).
+    const ws = createWorkspace();
+    try {
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+      const script = join(ws, "packages", "scores", "build", "buildScores.mjs");
+      const failEnv = {
+        ...env,
+        SCORES_CONCURRENCY: "1",
+        LILYPOND_CMD: JSON.stringify(createLoggingFailLilypond("Choir II A")),
+      };
+
+      const result = spawnSync(process.execPath, [script], {
+        cwd: ws,
+        env: failEnv,
+        encoding: "utf-8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("simulated failure for Choir II A");
+      const earlyDir = join(ws, "packages", "pwa", "src", "scores", "Hugh Keyte", "early");
+      // Serial order (sorted) renders Choir I A before Choir II A, so I A's final
+      // exists and was not deleted by II A's cleanup; II A's final is gone.
+      expect(existsSync(join(earlyDir, "Choir I A.svg"))).toBe(true);
+      expect(existsSync(join(earlyDir, "Choir II A.svg"))).toBe(false);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("re-postprocesses a deleted final from the kept raw with no render (#760)", () => {
+    // Vera 760-06: the other postprocess-only trigger — published output deleted,
+    // sources and postprocessor unchanged. The final must reappear from the kept
+    // raw without invoking lilypond.
+    const ws = createWorkspace();
+    try {
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+      const script = join(ws, "packages", "scores", "build", "buildScores.mjs");
+
+      const r1 = spawnSync(process.execPath, [script], { cwd: ws, env, encoding: "utf-8" });
+      expect(r1.status).toBe(0);
+      expect(countScoreInvocations()).toBe(16);
+
+      const finalSvg = join(
+        ws, "packages", "pwa", "src", "scores", "Hugh Keyte", "early", "Choir I A.svg"
+      );
+      rmSync(finalSvg);
+      if (existsSync(FAKE_LILYPOND_LOG)) rmSync(FAKE_LILYPOND_LOG);
+
+      const r2 = spawnSync(process.execPath, [script], { cwd: ws, env, encoding: "utf-8" });
+      expect(r2.status).toBe(0);
+      expect(existsSync(finalSvg)).toBe(true);
+      // Reproduced from the kept raw: no lilypond invocation.
+      expect(countScoreInvocations()).toBe(0);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  }, 60000);
+
+  it("keeps a gitignorable raw render alongside the final SVG (#760)", () => {
+    const ws = createWorkspace();
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [join(ws, "packages", "scores", "build", "buildScores.mjs")],
+        { cwd: ws, env, encoding: "utf-8" }
+      );
+      expect(result.status).toBe(0);
+
+      const earlyDir = join(ws, "packages", "pwa", "src", "scores", "Hugh Keyte", "early");
+      // Final SVGs live at the notation root; raw renders are kept under .raw/.
+      expect(countSvgs(earlyDir)).toBe(8);
+      expect(existsSync(join(earlyDir, ".raw", "Choir I A.svg"))).toBe(true);
+      expect(countSvgs(join(earlyDir, ".raw"))).toBe(8);
     } finally {
       rmSync(ws, { recursive: true, force: true });
     }

--- a/packages/scores/test/buildScores.security.test.ts
+++ b/packages/scores/test/buildScores.security.test.ts
@@ -1,22 +1,38 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 // buildScore must shell out without a shell, so mock the exec layer and the
-// fs/postprocess touchpoints it hits between entry and the exec call.
+// fs/postprocess touchpoints it hits between entry and the exec call. The render
+// runs through promisified execFile (#760), so the mock invokes execFile's
+// callback to resolve; execSync/execFileSync stay mocked to assert neither is
+// used.
 vi.mock("child_process", () => ({
   execSync: vi.fn(),
   execFileSync: vi.fn(),
+  execFile: vi.fn((...args: unknown[]) => {
+    const cb = args[args.length - 1];
+    if (typeof cb === "function") {
+      (cb as (e: unknown, r: unknown) => void)(null, { stdout: "", stderr: "" });
+    }
+  }),
 }));
-// existsSync:false makes needsRebuild() short-circuit true at its first check,
+// existsSync:false makes rawNeedsRender() short-circuit true at its first check,
 // so buildScore skips the real statSync and reaches the (mocked) exec call;
-// mkdirSync is stubbed because buildScore creates the output dir before exec.
+// mkdirSync/copyFileSync are stubbed because buildScore creates the output dir
+// and copies the raw render to the final path before postprocessing (#760).
 vi.mock("fs", async (importOriginal) => ({
   ...(await importOriginal<typeof import("fs")>()),
   existsSync: () => false,
   mkdirSync: () => undefined,
+  copyFileSync: () => undefined,
 }));
-vi.mock("../build/postprocessSvg.mjs", () => ({ postprocessSvg: vi.fn() }));
+// isMainModule is stubbed to false so importing buildScores.mjs does not run
+// main() during the test (buildScores now guards its entry with it, #760/#555).
+vi.mock("../build/postprocessSvg.mjs", () => ({
+  postprocessSvg: vi.fn(),
+  isMainModule: () => false,
+}));
 
-import { execSync, execFileSync } from "child_process";
+import { execSync, execFileSync, execFile } from "child_process";
 import {
   validateOptions,
   buildScore,
@@ -152,11 +168,14 @@ describe("lilypondCommand LILYPOND_CMD parsing (#624)", () => {
 });
 
 describe("buildScore shells out without a shell (#624)", () => {
-  it("invokes execFileSync with an argument array, never a shell string", () => {
-    buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out");
+  // The render now runs through promisified execFile (#760), so buildScore is
+  // async and the no-shell guarantee is asserted against execFile — the array
+  // form and literal-argument property are unchanged from the execFileSync era.
+  it("invokes execFile with an argument array, never a shell string", async () => {
+    await buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out");
 
-    expect(execFileSync).toHaveBeenCalledTimes(1);
-    const [cmd, args, opts] = vi.mocked(execFileSync).mock.calls[0];
+    expect(execFile).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = vi.mocked(execFile).mock.calls[0];
     expect(cmd).toBe("lilypond");
     expect(Array.isArray(args)).toBe(true);
     expect(args).toContain("--svg");
@@ -168,18 +187,19 @@ describe("buildScore shells out without a shell (#624)", () => {
     // every assertion above would still pass — so pin it explicitly (Vera 624-S1).
     expect((opts as { shell?: unknown } | undefined)?.shell).toBeFalsy();
 
-    // The vulnerable form interpolated everything into one execSync string.
+    // Neither the sync exec APIs nor the vulnerable execSync string form run.
     expect(execSync).not.toHaveBeenCalled();
+    expect(execFileSync).not.toHaveBeenCalled();
   });
 
-  it("passes a metacharacter-laden outDir to execFileSync as one literal arg (#624)", () => {
+  it("passes a metacharacter-laden outDir to execFile as one literal arg (#624)", async () => {
     // outDir flows from --outDir (deliberately not whitelisted, since it is a
-    // real user path). execFileSync (no shell) must pass it literally, so a
+    // real user path). execFile (no shell) must pass it literally, so a
     // shell-metacharacter value cannot inject. Pins the bug class against a
     // future revert to a template string on the -o argument (Vera 624-06).
-    buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out; touch pwned");
+    await buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out; touch pwned");
 
-    const args = vi.mocked(execFileSync).mock.calls[0][1] as string[];
+    const args = vi.mocked(execFile).mock.calls[0][1] as string[];
     const outArg = args[args.indexOf("-o") + 1];
     expect(outArg).toContain("; touch pwned"); // survived as a literal segment
     expect(outArg).toContain("Hugh Keyte");
@@ -188,12 +208,12 @@ describe("buildScore shells out without a shell (#624)", () => {
     expect(execSync).not.toHaveBeenCalled();
   });
 
-  it("honours a LILYPOND_CMD override as [binary, ...prefix] (#624)", () => {
+  it("honours a LILYPOND_CMD override as [binary, ...prefix] (#624)", async () => {
     const prev = process.env.LILYPOND_CMD;
     process.env.LILYPOND_CMD = JSON.stringify(["node", "/fake/helper.js"]);
     try {
-      buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out");
-      const [cmd, args] = vi.mocked(execFileSync).mock.calls[0];
+      await buildScore("/src/Choir I A.ly", "Hugh Keyte", "early", 0, "/out");
+      const [cmd, args] = vi.mocked(execFile).mock.calls[0];
       expect(cmd).toBe("node");
       expect(args?.[0]).toBe("/fake/helper.js");
       expect(args).toContain("--svg");

--- a/packages/scores/test/buildScores.test.ts
+++ b/packages/scores/test/buildScores.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { parseArgs, buildPattern } from "../build/buildScores.mjs";
+import { afterEach, describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  parseArgs,
+  buildPattern,
+  rawNeedsRender,
+  finalNeedsRebuild,
+} from "../build/buildScores.mjs";
 
 describe("parseArgs", () => {
   it("returns defaults when given no arguments", () => {
@@ -59,5 +67,94 @@ describe("buildPattern", () => {
     expect(buildPattern("lilypond/src/Hugh Keyte/early", "I A")).toBe(
       "lilypond/src/Hugh Keyte/early/Choir I A.ly"
     );
+  });
+});
+
+// The rebuild decision is split (#760): a raw render is only redone when the
+// sources are newer than the kept raw SVG; the postprocess step is only redone
+// when the raw was re-rendered, the final is missing, or the postprocessor is
+// newer than the final. Both gates use `>=` so an equal mtime forces the work
+// (the RR item-4 tie fix folded in — a coarse-FS tie must not skip a rebuild).
+describe("rawNeedsRender", () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function svgAt(mtimeMs: number): string {
+    dir = mkdtempSync(join(tmpdir(), "spem-rebuild-"));
+    const p = join(dir, "raw.svg");
+    writeFileSync(p, "<svg/>", "utf-8");
+    const when = new Date(mtimeMs);
+    utimesSync(p, when, when);
+    return p;
+  }
+
+  it("renders when the raw SVG is missing", () => {
+    expect(rawNeedsRender(1000, join(tmpdir(), "does-not-exist-760.svg"))).toBe(
+      true
+    );
+  });
+
+  it("does not render when the raw is strictly newer than its sources", () => {
+    const raw = svgAt(20000);
+    expect(rawNeedsRender(19000, raw)).toBe(false);
+  });
+
+  it("renders when a source is strictly newer than the raw", () => {
+    const raw = svgAt(20000);
+    expect(rawNeedsRender(21000, raw)).toBe(true);
+  });
+
+  it("renders on an equal mtime (tie forces a rebuild, RR item 4)", () => {
+    const raw = svgAt(20000);
+    expect(rawNeedsRender(20000, raw)).toBe(true);
+  });
+});
+
+describe("finalNeedsRebuild", () => {
+  let dir: string;
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function finalAt(mtimeMs: number): string {
+    dir = mkdtempSync(join(tmpdir(), "spem-final-"));
+    const p = join(dir, "final.svg");
+    writeFileSync(p, "<svg/>", "utf-8");
+    const when = new Date(mtimeMs);
+    utimesSync(p, when, when);
+    return p;
+  }
+
+  it("rebuilds when the final SVG is missing", () => {
+    expect(
+      finalNeedsRebuild(1000, join(tmpdir(), "no-final-760.svg"), 1)
+    ).toBe(true);
+  });
+
+  it("does not rebuild when the final is strictly newer than sources and postprocessor", () => {
+    const final = finalAt(30000);
+    expect(finalNeedsRebuild(29000, final, 29000)).toBe(false);
+  });
+
+  it("rebuilds when a source is strictly newer than the final", () => {
+    const final = finalAt(30000);
+    expect(finalNeedsRebuild(31000, final, 1)).toBe(true);
+  });
+
+  it("rebuilds when the postprocessor is strictly newer than the final", () => {
+    const final = finalAt(30000);
+    expect(finalNeedsRebuild(1, final, 31000)).toBe(true);
+  });
+
+  it("rebuilds on an equal source mtime (tie forces a rebuild, RR item 4)", () => {
+    const final = finalAt(30000);
+    expect(finalNeedsRebuild(30000, final, 1)).toBe(true);
+  });
+
+  it("rebuilds on an equal postprocessor mtime (tie forces a rebuild, RR item 4)", () => {
+    const final = finalAt(30000);
+    expect(finalNeedsRebuild(1, final, 30000)).toBe(true);
   });
 });

--- a/packages/scores/test/postprocessSvg.test.ts
+++ b/packages/scores/test/postprocessSvg.test.ts
@@ -1,7 +1,21 @@
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { afterAll, beforeAll, describe, it, expect, vi } from "vitest";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { postprocessSvg } from "../build/postprocessSvg.mjs";
+
+// Spy on readFileSync while leaving every other fs export real, so the
+// parseVariables memo (#760) can be checked by counting source-file reads.
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
 
 describe("postprocessSvg build script", () => {
   const tmpDir = mkdtempSync(join(tmpdir(), "spem-annotate-test-"));
@@ -141,5 +155,64 @@ wordsIABass = \\lyricmode { Spem }
     // Defence in depth: exactly one data-part in the output.
     const dataParts = output.match(/data-part="\d+"/g) || [];
     expect(dataParts).toEqual(['data-part="0"']);
+  });
+});
+
+describe("parseVariables memo (#760)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "spem-memo-test-"));
+  const spem = join(dir, "spem.ly");
+  const words = join(dir, "spem words.ly");
+  const svgA = join(dir, "A.svg");
+  const svgB = join(dir, "B.svg");
+
+  const spemLy = `notesIASoprano = \\relative c' { c4 }
+notesIAAlto = \\relative c' { c4 }
+`;
+  const wordsLy = `wordsIASoprano = \\lyricmode { la }\n`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <a xlink:href="spem.ly:1:1:1"><path d="M0,0 L1,1"/></a>
+</svg>`;
+
+  beforeAll(() => {
+    writeFileSync(spem, spemLy, "utf-8");
+    writeFileSync(words, wordsLy, "utf-8");
+    writeFileSync(svgA, svg, "utf-8");
+    writeFileSync(svgB, svg, "utf-8");
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function countReads(path: string): number {
+    return vi
+      .mocked(readFileSync)
+      .mock.calls.filter((c) => c[0] === path).length;
+  }
+
+  it("reads each source .ly once across repeated postprocess calls", () => {
+    vi.mocked(readFileSync).mockClear();
+
+    // Two SVGs postprocessed against the same source files: without the memo
+    // each source .ly is read twice; the memo reads each once.
+    postprocessSvg(svgA, spem, words);
+    postprocessSvg(svgB, spem, words);
+
+    expect(countReads(spem)).toBe(1);
+    expect(countReads(words)).toBe(1);
+  });
+
+  it("re-reads a source .ly after it changes (mtime-keyed, no stale memo)", () => {
+    // Prime the memo, then change the file and bump its mtime: the memo must
+    // miss and re-read rather than return the stale parse.
+    postprocessSvg(svgA, spem, words);
+    vi.mocked(readFileSync).mockClear();
+
+    writeFileSync(spem, spemLy + "notesIATenor = \\relative c' { c4 }\n", "utf-8");
+    const future = new Date(Date.now() + 2000);
+    utimesSync(spem, future, future);
+
+    postprocessSvg(svgB, spem, words);
+    expect(countReads(spem)).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #760

A full score rebuild re-rendered and re-postprocessed every SVG even when only the postprocess step had changed, and the LilyPond renders ran serially.

Two cuts to that cost: invalidation is split so a postprocess-only change no longer forces a LilyPond re-render (the render cache keys the two stages separately), and the renders that are needed run in parallel. `packages/scores/build/buildScores.mjs` and `postprocessSvg.mjs` carry the change, with unit, integration and security tests updated alongside; `doc/BUILD.md` describes the split.

Note: this PR is `expensive` (it touches the score build, so merging busts the SVG cache and forces one full re-render).
