### PR TITLE
fix: toggle play/pause on NumpadEnter

### DIFF
--- a/packages/pwa/index.ts
+++ b/packages/pwa/index.ts
@@ -325,11 +325,7 @@ function keyboardTapped(e: KeyboardEvent) {
     return;
   }
 
-  if (e.code == "Enter") {
-    controls.isPlaying() ? controls.pause() : controls.play();
-    return;
-  }
-  if (e.code == "Space") {
+  if (e.code === "Enter" || e.code === "NumpadEnter" || e.code === "Space") {
     controls.isPlaying() ? controls.pause() : controls.play();
     return;
   }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.11",
+  "version": "2.8.12",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/src/test/keyboard.test.ts
+++ b/packages/pwa/src/test/keyboard.test.ts
@@ -31,6 +31,23 @@ describe("keyboard shortcuts", () => {
     expect(controls.isPlaying()).toBe(false);
   });
 
+  it("NumpadEnter toggles play/pause when focus is on the document body (#711)", async () => {
+    const controls = document.querySelector("music-controls") as MusicControls;
+    controls.playing = false;
+
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { code: "NumpadEnter", bubbles: true })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controls.isPlaying()).toBe(true);
+
+    document.body.dispatchEvent(
+      new KeyboardEvent("keydown", { code: "NumpadEnter", bubbles: true })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controls.isPlaying()).toBe(false);
+  });
+
   it("Space does not toggle play/pause when an input element is focused", () => {
     const controls = document.querySelector("music-controls") as MusicControls;
     const input = document.createElement("input");
@@ -344,6 +361,22 @@ describe("keyboard shortcuts", () => {
       document.body.dispatchEvent(
         new KeyboardEvent("keydown", {
           code: "Enter",
+          bubbles: true,
+          repeat: true,
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(controls.isPlaying()).toBe(false);
+    });
+
+    it("held NumpadEnter does not toggle play/pause (#711)", async () => {
+      const controls = document.querySelector(
+        "music-controls"
+      ) as MusicControls;
+      controls.playing = false;
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "NumpadEnter",
           bubbles: true,
           repeat: true,
         })


### PR DESCRIPTION
Fixes #711

The Enter key on the numeric keypad did not toggle play/pause. The main Enter key and the space bar did.

The keyboard handler matches on the event's `code`, and the keypad's Enter reports `NumpadEnter`, not `Enter`, so it fell through unhandled. Someone driving playback from the keypad had no way to start or stop it from there.

`NumpadEnter` now joins `Enter` and `Space` in the play/pause branch, and the two duplicated branches collapse into one. The keyboard test covers the keypad path.
