### PR TITLE
fix: derive feedback status at read time instead of a stored mirror

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -70,7 +70,11 @@ The central `State` interface (`packages/pwa/src/ts/common.ts`) tracks:
 - `choir` — 0 to 7
 - `part` — `"all"` or 0 to 4
 - `bar` — 0 to 139
-- `status` — `"playing"`, `"paused"`, or `"loading"`
+
+Playback status is not stored on `State`. The `Status` type
+(`"playing" | "paused" | "loading"`) is still exported, but the value is derived
+at read time from the audio element (`deriveFeedbackStatus()` in `index.ts`) when
+the feedback payload is built, so it cannot drift stale.
 
 State changes flow through `index.ts` helpers (`setChoir()`, `setPart()`, `setBar()`), which set
 attributes on elements. Components react via `attributeChangedCallback` and fire custom events

--- a/packages/pwa/index.ts
+++ b/packages/pwa/index.ts
@@ -9,6 +9,7 @@ import {
   MusicEventDetail,
   PartType,
   State,
+  Status,
   colors,
   toNum,
   toRecordingIndex,
@@ -85,7 +86,6 @@ var current: State = {
   choir: 0,
   part: "all",
   bar: 0,
-  status: "paused",
 };
 
 // TODO: Change dark mode to moon/sun icons
@@ -449,6 +449,25 @@ function showFeedbackResult(message: string) {
   setTimeout(() => showFeedback(false), 1500);
 }
 
+// Derive the playback status from the audio element at read time, rather than
+// mirroring it into a stored State field that every handler must remember to
+// update (the field was the stale-status bug this replaces). networkState is
+// checked first: it reports NETWORK_LOADING through the whole fetch, including
+// the load window where play() has already flipped audio.paused to false, so a
+// paused-first order would misreport a loading track as playing. The trade is
+// that mid-play buffering (a not-yet-fully-fetched track that is audibly
+// playing) also reads "loading"; the audio element alone cannot tell that from
+// the pre-play load window. Distinguishing them needs MusicControls' own state
+// (a status() getter) — deferred to a follow-up. Guard the controls read so a
+// missing element degrades to a default rather than throwing and dropping a
+// feedback submit, matching updateFeedbackContext's other null-guards.
+function deriveFeedbackStatus(): Status {
+  const audio = controls?.audio;
+  if (!audio) return "paused";
+  if (audio.networkState === HTMLMediaElement.NETWORK_LOADING) return "loading";
+  return audio.paused ? "paused" : "playing";
+}
+
 function updateFeedbackContext() {
   if (!hiddenFeedbackForm) return;
   const contextInput = hiddenFeedbackForm.querySelector<HTMLInputElement>(
@@ -462,7 +481,7 @@ function updateFeedbackContext() {
     bar: current.bar,
     viewmode: current.viewmode,
     period: current.period,
-    status: current.status,
+    status: deriveFeedbackStatus(),
     userAgent: navigator.userAgent,
     viewport: `${window.innerWidth}x${window.innerHeight}`,
   };

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/src/test/feedback.test.ts
+++ b/packages/pwa/src/test/feedback.test.ts
@@ -184,3 +184,91 @@ describe("Feedback modal", () => {
     });
   });
 });
+
+describe("Feedback context playback status (derived)", () => {
+  // Fresh app instance for this block. setupIntegrationFixture calls
+  // vi.resetModules() and re-imports "../../index.ts"; we re-import the same
+  // specifier for a cache hit on that live module so updateFeedbackContext()
+  // reads the same `controls` instance we drive here.
+  let idx: typeof import("../../index.ts");
+  let audio: HTMLAudioElement;
+
+  beforeAll(async () => {
+    await setupIntegrationFixture(() => {
+      document.body.insertAdjacentHTML(
+        "beforeend",
+        `<form name="feedback" netlify netlify-honeypot="bot-field" hidden>
+          <input type="hidden" name="bot-field" />
+          <input type="number" name="rating" />
+          <input type="hidden" name="context" />
+          <textarea name="message"></textarea>
+        </form>`
+      );
+    });
+    idx = await import("../../index.ts");
+    audio = (document.querySelector("music-controls") as MusicControls).audio;
+  }, 30000);
+
+  afterEach(() => {
+    // Restore any per-test getter overrides on the shared audio element.
+    for (const p of ["paused", "networkState"]) {
+      delete (audio as unknown as Record<string, unknown>)[p];
+    }
+  });
+
+  // The feedback status is derived from the audio element at read time, so drive
+  // the element's own getters rather than dispatching control events.
+  function stubAudio(
+    props: Partial<Record<"paused" | "networkState", unknown>>
+  ) {
+    for (const [key, value] of Object.entries(props)) {
+      Object.defineProperty(audio, key, {
+        get: () => value,
+        configurable: true,
+      });
+    }
+  }
+
+  function contextStatus(): string {
+    idx.exportedForTesting.updateFeedbackContext();
+    const contextInput = document.querySelector<HTMLInputElement>(
+      'form[name="feedback"] input[name="context"]'
+    );
+    return JSON.parse(contextInput!.value).status as string;
+  }
+
+  it("defaults to paused when idle (nothing loaded)", () => {
+    expect(contextStatus()).toBe("paused");
+  });
+
+  it("reports playing when the audio element is playing", () => {
+    stubAudio({ paused: false, networkState: HTMLMediaElement.NETWORK_IDLE });
+    expect(contextStatus()).toBe("playing");
+  });
+
+  it("reports paused when the audio element is paused", () => {
+    stubAudio({ paused: true, networkState: HTMLMediaElement.NETWORK_IDLE });
+    expect(contextStatus()).toBe("paused");
+  });
+
+  it("reports loading while the audio element is fetching a track", () => {
+    stubAudio({
+      paused: true,
+      networkState: HTMLMediaElement.NETWORK_LOADING,
+    });
+    expect(contextStatus()).toBe("loading");
+  });
+
+  it("reports loading during mid-play buffering (networkState precedence)", () => {
+    // play() flips audio.paused to false before its promise resolves, so the
+    // real load window is (paused: false, NETWORK_LOADING) — the same signature
+    // as buffering an already-playing track. networkState is checked first so
+    // the load window reads "loading"; the cost is that mid-play buffering does
+    // too. Pin that precedence so a reorder cannot silently regress the window.
+    stubAudio({
+      paused: false,
+      networkState: HTMLMediaElement.NETWORK_LOADING,
+    });
+    expect(contextStatus()).toBe("loading");
+  });
+});

--- a/packages/pwa/src/ts/common.ts
+++ b/packages/pwa/src/ts/common.ts
@@ -77,7 +77,6 @@ export type State = {
   choir: number;
   part: PartType;
   bar: number;
-  status: Status;
 };
 
 export interface Colors {


### PR DESCRIPTION
Fixes #772

The feedback payload always reported the playback status as `paused`, whatever the player was actually doing. `State.status` was declared and read, but nothing ever wrote to it, so the field sat at its initial value and every feedback report carried it.

The fix removes the stored mirror rather than adding a write to it. `State` no longer carries `status`; the value is derived at read time from the audio element, in `deriveFeedbackStatus()`, at the moment the feedback payload is built. A value that cannot be stored cannot go stale. The `Status` union type is kept as the derivation's return type.

`doc/CONTRIBUTING.md` is updated to describe the derivation, since it documented the removed field.
