### PR TITLE
fix(netlify): force build when CACHED_COMMIT_REF is empty (#809)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,13 +5,22 @@
 #
 # Ignore: skip the build when none of the listed paths changed. Exits 0
 # (skip) if no differences; exits 1 (build) if any path changed.
-# packages/scores/src/ is intentionally excluded — .ly changes trigger the
-# Scores CI workflow (#462) which commits updated SVGs, and the SVG commit
-# then triggers Netlify.
+#
+# The empty-$CACHED_COMMIT_REF guard is essential (#809): when Netlify passes
+# an empty cached ref (no prior successful production deploy), the bare
+# `git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF` degenerates to comparing
+# the checked-out commit against itself, always reports "no change", and skips
+# — a self-perpetuating loop that froze production at 2.8.3. Force a build
+# whenever the cached ref is empty.
+#
+# packages/scores/src/lily IS watched because since #804 the PWA build consumes
+# its precomputed lilyData.json. The rest of packages/scores/src is excluded —
+# .ly changes trigger the Scores CI workflow (#462) which commits updated SVGs,
+# and the SVG commit then triggers Netlify.
 [build]
   command = "pnpm run build"
   publish = "packages/pwa/dist"
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- packages/pwa/index.ts packages/pwa/src/ts packages/pwa/src/scss packages/pwa/src/ohmjs packages/pwa/src/scores packages/pwa/public packages/pwa/index.html packages/pwa/vite.config.ts packages/pwa/package.json pnpm-lock.yaml netlify.toml"
+  ignore = "if [ -z \"$CACHED_COMMIT_REF\" ]; then exit 1; fi; git diff --quiet \"$CACHED_COMMIT_REF\" \"$COMMIT_REF\" -- packages/pwa/index.ts packages/pwa/src/ts packages/pwa/src/scss packages/pwa/src/ohmjs packages/pwa/src/scores packages/pwa/public packages/pwa/index.html packages/pwa/vite.config.ts packages/pwa/package.json packages/scores/src/lily pnpm-lock.yaml netlify.toml"
   functions = "netlify/functions"
 
   ## Uncomment to use this redirect for Single Page Applications like create-react-app.


### PR DESCRIPTION
Fixes #809.

## Problem

Production has been frozen at PWA **2.8.3** while `main` reached **2.8.10**. Every merged PWA PR since then built fine as a deploy preview, then got auto-cancelled at merge with:

> Failed during stage 'checking build content for changes': Canceled build due to no content change

That stage is the `build.ignore` command. When Netlify passes an **empty `$CACHED_COMMIT_REF`** (no prior successful production deploy), `git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- …` degenerates to comparing the checked-out commit against itself → always "no change" → skip. The cached ref only advances on a *successful* deploy, so once stuck it never recovers — a self-perpetuating loop. Deploy previews are immune (Netlify seeds their cached ref with the PR base).

## Change

- **Guard the empty cached ref**: `if [ -z "$CACHED_COMMIT_REF" ]; then exit 1; fi; …` forces a build instead of skipping.
- **Watch `packages/scores/src/lily`**: since #804 the PWA build consumes its precomputed `lilyData.json`; changes there must not be skipped.
- Quoted the refs and updated the explanatory comment.

## Validation

Simulated the new command against real history:

| scenario | expected | result |
|---|---|---|
| empty `$CACHED_COMMIT_REF` | build | ✅ rc=1 |
| PWA change (#804) | build | ✅ rc=1 |
| scores/src/lily change | build | ✅ rc=1 |
| adjacent monitor-only commits | skip | ✅ rc=0 |

## ⚠️ Manual step required after merge

This rule cannot take effect until it is itself deployed, but deploying is exactly what's being skipped (chicken-and-egg). After merge, run **Netlify UI → Trigger deploy → Clear cache and deploy site** once. That publishes current `main` (→ 2.8.10) and sets `$CACHED_COMMIT_REF`, after which the rule self-heals every future deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)