### PR TITLE
refactor: add a compile-time exhaustiveness guard for music event typing

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.12",
+  "version": "2.8.13",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/src/test/musicelement.test.ts
+++ b/packages/pwa/src/test/musicelement.test.ts
@@ -1,6 +1,21 @@
 import { MusicElement } from "../ts/MusicElement";
 import { MusicControls } from "../ts/MusicControls";
-import type { MusicEventDetail } from "../ts/common";
+import type { AssertNever, MusicEventDetail } from "../ts/common";
+
+// Compile-time exhaustiveness guard for the music-event typing (#716).
+// `AssertNever<T>` (common.ts) errors unless `T` is `never`. Applied here to a
+// local union and a local event map with a deliberately MISSING key, the
+// `Exclude` resolves to that missing key, the assertion errors, and the
+// suppression directive below absorbs it. If the guard mechanism ever stops
+// rejecting a missing key, that directive becomes unused and `tsc`
+// (check:types) fails -- the same compile-time-guard pattern as the #646
+// fireEvent test below and the #551 readonly-Range test in spem.test.ts. This
+// pins the mechanism that protects the real `MusicEventType` /
+// `HTMLElementEventMap` lockstep in common.ts.
+type _ProbeMap = { "music-mapped": CustomEvent<MusicEventDetail> };
+type _ProbeUnion = "music-mapped" | "music-unmapped";
+// @ts-expect-error -- "music-unmapped" has no _ProbeMap key, so Exclude is "music-unmapped", which violates AssertNever's `never` constraint (#716)
+type _ProbeExhaustive = AssertNever<Exclude<_ProbeUnion, keyof _ProbeMap>>;
 
 // Create a concrete subclass for testing
 class TestElement extends MusicElement {

--- a/packages/pwa/src/ts/common.ts
+++ b/packages/pwa/src/ts/common.ts
@@ -67,6 +67,34 @@ declare global {
   }
 }
 
+/**
+ * Compile-time assertion that `T` is `never`. A non-`never` `T` fails the
+ * `extends never` constraint, so `tsc` errors at the instantiation site. It is a
+ * `type` alias (resolving to `void`), so it emits no runtime code. Shared so
+ * type-level guards (and their tests) can express "this set must be empty".
+ */
+export type AssertNever<_T extends never> = void;
+
+/**
+ * Compile-time exhaustiveness guard (#716): every `MusicEventType` member must
+ * have a matching key in the `HTMLElementEventMap` augmentation above, so a new
+ * event name cannot silently untype its listeners. If a member is added to the
+ * union without a map entry, `Exclude<...>` is that member (a string literal, not
+ * `never`) and `AssertNever` fails its `never` constraint, so `tsc`
+ * (check:types) errors here at the definition site. Type-only: no runtime output.
+ * The reverse direction (a map key with no union member) is not checkable here:
+ * `HTMLElementEventMap` is the global DOM event map, so `keyof` it spans every
+ * native event and the reverse `Exclude` is not an assertable-empty set. It is
+ * also low-harm, because `fireEvent`'s `MusicEventType` parameter rejects
+ * dispatching any name outside the union, so an orphan map key can never be fired.
+ *
+ * Exported (not a local alias) only so `noUnusedLocals` does not flag it; it is a
+ * guard, not a value to consume.
+ */
+export type MusicEventMapIsExhaustive = AssertNever<
+  Exclude<MusicEventType, keyof HTMLElementEventMap>
+>;
+
 export type Status = "playing" | "paused" | "loading";
 export type RecordingIndex = 0 | 1;
 


### PR DESCRIPTION
Fixes #716

`MusicElement`'s custom events are typed in two places that had to agree by hand: the `MusicEventType` union, and the `HTMLElementEventMap` augmentation that gives listeners their event types. Adding an event name to the union without adding the matching map entry compiled cleanly, and the listeners for that event silently lost their typing.

A compile-time guard now enforces the agreement. If a union member has no map entry, `Exclude<...>` leaves that member behind instead of `never`, and the assertion fails its constraint, so `tsc` (and therefore `check:types`) errors at the definition site. It is type-only, so nothing is emitted at runtime.

The reverse direction is deliberately not checked, and the comment says why: `HTMLElementEventMap` is the global DOM event map, so its keys span every native event and the reverse set is not assertably empty. It is also harmless, since `fireEvent` only accepts a `MusicEventType`, so an orphan map key could never be dispatched.
