### PR TITLE
test: fail e2e tests on captured page errors

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -124,6 +124,27 @@ Coverage reports are written to the `coverage/` directory. This directory is git
 
 End-to-end tests run in a real browser using Playwright. They live in `e2e/` and follow the naming convention `*.spec.ts`.
 
+### Page-error capture
+
+Every spec imports `test` and `expect` from `e2e/helpers/page-errors.ts`, not
+from `@playwright/test` (enforced by a scoped ESLint `no-restricted-imports`
+rule). That module wraps `test` with an automatic per-test fixture that
+collects uncaught page exceptions and unhandled rejections (`pageerror`),
+console errors, and `/audio/` requests that fail, return >=400, or whose 2xx
+response lacks an `audio/*` content-type (SPA hosting serves a missing file as
+200 text/html, so content-type, not status, is the reliable signal), and fails
+the test at
+teardown if any arrived. Playwright's default semantics ignore all three
+channels, so without the fixture a test can pass while the page under it is
+broken. `e2e/page-errors.spec.ts` is the fixture's self-test: each positive
+case injects one error class and polls the capture array, and a final
+`test.fail()`-annotated case pins that a non-empty capture fails at teardown.
+If a spec ever legitimately produces a captured message, add a narrow,
+commented entry to the module's `ALLOWLIST` (the current entries cover
+third-party script hosts that are absent or DNS-blocked in test environments)
+rather than reverting the import. Service workers are blocked suite-wide
+(`playwright.config.ts`) so page-level network events stay observable.
+
 ### E2E Prerequisites
 
 The production build must exist before e2e tests run:

--- a/packages/pwa/e2e/bar-navigation.spec.ts
+++ b/packages/pwa/e2e/bar-navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 test.describe("Bar navigation boundary wrapping", () => {
   test("ArrowRight from bar 139 wraps to bar 0", async ({ page }) => {

--- a/packages/pwa/e2e/computed-style.spec.ts
+++ b/packages/pwa/e2e/computed-style.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 import {
   getComputedStyleValue,
   expectComputedStyle,

--- a/packages/pwa/e2e/feedback-modal.spec.ts
+++ b/packages/pwa/e2e/feedback-modal.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 test.describe("Feedback modal mobile viewport", () => {
   test("does not overflow horizontally on iPhone SE viewport (375px)", async ({ page }) => {

--- a/packages/pwa/e2e/helpers/page-errors.ts
+++ b/packages/pwa/e2e/helpers/page-errors.ts
@@ -1,0 +1,134 @@
+import { test as base, expect } from "@playwright/test";
+
+/**
+ * Page-error capture fixture (#775).
+ *
+ * Playwright's default semantics ignore uncaught page exceptions, unhandled
+ * rejections, and console errors — none fail a test. That is a false-green
+ * channel here: MusicControls updates the asserted UI (the play/pause icon)
+ * before firing its events, so an exception in a `music-controls-*` listener
+ * silently kills that listener's per-frame updates (dispatchEvent does not
+ * propagate listener exceptions), and an exception in the rAF callback kills
+ * the playback loop outright — either way every icon assertion stays green.
+ * The un-mocked audio load is likewise silent on a 404 or decode failure.
+ *
+ * Scope: listeners attach to the per-test `page` fixture only. Popups, pages
+ * opened via context.newPage(), and dedicated workers are NOT captured. No
+ * spec opens any of these today; a spec that does must wire its extra pages
+ * explicitly. Service workers are blocked suite-wide (playwright.config.ts
+ * `serviceWorkers: "block"`) — an active SW would intercept requests and
+ * bypass page-level network events on Chromium, blinding the /audio/ channel.
+ *
+ * This module wraps `test` with an automatic per-test fixture that collects:
+ *
+ * - `pageerror` — uncaught exceptions and unhandled rejections in the page;
+ * - `console.error` — error-level console messages;
+ * - failed `/audio/` requests, and `/audio/` responses that are >=400, or 2xx
+ *   without an `audio/*` content-type (SPA hosting serves index.html with 200
+ *   for a missing file, so content-type, not status, is the reliable signal;
+ *   3xx hops and 304 revalidations are exempt).
+ *
+ * and fails the test at teardown if any arrived. Every spec imports
+ * `test`/`expect` from this module instead of `@playwright/test`.
+ *
+ * If a spec ever legitimately produces one of these (none does today), add an
+ * explicit, commented entry to ALLOWLIST rather than reverting its import —
+ * silent suppression is the failure mode this fixture exists to remove.
+ */
+
+// Substrings of captured messages that are expected and must not fail a test.
+// Keep each entry commented with the reason and keep it as narrow as the URL.
+const ALLOWLIST: string[] = [
+  // Third-party scripts loaded by index.html are routinely absent or
+  // DNS-blocked in test environments (net::ERR_NAME_NOT_RESOLVED); their
+  // load failure is environmental, not an app defect. Matched on the URL
+  // suffix this fixture appends, so the entries are browser-agnostic.
+  "at https://static.cloudflareinsights.com/",
+  "at https://www.googletagmanager.com/",
+  "at https://cdnjs.buymeacoffee.com/",
+];
+
+// "/audio/" mirrors config.audio_prefix (src/ts/config.ts, value pinned by
+// src/test/config.test.ts). If that prefix ever changes — or if hosting ever
+// implements SPA fallback by redirecting /audio/ off-path, whose final hop
+// this filter would no longer match — update this too, or the audio channel
+// guards a dead path silently.
+function isAudioUrl(url: string): boolean {
+  try {
+    return new URL(url).pathname.startsWith("/audio/");
+  } catch {
+    return false;
+  }
+}
+
+export const test = base.extend<{ pageErrorCapture: readonly string[] }>({
+  pageErrorCapture: [
+    async ({ page }, use) => {
+      const captured: string[] = [];
+      const record = (entry: string) => {
+        if (!ALLOWLIST.some((allowed) => entry.includes(allowed))) {
+          captured.push(entry);
+        }
+      };
+
+      page.on("pageerror", (err) => {
+        record(`pageerror: ${err.message}`);
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") {
+          // Include the source URL: resource-load failures ("Failed to load
+          // resource") carry the failing URL only in location, not the text.
+          const loc = msg.location().url;
+          record(`console.error: ${msg.text()}${loc ? ` (at ${loc})` : ""}`);
+        }
+      });
+      page.on("requestfailed", (req) => {
+        if (isAudioUrl(req.url())) {
+          record(
+            `audio request failed: ${req.url()} (${req.failure()?.errorText})`
+          );
+        }
+      });
+      page.on("response", (res) => {
+        if (!isAudioUrl(res.url())) return;
+        // A missing audio file does NOT 404 under SPA hosting: vite preview
+        // (and Netlify) fall back to index.html with 200 text/html, so the
+        // status check alone is blind to the main real-world failure class.
+        // A non-audio/* body on a 2xx /audio/ response is wrong; 3xx hops and
+        // 304 revalidations legitimately carry no content-type (probe-verified
+        // against vite preview, which serves audio with ETag + no-cache) and
+        // are exempt — the followed-to or originally-cached response is the
+        // one that gets content-type-checked.
+        const contentType = res.headers()["content-type"] ?? "";
+        if (
+          res.status() >= 400 ||
+          (res.status() < 300 && !contentType.startsWith("audio/"))
+        ) {
+          record(
+            `audio response ${res.status()} (${contentType || "no content-type"}): ${res.url()}`
+          );
+        }
+      });
+
+      await use(captured);
+
+      // Flush in-transit events before asserting: event delivery from the
+      // browser to the Playwright client is asynchronous, and protocol
+      // responses are ordered after events already raised on the session, so
+      // this no-op round trip delivers any events the browser had already
+      // raised. The catch is deliberate — at teardown the page may already
+      // be unusable, and a flush failure must not replace the real verdict.
+      await page.evaluate(() => undefined).catch(() => {});
+
+      expect(
+        captured,
+        "errors captured during the test (pageerror / console.error / audio " +
+          "request) — see e2e/helpers/page-errors.ts; allowlist only what a " +
+          "spec legitimately produces"
+      ).toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/packages/pwa/e2e/lightmode-contrast.spec.ts
+++ b/packages/pwa/e2e/lightmode-contrast.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 import {
   getComputedStyleValue,
   expectComputedStyleNot,

--- a/packages/pwa/e2e/page-errors.spec.ts
+++ b/packages/pwa/e2e/page-errors.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from "./helpers/page-errors";
+
+// Self-test for the page-error capture fixture (#775).
+//
+// Capture-pinning cases are POSITIVE tests: inject one error class, poll the
+// exposed capture array until the entry arrives (event delivery to the
+// Playwright client is asynchronous; a fixed sleep raced on firefox), then
+// clear the array so the fixture's teardown assertion passes. A dead capture
+// channel times the poll out and fails its test red. Do NOT wrap these in
+// test.fail(): it inverts ANY failure, including the poll timeout, which is
+// exactly how a capture regression would hide (Vera 775-01).
+//
+// The final case pins the other direction — that a non-empty capture actually
+// fails the test at teardown. It is test.fail()-annotated and deliberately
+// never asserts in its body (its wait is a Node-side sleep, so a page crash
+// cannot reject it), leaving the fixture's teardown assertion as the failure
+// source — goto/evaluate infrastructure failures excepted, which every other
+// spec would catch as a dead server. Healthy fixture -> teardown fails ->
+// expected failure (green); capture or teardown regressed -> body and
+// teardown both pass -> "unexpectedly passed" -> red.
+
+// Deliberate bypass of the readonly exposure: the positive cases must reset
+// the array after verifying capture so their teardown passes. Specs must
+// never do this; the readonly type forbids it everywhere else. The flush
+// round trip first (same trick as the fixture's teardown) delivers any
+// correlated twin event still in transit — e.g. an aborted fetch raises both
+// requestfailed and a console error — so the clear cannot slice between the
+// pair and leave the twin to fail teardown.
+async function flushAndClear(
+  page: import("@playwright/test").Page,
+  captured: readonly string[]
+): Promise<void> {
+  await page.evaluate(() => undefined).catch(() => {});
+  (captured as string[]).length = 0;
+}
+
+test.describe("page-error capture fixture (self-test)", () => {
+  test("captures an uncaught page exception", async ({
+    page,
+    pageErrorCapture,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      setTimeout(() => {
+        throw new Error("page-errors self-test: injected exception");
+      }, 0);
+    });
+    await expect
+      .poll(() =>
+        pageErrorCapture.some((e) => e.includes("injected exception"))
+      )
+      .toBe(true);
+    await flushAndClear(page, pageErrorCapture);
+  });
+
+  test("captures an unhandled promise rejection", async ({
+    page,
+    pageErrorCapture,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      void Promise.reject(
+        new Error("page-errors self-test: injected rejection")
+      );
+    });
+    await expect
+      .poll(() =>
+        pageErrorCapture.some((e) => e.includes("injected rejection"))
+      )
+      .toBe(true);
+    await flushAndClear(page, pageErrorCapture);
+  });
+
+  test("captures a console.error", async ({ page, pageErrorCapture }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      console.error("page-errors self-test: injected console error");
+    });
+    await expect
+      .poll(() =>
+        pageErrorCapture.some((e) => e.includes("injected console error"))
+      )
+      .toBe(true);
+    await flushAndClear(page, pageErrorCapture);
+  });
+
+  test("does not capture an allowlisted message", async ({
+    page,
+    pageErrorCapture,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      console.error(
+        "allowlist probe at https://static.cloudflareinsights.com/beacon.min.js"
+      );
+      console.error("page-errors self-test: sentinel after allowlisted");
+    });
+    // The sentinel arriving proves the console channel processed both
+    // messages in order; the allowlisted one must have been filtered out,
+    // not merely delayed.
+    await expect
+      .poll(() =>
+        pageErrorCapture.some((e) => e.includes("sentinel after allowlisted"))
+      )
+      .toBe(true);
+    expect(pageErrorCapture.some((e) => e.includes("allowlist probe"))).toBe(
+      false
+    );
+    await flushAndClear(page, pageErrorCapture);
+  });
+
+  test("captures a missing audio file (SPA fallback serves non-audio)", async ({
+    page,
+    pageErrorCapture,
+  }) => {
+    // Under SPA hosting a missing mp3 returns 200 text/html (index.html
+    // fallback), not 404 — verified against vite preview. The fixture flags
+    // the wrong content-type, whatever the status.
+    await page.goto("/");
+    await page.evaluate(() =>
+      fetch("/audio/__page-errors-self-test__.mp3").catch(() => undefined)
+    );
+    await expect
+      .poll(() =>
+        pageErrorCapture.some((e) =>
+          e.includes("__page-errors-self-test__.mp3")
+        )
+      )
+      .toBe(true);
+    await flushAndClear(page, pageErrorCapture);
+  });
+
+  test("captures a network-failed /audio/ request", async ({
+    page,
+    pageErrorCapture,
+  }) => {
+    await page.goto("/");
+    await page.route("**/audio/__page-errors-abort__.mp3", (route) =>
+      route.abort()
+    );
+    await page.evaluate(() =>
+      fetch("/audio/__page-errors-abort__.mp3").catch(() => undefined)
+    );
+    await expect
+      .poll(() =>
+        pageErrorCapture.some((e) => e.includes("__page-errors-abort__.mp3"))
+      )
+      .toBe(true);
+    await flushAndClear(page, pageErrorCapture);
+  });
+
+  test("a non-empty capture fails the test at teardown", async ({
+    page,
+    pageErrorCapture,
+  }) => {
+    test.fail();
+    await page.goto("/");
+    await page.evaluate(() => {
+      console.error("page-errors self-test: teardown pin");
+    });
+    // Non-throwing wait: give the entry time to arrive without asserting.
+    // Node-side sleep, not page.waitForTimeout — the page-bound wait rejects
+    // if the page crashes mid-wait, and test.fail() would invert that into a
+    // green run without the teardown assertion ever being exercised.
+    // See the header comment for the two directions this case closes.
+    const deadline = Date.now() + 3000;
+    while (pageErrorCapture.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  });
+});

--- a/packages/pwa/e2e/playback-toggle.spec.ts
+++ b/packages/pwa/e2e/playback-toggle.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 test.describe("Playback keyboard toggle", () => {
   test("Space toggles play and pause", async ({ page }) => {

--- a/packages/pwa/e2e/pwa-update-toast.spec.ts
+++ b/packages/pwa/e2e/pwa-update-toast.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 test.describe("PWA update toast accessibility", () => {
   test("focus moves to the refresh button when the toast appears", async ({ page }) => {

--- a/packages/pwa/e2e/smoke.spec.ts
+++ b/packages/pwa/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 test.describe("Spem Player smoke tests", () => {
   test("page loads with all custom elements", async ({ page }) => {

--- a/packages/pwa/e2e/splitter-cursor.spec.ts
+++ b/packages/pwa/e2e/splitter-cursor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 /**
  * Regression test for #709 — while dragging the splitter, the resize cursor

--- a/packages/pwa/e2e/tooltip.spec.ts
+++ b/packages/pwa/e2e/tooltip.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 test.describe("Header tooltip positioning", () => {
   test("tooltip is horizontally centred under its icon", async ({ page }) => {

--- a/packages/pwa/e2e/touch-drag.spec.ts
+++ b/packages/pwa/e2e/touch-drag.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./helpers/page-errors";
 
 /**
  * Regression tests for #317 — touch drag on the canvas overview must not

--- a/packages/pwa/eslint.config.js
+++ b/packages/pwa/eslint.config.js
@@ -55,6 +55,24 @@ export default tseslint.config(
     },
   },
   {
+    // Every e2e spec must take test/expect from the page-error capture
+    // fixture (e2e/helpers/page-errors.ts, #775): a spec importing them from
+    // @playwright/test compiles and runs green with the error-capture safety
+    // net silently absent, so the convention is enforced here rather than by
+    // review. allowTypeImports keeps type-only imports (e.g. Page) legal.
+    files: ['e2e/**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': ['error', {
+        paths: [{
+          name: '@playwright/test',
+          importNames: ['test', 'expect'],
+          message: 'Import test/expect from ./helpers/page-errors (see doc/TESTING.md § Page-error capture).',
+          allowTypeImports: true,
+        }],
+      }],
+    },
+  },
+  {
     // .gitignore is honoured via includeIgnoreFile above; only paths that are
     // NOT gitignored need listing here. tests-local/ and probes/ are local-only
     // (.git/info/exclude, not .gitignore); .dependency-cruiser.cjs is tracked.

--- a/packages/pwa/playwright.config.ts
+++ b/packages/pwa/playwright.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
   use: {
     baseURL: `http://localhost:${PREVIEW_PORT}`,
     trace: "on-first-retry",
+    // Block service-worker registration in e2e. The built app's SW claims the
+    // page immediately (workbox clientsClaim/skipWaiting), and SW-intercepted
+    // requests bypass page-level network events on Chromium, which blinds the
+    // page-error fixture's /audio/ channel (e2e/helpers/page-errors.ts, #775)
+    // and makes network-dependent tests SW-state-dependent. No spec exercises
+    // the real SW (pwa-update-toast.spec.ts drives the __pwaShowUpdateToast
+    // test hook); remove this deliberately if one ever must.
+    serviceWorkers: "block",
   },
   projects: [
     {


### PR DESCRIPTION
Fixes #775

An e2e test could pass while the page it was driving threw errors. Playwright reports assertion failures, but an uncaught page error, a `console.error`, or a mis-served audio file left no mark on the run, so a genuine crash could hide behind a green suite.

Every spec now imports `test` and `expect` from a shared fixture, `e2e/helpers/page-errors.ts`, which captures three channels (uncaught page errors, `console.error`, and wrong content-type responses under `/audio/`) and asserts they are empty at teardown. A new `page-errors.spec.ts` covers the fixture itself. An ESLint rule enforces the import convention, so a future spec cannot quietly opt out by importing Playwright directly. Service workers are blocked suite-wide in `playwright.config.ts`, since their console noise is not the application's.

An allowlist is provided for the errors we knowingly tolerate, so the assertion stays honest rather than being switched off.

`doc/TESTING.md` documents the fixture and the import convention.
