### PR TITLE
fix: honour control changes during the audio load window

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.9",
+  "version": "2.8.10",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {

--- a/packages/pwa/src/test/controls.test.ts
+++ b/packages/pwa/src/test/controls.test.ts
@@ -655,4 +655,224 @@ describe("MusicControls custom element", () => {
 
     cancelSpy.mockRestore();
   });
+
+  // #764: while a new file is loading, play() holds playing=false across the
+  // await, so a control change arriving mid-load sees isPlaying()===false and is
+  // dropped; audio then resumes on the stale file. The fix adds an in-flight
+  // signal (reload guards fire during a load) and a generation counter (a stale
+  // play() resolution no-ops).
+  describe("play() load-window race (#764)", () => {
+    // A deferred play() mock we settle by hand, so the load window can be held
+    // open across further control changes. In a real browser a play() promise
+    // whose load is interrupted by a new load()/pause() REJECTS with AbortError,
+    // so both a resolve and a reject handle are exposed per call.
+    let playResolvers: Array<() => void>;
+    let playRejecters: Array<(reason?: unknown) => void>;
+
+    beforeEach(() => {
+      playResolvers = [];
+      playRejecters = [];
+      vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementation(
+        () =>
+          new Promise<void>((resolve, reject) => {
+            playResolvers.push(resolve);
+            playRejecters.push(reject);
+          })
+      );
+    });
+
+    afterEach(() => {
+      // Re-apply the suite-wide immediate stub for later tests. mockRestore()
+      // would expose the real (jsdom-unimplemented) play(), so re-stub instead.
+      vi.spyOn(HTMLMediaElement.prototype, "play").mockReturnThis();
+    });
+
+    // Put the element in a loaded, playing choir-part state without opening a
+    // load window (a choir-part file, not default.mp3, so a later change reloads).
+    function loadedAndPlaying(elem: MusicControls): void {
+      elem.setPart(0); // Soprano
+      elem.setChoir(0); // Choir 1
+      elem.audio.src = "http://localhost/audio/ALC/Choir%201-Soprano.mp3";
+      elem.playing = true;
+    }
+
+    const last = <T>(a: T[]): T => a[a.length - 1];
+
+    it("a control change during the load window reloads the latest selection", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      loadedAndPlaying(elem);
+      let playingEvents = 0;
+      elem.addEventListener("music-controls-playing", () => playingEvents++);
+
+      // Choir 2: a new file, so play() opens the load window and awaits.
+      elem.setChoir(1);
+      await Promise.resolve();
+      expect(playResolvers.length).toBe(1);
+
+      // Choir 3 arrives mid-load. Without the fix, playing===false drops it and
+      // audio stays on Choir 2.
+      elem.setChoir(2);
+      await Promise.resolve();
+      expect(decodeURIComponent(elem.audio.src)).toContain("Choir 3-Soprano");
+
+      // Resolve the STALE load alone: the generation guard must swallow it, so
+      // no state flip while the newer call is still pending. (Resolving both
+      // would pass whether or not the guard exists, so this isolates it.)
+      playResolvers[0]();
+      await Promise.resolve();
+      expect(elem.playing).toBe(false);
+      expect(playingEvents).toBe(0);
+
+      // The latest load resolving is the one that flips state.
+      last(playResolvers)();
+      await Promise.resolve();
+      expect(elem.playing).toBe(true);
+      expect(playingEvents).toBe(1);
+
+      elem.pause();
+    });
+
+    it("a superseded load REJECTING (AbortError) does not disturb the newer call", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      const spinner = document.getElementById("spinner");
+      const play = document.getElementById("play");
+      loadedAndPlaying(elem);
+
+      elem.setChoir(1); // opens the load window (stale call)
+      await Promise.resolve();
+      elem.setChoir(2); // supersedes mid-load (newer call)
+      await Promise.resolve();
+
+      // The stale play() rejects, as the browser aborts it on the new load. The
+      // catch's generation guard must leave the newer call's loading UI alone.
+      playRejecters[0](new DOMException("aborted", "AbortError"));
+      await Promise.resolve();
+      expect(elem.playing).toBe(false);
+      expect(spinner?.style.display).toBe("block");
+      expect(play?.style.display).toBe("none");
+
+      // The newer load then resolves and takes over cleanly.
+      last(playResolvers)();
+      await Promise.resolve();
+      expect(elem.playing).toBe(true);
+
+      elem.pause();
+    });
+
+    it("the current load REJECTING resets to the play icon", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      const play = document.getElementById("play");
+      loadedAndPlaying(elem);
+
+      elem.setChoir(1); // opens the load window (no supersession)
+      await Promise.resolve();
+
+      // The one in-flight (current-generation) play rejects, e.g. autoplay
+      // blocked: the UI resets to the play icon and playing stays false.
+      last(playRejecters)(new DOMException("blocked", "NotAllowedError"));
+      await Promise.resolve();
+      expect(elem.playing).toBe(false);
+      expect(play?.style.display).toBe("block");
+    });
+
+    it("rapid changes during the load window land on the latest selection", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      loadedAndPlaying(elem);
+
+      elem.setPart(1); // Alto: opens the load window
+      await Promise.resolve();
+      elem.setPart(2); // Tenor
+      elem.setPart(3); // Baritone, in quick succession
+      await Promise.resolve();
+
+      expect(decodeURIComponent(elem.audio.src)).toContain("Choir 1-Baritone");
+
+      last(playResolvers)();
+      await Promise.resolve();
+      expect(elem.playing).toBe(true);
+
+      elem.pause();
+    });
+
+    it("a recording change during the load window reloads the latest selection", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      loadedAndPlaying(elem);
+
+      elem.setChoir(1); // opens the load window on ALC
+      await Promise.resolve();
+      elem.setRecording(1); // CotE arrives mid-load
+      await Promise.resolve();
+
+      expect(decodeURIComponent(elem.audio.src)).toContain("/CotE/");
+
+      last(playResolvers)();
+      await Promise.resolve();
+      expect(elem.playing).toBe(true);
+
+      elem.pause();
+    });
+
+    it("a control change while paused and idle does not start playback", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      // Fresh element: not playing, not loading. #intendsToPlay() is false, so
+      // the reload guard must not fire and no play() may run.
+      elem.setChoir(1);
+      await Promise.resolve();
+      expect(playResolvers.length).toBe(0);
+      expect(elem.playing).toBe(false);
+    });
+
+    it("shows the loading icon for the duration of the load window", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      const spinner = document.getElementById("spinner");
+      const play = document.getElementById("play");
+      loadedAndPlaying(elem);
+
+      elem.setChoir(1); // opens the load window
+      await Promise.resolve();
+      expect(spinner?.style.display).toBe("block");
+      expect(play?.style.display).toBe("none");
+
+      last(playResolvers)();
+      await Promise.resolve();
+      const pause = document.getElementById("pause");
+      expect(pause?.style.display).toBe("block");
+
+      elem.pause();
+    });
+
+    it("pause during the load window cancels the pending play", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      const play = document.getElementById("play");
+      loadedAndPlaying(elem);
+
+      elem.setChoir(1); // opens the load window
+      await Promise.resolve();
+
+      elem.pause();
+      // The in-flight play() resolving after pause must not resume playback.
+      playResolvers[0]();
+      await Promise.resolve();
+
+      expect(elem.playing).toBe(false);
+      expect(play?.style.display).toBe("block");
+    });
+
+    it("a control change after a mid-load pause does not restart playback", async () => {
+      const elem = document.querySelector("music-controls") as MusicControls;
+      loadedAndPlaying(elem);
+
+      elem.setChoir(1); // opens the load window
+      await Promise.resolve();
+      elem.pause(); // clears #loading as well as bumping the generation
+
+      // #intendsToPlay() must now be false, so a later control change starts no
+      // new play(). If pause() left #loading true, this would silently restart
+      // the playback the user just paused.
+      elem.setChoir(2);
+      await Promise.resolve();
+      expect(playResolvers.length).toBe(1); // no second load window opened
+      expect(elem.playing).toBe(false);
+    });
+  });
 });

--- a/packages/pwa/src/ts/MusicControls.ts
+++ b/packages/pwa/src/ts/MusicControls.ts
@@ -28,6 +28,13 @@ export class MusicControls extends MusicElement {
   #isLooping = false;
   #loopId = 0;
 
+  // #loading is true while a play() call is awaiting audio.play() (the audio is
+  // not yet audible but the user intends playback); #playGeneration tags each
+  // play() call so a superseded one no-ops on resolve instead of flipping the UI
+  // back to the stale file/state (#764).
+  #playGeneration = 0;
+  #loading = false;
+
   #showIcon(state: "play" | "pause" | "loading"): void {
     if (!this.svgPlay || !this.svgPause || !this.svgLoading) return;
     this.svgPlay.style.display = state === "play" ? "block" : "none";
@@ -233,6 +240,11 @@ export class MusicControls extends MusicElement {
   }
 
   async play() {
+    // Tag this call so a later play() (or pause) can supersede it: a control
+    // change arriving during the load window starts its own play(), and only
+    // the latest call may update the UI when it resolves (#764).
+    const gen = ++this.#playGeneration;
+
     // Load the new audio if necessary
     const newfile = this.getMP3filename();
     if (!this.isSameAudio(newfile)) {
@@ -247,43 +259,65 @@ export class MusicControls extends MusicElement {
       this.audio.currentTime = getTimeFromBar(this.bar, this.recording);
     }
 
+    this.#loading = true;
+
     try {
       await this.audio.play();
     } catch {
+      // A superseded call (a mid-load control change bumped the generation)
+      // leaves the UI to the newer call; only the current call resets on a
+      // genuine reject (e.g. autoplay blocked).
+      if (gen !== this.#playGeneration) return;
       this.#showIcon("play");
       this.playing = false;
+      this.#loading = false;
       return;
     }
 
+    // A control change (or pause) during the load window bumped the generation;
+    // that newer call owns the state, so this stale resolution stops here.
+    if (gen !== this.#playGeneration) return;
     this.playing = true;
     this.#showIcon("pause");
     this.fireEvent("music-controls-playing");
+    this.#loading = false;
 
     if (this.#isLooping) return;
     this.#isLooping = true;
 
-    const self = this;
+    const loop = () => {
+      this.bar = getBarFromTime(this.audio.currentTime, this.recording);
 
-    function loop() {
-      self.bar = getBarFromTime(self.audio.currentTime, self.recording);
-
-      const intbar = Math.floor(self.bar);
-      if (self.barinput && Number(self.barinput.value) != intbar) {
-        self.barinput.value = String(intbar);
+      const intbar = Math.floor(this.bar);
+      if (this.barinput && Number(this.barinput.value) != intbar) {
+        this.barinput.value = String(intbar);
       }
-      self.fireEvent("music-controls-changed");
+      this.fireEvent("music-controls-changed");
 
-      if (self.isPlaying()) {
-        self.#loopId = window.requestAnimationFrame(loop);
+      if (this.isPlaying()) {
+        this.#loopId = window.requestAnimationFrame(loop);
       } else {
-        self.#isLooping = false;
+        this.#isLooping = false;
       }
-    }
+    };
     this.#loopId = window.requestAnimationFrame(loop);
+  }
+
+  // The user intends playback either while audio is audible (playing) or while a
+  // play() call is still awaiting audio.play() (#loading, not yet audible). The
+  // reload guards fire on this, so a mid-load control change reloads (#764).
+  #intendsToPlay(): boolean {
+    return this.playing || this.#loading;
   }
 
   pause() {
     this.playing = false;
+    // Bumping the generation makes any in-flight play()'s resolution guard fail,
+    // so its await no-ops instead of flipping the UI back to "playing". Clearing
+    // #loading separately resets #intendsToPlay() so a control change after this
+    // pause does not restart playback (#764).
+    this.#playGeneration++;
+    this.#loading = false;
     this.#isLooping = false;
     window.cancelAnimationFrame(this.#loopId);
     this.#showIcon("play");
@@ -296,14 +330,14 @@ export class MusicControls extends MusicElement {
     super.setChoir(c);
 
     this.choirselect.value = String(this.choir);
-    if (this.isPlaying()) this.play();
+    if (this.#intendsToPlay()) this.play();
   }
 
   setRecording(v: number | string): void {
     super.setRecording(v);
     this.#buildChoirDropdown();
     this.audio.currentTime = getTimeFromBar(this.bar, this.recording);
-    if (this.isPlaying()) this.play();
+    if (this.#intendsToPlay()) this.play();
   }
 
   setPart(p: string | number) {
@@ -311,7 +345,7 @@ export class MusicControls extends MusicElement {
     super.setPart(p);
 
     this.partselect.value = String(p);
-    if (this.isPlaying()) this.play();
+    if (this.#intendsToPlay()) this.play();
   }
 
   setBar(b: string | number) {


### PR DESCRIPTION
Fixes #764

Control changes made while the audio was still loading were silently discarded. `play()` set `playing = false` while awaiting the load, so a choir, part or bar change during that window (and a second press of play) was overwritten when the load resolved, leaving the UI showing one state and the player in another.

The load window is now guarded: state changes made during it are honoured when the load completes rather than clobbered. `MusicControls.ts` carries the fix, with the cases pinned in `controls.test.ts`.
