### PR TITLE
ci: guard the app version on every pull request

### DIFF
--- a/.github/scripts/version-check-cli.mjs
+++ b/.github/scripts/version-check-cli.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * The entry point CI runs for the app-version guard (ticket #810).
+ *
+ * This file exists so `version-check.mjs` can be imported by its tests without
+ * running, WITHOUT the module needing to ask "was I invoked directly?". That question
+ * used to be answered by comparing `process.argv[1]` against `import.meta.url`
+ * (realpath'd on both sides, after a symlinked-checkout bug). It was a fail-OPEN guard
+ * on a fail-CLOSED tool: had the comparison ever returned false in CI, `main()` would
+ * simply not have run, the process would have exited 0, and the check would have been a
+ * silent no-op on every PR forever. A separate entry file cannot fail that way. There
+ * is no condition to get wrong.
+ */
+import { main } from "./version-check.mjs";
+
+let code;
+try {
+  code = main();
+} catch (e) {
+  // An uncaught throw would exit 1, and 1 is reserved for "the version is wrong". A
+  // crash is not a version violation; report it as one the contributor cannot fix.
+  console.error(`version-check: crashed: ${e?.stack || e}`);
+  code = 2;
+}
+// `process.exitCode`, never `process.exit()`: stdout to a pipe (which is what an
+// Actions step gives us) is async, and `process.exit()` terminates without draining it,
+// so the verdict we just printed could be thrown away and the guard would blame nothing.
+process.exitCode = code;

--- a/.github/scripts/version-check.mjs
+++ b/.github/scripts/version-check.mjs
@@ -1,0 +1,587 @@
+/**
+ * CI guard for the app version (ticket #810).
+ *
+ * Two builds must never ship under one version string. On 2026-07-13 PR #804 and
+ * PR #805 each computed their version against `main` alone, both claimed 2.8.10,
+ * and the second to merge shipped a different build under an already-published
+ * version. That is the failure this guard exists to prevent, and the reason to
+ * resist relaxing the rules below.
+ *
+ * THE RULE
+ *
+ *   1. A PR that changes APP SOURCE with a user-facing intent must carry a version
+ *      strictly above main's, and equal to no other open PR's.
+ *   2. Any other PR must carry no bump: its version must not be above main's. (It
+ *      may sit BELOW main, which happens whenever main moves under a branch that
+ *      correctly did not bump. Requiring equality would fail such a PR; #808 was
+ *      exactly that shape.)
+ *
+ * WHY THE PATH, AND NOT THE COMMIT TYPE ALONE
+ *
+ * The first cut of this guard classified on the commit type alone (with a list of
+ * "internal" scopes). Replayed against the real history of `main`, it demanded a
+ * bump on 11 of 21 user-facing-typed commits that correctly shipped without one,
+ * because the dominant real shape is an UNSCOPED `fix:` on the monitor package, on
+ * lint config, or on a build script. Only 14 of 129 user-facing commits carry any
+ * scope at all, so scope could never have carried this weight.
+ *
+ * Worse, it red-flagged its own review process: the Vera gate appends
+ * `fix: ... (Vera NNN-NN)` commits to the branch it reviews, so any CI-only PR that
+ * went through a gate would have been told to bump the app version. The escape
+ * route (bump to go green) burns a version number a real in-flight PR is racing
+ * for. That is a self-inflicted #810.
+ *
+ * The signal the history actually carries is the PATH: every commit that bumped touched
+ * app source; none of the false reds did. So we ask that question directly, and the scope
+ * list is gone. (Andrew's ruling, 2026-07-13, on the Vera gate for this branch.)
+ *
+ * Replayed against all 128 commits merged since `packages/pwa/package.json` was created,
+ * the path rule agrees with what actually happened 122 times, with ZERO false greens in
+ * either direction, and reds 6.
+ *
+ * FIVE of those reds are the guard working: #804 itself (`7ad3a8b`), and four commits
+ * (`8467e3b`, `8acb303`, `d0127fc`, `73dbee2`) that changed app source and shipped under an
+ * unchanged version.
+ *
+ * The SIXTH is a FALSE red, and it is named here rather than buried: `f2207fb fix: restore
+ * ESLint coverage for packages/monitor .mjs files` touches only `pnpm-lock.yaml`, ships
+ * nothing to a user, and is red solely because the lockfile counts as app source (see
+ * `isAppSource`) under a `fix:` subject. That is the measured cost of closing the
+ * dependency hole: one in 128. The remedy is honest typing, not a version burn: a
+ * lint-dependency change is `build:` or `tooling:`, not `fix:`. Do NOT clear such a red by
+ * bumping the version, which burns a number a real in-flight PR is racing for.
+ *
+ * The replay is on the Vera report attached to #810.
+ *
+ * WHAT SHIPS
+ *
+ * The version guards `packages/pwa/package.json`, which vite injects into
+ * `index.html` at build time. `packages/scores/src` is app source too: `vite.config.ts`
+ * aliases `@scores` to it and `lilyData.ts` and `config.ts` import from it, so it is
+ * bundled. `packages/scores/build` is NOT: it is the LilyPond pipeline that produces
+ * the assets, and it does not ship.
+ *
+ * WHICH SUBJECTS
+ *
+ * The repo squash-merges with `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, which
+ * means the landed subject is the branch COMMIT's when the PR has exactly one commit,
+ * and the PR TITLE otherwise. EITHER can be the thing that ships, so the guard reads
+ * the union: the title AND the branch commits, with a user-facing intent in any one of
+ * them counting. Do not "simplify" the union away to just the title (a single-commit PR
+ * would escape) or to just the commits (a `chore: wip` branch under a `feat:` title
+ * would escape, which is #804 again).
+ *
+ * FAIL CLOSED
+ *
+ * Every LOOKUP here fails closed. A guard that passes when it cannot do its job is
+ * worse than no guard, because it manufactures the confidence it was built to earn.
+ * Do not add a path that returns `pass: true` on a value that stood in for a failed
+ * lookup.
+ *
+ * KNOWN RESIDUAL, THE TYPE SIGNAL. An INTERNALLY-typed change to app source owes no
+ * bump, and this is NOT the rare double-failure it might look like. Measured against
+ * history: 12 of 122 passing commits changed app source, shipped no bump, and were
+ * green, and they are ordinary honest `refactor:` PRs (`refactor: type fireEvent's
+ * CustomEvent detail across the event system`, `refactor: harden colors() against
+ * partial CSS load`). Roughly one commit in nine. The path does not mislead there; only
+ * the type does, and `refactor:` is the CORRECT type for a change that does alter the
+ * bundle.
+ *
+ * Closing it means dropping the type signal for app-source paths ("app source changed
+ * implies a bump"), which would have flagged 18 of 128. That is a RULE CHANGE, not a
+ * bug fix, and it is Andrew's and Mark's to make. It is tracked on the Workbench.
+ *
+ * KNOWN RESIDUAL, DEPENDABOT. A Dependabot dev-dependency bump changes the lockfile,
+ * which IS app source, but classifies `internal` and so owes no bump. `vite` is a
+ * devDependency, so a bundler bump can ship a different build under an unchanged
+ * version. The exemption is deliberate: without it every Dependabot PR goes red, and
+ * Dependabot can neither bump the app version nor clear the check, and its PRs
+ * auto-merge. Whether that should change is the same call, tracked with the above.
+ *
+ * A LANDMINE for the day any package gains a real runtime dependency: Dependabot would then
+ * emit `[deps](deps):`, which matches neither the dev exemption nor the conventional regex
+ * (it starts with `[`), so it classifies `unrecognised`, touches the lockfile, and owes a
+ * bump it cannot make. Unreachable today: every `dependencies` block in the repo is empty.
+ *
+ * The decision lives in `decideVersion`, a pure function. `main` gathers the inputs;
+ * `version-check-cli.mjs` is the entry point CI runs.
+ */
+import { execFileSync } from "node:child_process";
+
+/** Commit types whose intent is a change a user of the app can perceive. */
+export const USER_FACING_TYPES = Object.freeze(["feat", "feature", "fix", "perf", "revert"]);
+
+/**
+ * Commit types that are internal by nature, whatever they touch.
+ *
+ * This list exists so that "internal" and "I have never heard of this type" are
+ * DIFFERENT answers. Collapsing them (a classifier returning a bare boolean) made an
+ * unrecognised type a *confident* internal: `bugfix:` and `hotfix:` match the
+ * conventional regex, miss the user-facing lookup, and used to ship a user-facing
+ * change with no bump and a green tick. They are now `unrecognised`, which is not
+ * internal, so they owe a bump when they touch app source.
+ */
+export const INTERNAL_TYPES = Object.freeze([
+  "build",
+  "chore",
+  "ci",
+  "docs",
+  "refactor",
+  "style",
+  "test",
+  "tooling", // live in this repo: 7c7f0bb moved the LilyPond pipeline into @spem/scores
+]);
+
+const CONVENTIONAL = /^(\w+)(?:\(([^)]*)\))?!?:/;
+
+/** `git revert` and GitHub's Revert button both write `Revert "<original subject>"`. */
+const GIT_REVERT = /^Revert\s+"(.*)"\s*$/i;
+
+/**
+ * Dependabot's DEV-dependency subject, e.g. `[deps](deps-dev): bump prettier ...`.
+ *
+ * It needs naming because the subject matches no conventional type, so it would
+ * otherwise be `unrecognised`, and a dependency bump DOES change app source now that the
+ * lockfile counts. Without this exemption every Dependabot PR would go red, and
+ * Dependabot can neither bump the app version nor clear the check, and its PRs
+ * auto-merge. See KNOWN RESIDUAL, DEPENDABOT in the header: the exemption is a
+ * deliberate, tracked trade, not an oversight.
+ */
+const DEPENDABOT_DEV = /^\[deps\]\(deps-dev\)/i;
+
+/**
+ * The files under `packages/pwa/` that CANNOT change what a user downloads.
+ *
+ * Enumerated by exact path, not matched by pattern, because `packages/pwa/` is small
+ * and closed (three subdirectories and fourteen top-level files) and a pattern drifts
+ * silently: a `prettier.config.*` glob matched nothing here, because this repo's
+ * Prettier config is `.prettierrc`, so it was app source and `fix: reformat` would have
+ * demanded a version bump.
+ *
+ * NOT excluded, and deliberately so: `.browserslistrc` and `.postcssrc.json` shape the
+ * built CSS through autoprefixer and PostCSS, so they DO affect what ships.
+ */
+export const NON_SHIPPING_PWA_FILES = Object.freeze([
+  "packages/pwa/package.json", // the version file itself: counting it is circular
+  "packages/pwa/eslint.config.js",
+  "packages/pwa/.prettierrc",
+  "packages/pwa/.prettierignore",
+  "packages/pwa/knip.json",
+  "packages/pwa/.dependency-cruiser.cjs",
+  "packages/pwa/playwright.config.ts",
+  "packages/pwa/tsconfig.e2e.json",
+  "packages/pwa/worktree-ports.ts", // dev-server ports, not the bundle
+]);
+
+/**
+ * Does a changed path ship in the app bundle?
+ *
+ * The boundary is "can this change what a user downloads". A false positive is a loud
+ * red the author can argue with; a false negative ships a different build under an
+ * unchanged version, which is #810. So the DEFAULT under `packages/pwa/` is IN: a new
+ * file added there counts as shipping until someone says otherwise, which fails safe.
+ */
+export function isAppSource(path) {
+  const p = path.replace(/\\/g, "/");
+  // The lockfile IS build input. `packages/pwa/package.json` declares `dependencies: {}`,
+  // so EVERYTHING is a devDependency, `vite`, `vite-plugin-pwa`, `sass-embedded` and
+  // `workbox-window` included, and their output is the bundle. Without this line a
+  // dependency change is structurally invisible: it touches only the lockfile and the
+  // version file, both of which were excluded, so no bump could ever be owed. `pwa-ci`
+  // already treats the lockfile as build-affecting in its path filter (doc/CI.md).
+  if (p === "pnpm-lock.yaml") return true;
+  if (p.startsWith("packages/scores/src/")) return true; // aliased as @scores, bundled
+  if (!p.startsWith("packages/pwa/")) return false; // monitor, scores/build, .github, docs
+  if (p.startsWith("packages/pwa/src/test/")) return false; // tests do not ship
+  if (p.startsWith("packages/pwa/e2e/")) return false; // nor do they
+  if (NON_SHIPPING_PWA_FILES.includes(p)) return false;
+  return true; // src/, public/, index.html, index.ts, vite.config.ts, tsconfig.json, ...
+}
+
+/** @returns {"user-facing" | "internal" | "unrecognised"} */
+export function classify(subject) {
+  if (DEPENDABOT_DEV.test(subject)) return "internal";
+  const reverted = GIT_REVERT.exec(subject);
+  // A revert inherits the intent of what it reverts: reverting a shipped `fix:` is
+  // itself user-facing. Neither `git revert` nor GitHub's button ever writes
+  // `revert:`, so matching only that literal type covered nothing real.
+  if (reverted) return classify(reverted[1]);
+  const m = CONVENTIONAL.exec(subject);
+  if (!m) return "unrecognised"; // a merge subject, a bare `wip`
+  const type = m[1].toLowerCase();
+  if (USER_FACING_TYPES.includes(type)) return "user-facing";
+  if (INTERNAL_TYPES.includes(type)) return "internal";
+  return "unrecognised"; // `bugfix:`, `hotfix:`, a typo. (`Fix:` is lowercased above.)
+}
+
+/**
+ * Does this PR owe a version bump?
+ *
+ * BOTH signals must fire: an intent that is not plainly internal, AND a change to
+ * something that actually ships. Either alone produces the false reds and false
+ * greens documented in the header.
+ */
+export function owesBump(subjects, changedPaths) {
+  if (!changedPaths.some(isAppSource)) return false;
+  return subjects.map(classify).some((k) => k !== "internal");
+}
+
+/**
+ * The pure decision.
+ *
+ * @param {object} input
+ * @param {string[]} input.subjects - The PR title, then the branch commit subjects.
+ *   Not "commits": the title is what a squash-merge actually lands.
+ * @param {string[]} input.changedPaths - `git diff --name-only origin/main...HEAD`.
+ * @param {string} input.prVersion - `packages/pwa/package.json` version at the PR head.
+ * @param {string} input.mainVersion - The same version at `origin/main`.
+ * @param {Array<{number: number, version: string}>|null} input.allOpenPrs -
+ *   EVERY open PR's version, INCLUDING this one, or null when it could not be read.
+ *   Self-inclusion is not a convenience: when the guard runs, the PR under test is
+ *   itself an open PR, so its absence proves the list is not the list we think it
+ *   is, and an empty list would otherwise read as "nothing to collide with".
+ * @param {number} input.selfNumber - This PR's number. Required.
+ * @returns {{pass: boolean, code: string, message: string}}
+ */
+export function decideVersion({
+  subjects,
+  changedPaths,
+  prVersion,
+  mainVersion,
+  allOpenPrs,
+  selfNumber,
+}) {
+  const cmp = compareSemver(prVersion, mainVersion);
+  if (cmp === null) {
+    return {
+      pass: false,
+      code: "malformed-version",
+      message: `version "${prVersion}" or main's "${mainVersion}" is not a plain x.y.z version, so they cannot be compared`,
+    };
+  }
+
+  const owed = owesBump(subjects, changedPaths);
+
+  // An internal-only PR never consults the peer list, so it must not be failed for
+  // a peer it never needed to read. Carrying no new version, it cannot collide.
+  if (!owed) {
+    if (cmp > 0) {
+      return {
+        pass: false,
+        code: "no-bump-owed",
+        message: `version ${prVersion} bumps above main's ${mainVersion}, but this PR changes no app source with a user-facing intent, so no bump is owed`,
+      };
+    }
+    return {
+      pass: true,
+      code: "ok",
+      message: `version ${prVersion} is not above main's ${mainVersion}, and no bump is owed`,
+    };
+  }
+
+  // From here the PR owes a bump, so the collision question is live and the open-PR
+  // list must be readable and trustworthy.
+  if (allOpenPrs === null || allOpenPrs === undefined) {
+    return {
+      pass: false,
+      code: "unreadable",
+      message:
+        "could not read the open PR list, so a version collision cannot be ruled out; see the log above for why",
+    };
+  }
+  if (!Number.isInteger(selfNumber)) {
+    return {
+      pass: false,
+      code: "unreadable",
+      message: `this PR's own number is not an integer (got ${JSON.stringify(selfNumber)}), so a version collision cannot be ruled out`,
+    };
+  }
+  if (!allOpenPrs.some((p) => p.number === selfNumber)) {
+    return {
+      pass: false,
+      code: "unreadable",
+      message: `the open PR list does not contain this PR (#${selfNumber}), so it cannot be trusted and a version collision cannot be ruled out`,
+    };
+  }
+
+  const peers = allOpenPrs.filter((p) => p.number !== selfNumber);
+
+  // A peer whose version will not parse must not silently drop out of the collision
+  // set: `compareSemver` returns null there and `null === 0` is false, so it would
+  // read as "does not collide".
+  const unparseable = peers.find((p) => parseSemver(p.version) === null);
+  if (unparseable) {
+    return {
+      pass: false,
+      code: "unreadable-peer",
+      message: `could not read the version of open PR #${unparseable.number} (got "${unparseable.version}"), so a version collision cannot be ruled out`,
+    };
+  }
+
+  if (cmp <= 0) {
+    return {
+      pass: false,
+      code: "bump-owed",
+      message: `version ${prVersion} is not strictly above main's ${mainVersion}, but this PR changes app source with a user-facing intent, so it owes a version bump`,
+    };
+  }
+  const hit = peers.find((p) => compareSemver(p.version, prVersion) === 0);
+  if (hit) {
+    return {
+      pass: false,
+      code: "collision",
+      message: `version ${prVersion} collides with open PR #${hit.number}, which declares the same version`,
+    };
+  }
+  return {
+    pass: true,
+    code: "ok",
+    message: `version ${prVersion} is above main's ${mainVersion} and unique among open PRs`,
+  };
+}
+
+/**
+ * Parse a plain `x.y.z`. Returns null for anything else.
+ *
+ * Anchored at BOTH ends on purpose. Unanchored it prefix-matched, so `2.8.10-rc.1`,
+ * `2.8.10.4` and `2.8.10junk` all read as `2.8.10` and passed, while this comment
+ * claimed they would not. We have no prerelease convention, so anything that is not
+ * a plain `x.y.z` is something we do not understand, and this file fails closed on
+ * what it does not understand rather than normalising it away.
+ */
+function parseSemver(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(String(v).trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/**
+ * Returns -1, 0, 1, or null when either side is not a semver.
+ *
+ * The `null` is an in-band error value flowing into `<=` / `>` comparisons, and
+ * JavaScript coerces it to 0 (`null <= 0` is true, `null > 0` is false). The two
+ * ordering comparisons below therefore run only AFTER the `cmp === null` guard at
+ * the top of `decideVersion`. The collision test uses `=== 0`, which is null-safe by
+ * strict equality. Do not move that guard inside a branch: an internal-only PR would
+ * then reach `if (cmp > 0)`, `null > 0` is false, and it would PASS on a version it
+ * could not parse.
+ */
+function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return null;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Read `packages/pwa/package.json`'s version from a git ref. NOT the root package.json. */
+function versionAtRef(ref, run) {
+  return JSON.parse(run("git", ["show", `${ref}:packages/pwa/package.json`])).version;
+}
+
+/**
+ * A full page back from `gh pr list` is evidence of truncation, not of completeness,
+ * and a dropped PR is a collision we cannot see. Set well above any plausible
+ * open-PR count; hitting it fails closed rather than guessing.
+ */
+export const PR_LIST_LIMIT = 500;
+
+/** The guard's contract with CI, kept pure so it can be tested. */
+export function exitCodeFor(verdict) {
+  if (verdict.pass) return 0;
+  // Exit 2 means "the guard could not tell" (an infrastructure failure). Exit 1
+  // means "it told you, and the version is wrong". Conflating them tells a
+  // contributor to fix their version when the real fault is a 403 on the PR list.
+  return verdict.code === "unreadable" || verdict.code === "unreadable-peer" ? 2 : 1;
+}
+
+/** Run a command and return stdout. Injectable so the CLI layer is testable. */
+const execRun = (cmd, args) =>
+  execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+/**
+ * EVERY open PR's head version, INCLUDING this one.
+ *
+ * Returns `{prs, skipped}`, or `null` when the list could not be read. `skipped` names
+ * the PRs left out of the collision set (a head with no app package.json), so the
+ * verdict can SAY the set was reduced rather than printing a bare "unique among open
+ * PRs" over a shortened list.
+ *
+ * Self is deliberately not filtered out here: `decideVersion` owns that, and it
+ * needs to see self to know the list is trustworthy at all.
+ *
+ * The repo is PINNED rather than resolved from the ambient git remote, because a
+ * wrong-repo read returns a confident EMPTY list. Do not add `--search`, `--author`
+ * or `--label` to the `gh pr list` call: those switch it to the search API, which
+ * has indexing lag, and a freshly-opened PR would then be legitimately absent from
+ * its own list and every new PR would fail closed.
+ */
+export function readOpenPrVersions(repo, run = execRun) {
+  let prs;
+  try {
+    prs = JSON.parse(
+      run("gh", [
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "number,headRefOid,isCrossRepository",
+        "--limit",
+        String(PR_LIST_LIMIT),
+      ]),
+    );
+  } catch (e) {
+    // Fail closed, but SAY WHY: "re-run the check" is useless advice for a 403, a
+    // missing `gh`, or a rate limit.
+    console.error(`version-check: could not list open PRs: ${e.stderr || e.message}`);
+    return null;
+  }
+  if (!Array.isArray(prs)) {
+    console.error(`version-check: the open PR list was not an array; refusing to guess`);
+    return null;
+  }
+  if (prs.length >= PR_LIST_LIMIT) {
+    console.error(
+      `version-check: the open PR list came back full (${prs.length} of a ${PR_LIST_LIMIT} limit), so it may be truncated and a collision could be hidden`,
+    );
+    return null;
+  }
+  const out = [];
+  const skipped = [];
+  for (const pr of prs) {
+    try {
+      const raw = run("gh", [
+        "api",
+        "-H",
+        "Accept: application/vnd.github.raw",
+        `repos/${repo}/contents/packages/pwa/package.json?ref=${pr.headRefOid}`,
+        "--jq",
+        ".version",
+      ]);
+      out.push({ number: pr.number, version: raw.trim() });
+    } catch (e) {
+      const why = String(e.stderr || e.message);
+      // A 404 CAN be information rather than the absence of it: a head with no
+      // `packages/pwa/package.json` (a branch cut before the monorepo move) declares no
+      // app version, so it cannot collide, and failing the list would red every PR in
+      // the repo until that one stale PR was closed.
+      //
+      // But the contents API ALSO returns 404 when it cannot resolve the REF (a fork
+      // head, a force-pushed and unreferenced SHA). Skipping that peer would drop a
+      // real, possibly colliding version out of the set and print "unique among open
+      // PRs" over it: a silent pass on the exact question this guard answers.
+      //
+      // So skip only on PROOF: the ref must independently resolve. If it does not, or
+      // if we cannot tell, fail closed.
+      // A FORK peer must never be skipped. `repos/{base}/contents/...?ref={forkHead}`
+      // can 404 even though that PR declares a real, possibly colliding version, so a
+      // skip there would drop it out of the collision set and print "unique among open
+      // PRs" over it.
+      const forkable = pr.isCrossRepository === true;
+      if (!forkable && /\(HTTP 404\)/.test(why) && refResolves(repo, pr.headRefOid, run)) {
+        console.error(
+          `version-check: open PR #${pr.number} has no packages/pwa/package.json at a ref that does resolve, so it declares no app version; not counting it`,
+        );
+        skipped.push(pr.number);
+        continue;
+      }
+      console.error(
+        `version-check: could not read packages/pwa/package.json on open PR #${pr.number}: ${why}`,
+      );
+      return null;
+    }
+  }
+  return { prs: out, skipped };
+}
+
+/** Does this commit-ish exist in the repo? Used to tell a missing PATH from a missing REF. */
+function refResolves(repo, sha, run) {
+  try {
+    run("gh", ["api", `repos/${repo}/commits/${sha}`, "--jq", ".sha"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The CLI. Called by `version-check-cli.mjs`; never runs on import.
+ *
+ * `env` and `run` are injected so this WIRING is testable. It was not, and eight
+ * mutations of it survived the whole suite: the worst simply dropped `prTitle` from
+ * `subjects`, which silently reinstates the #804 false green (a PR titled `fix:` over
+ * `chore:` branch commits stops owing a bump) with no test to catch it.
+ */
+export function main({ env = process.env, run = execRun } = {}) {
+  const prNumber = Number(env.PR_NUMBER);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    console.error("version-check: PR_NUMBER is not set; refusing to guess");
+    return 2;
+  }
+  const prTitle = env.PR_TITLE;
+  if (!prTitle) {
+    console.error("version-check: PR_TITLE is not set; refusing to guess");
+    return 2;
+  }
+  // No hard-coded fallback. A wrong-repo read returns a confident EMPTY open-PR list,
+  // which is the silent pass the repo pin exists to prevent; defaulting to a guess
+  // re-opens it by another door.
+  const repo = env.GH_REPO;
+  if (!repo) {
+    console.error("version-check: GH_REPO is not set; refusing to guess the repository");
+    return 2;
+  }
+
+  let subjects;
+  let changedPaths;
+  let prVersion;
+  let mainVersion;
+  try {
+    const branchSubjects = run("git", [
+      "log",
+      "origin/main..HEAD",
+      "--format=%s",
+      "--no-merges", // a merge of main into the branch is not this PR's own work
+    ])
+      .split("\n")
+      .filter(Boolean);
+    // BOTH the title and the branch commits. Under squash-merge the landed subject is
+    // the branch commit's when there is exactly one, and the PR title otherwise, so
+    // either can be what ships. Reading the union means we never miss the one that does.
+    subjects = [prTitle, ...branchSubjects];
+    // Three dots: diff against the MERGE BASE, so this is the branch's own work and not
+    // whatever main changed underneath it.
+    changedPaths = run("git", ["diff", "--name-only", "origin/main...HEAD"])
+      .split("\n")
+      .filter(Boolean);
+    prVersion = versionAtRef("HEAD", run);
+    mainVersion = versionAtRef("origin/main", run);
+  } catch (e) {
+    console.error(
+      `version-check: could not read the PR's subjects, paths or versions: ${e.stderr || e.message}`,
+    );
+    return 2;
+  }
+
+  const read = readOpenPrVersions(repo, run);
+  const allOpenPrs = read ? read.prs : null;
+  const verdict = decideVersion({
+    subjects,
+    changedPaths,
+    prVersion,
+    mainVersion,
+    allOpenPrs,
+    selfNumber: prNumber,
+  });
+  const tag = verdict.pass ? "PASS" : `FAIL (${verdict.code})`;
+  const skipped = read?.skipped;
+  const caveat = skipped?.length
+    ? ` (the collision set excludes #${skipped.join(", #")}: no app package.json at that head)`
+    : "";
+  console.log(`version-check ${tag}: ${verdict.message}${caveat}`);
+  return exitCodeFor(verdict);
+}

--- a/.github/scripts/version-check.test.mjs
+++ b/.github/scripts/version-check.test.mjs
@@ -1,0 +1,652 @@
+// Unit tests for the version-guard decision function (ticket #810).
+// Run with: node --test .github/scripts/version-check.test.mjs
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  decideVersion,
+  classify,
+  owesBump,
+  isAppSource,
+  exitCodeFor,
+  readOpenPrVersions,
+  main,
+  NON_SHIPPING_PWA_FILES,
+  USER_FACING_TYPES,
+  INTERNAL_TYPES,
+  PR_LIST_LIMIT,
+} from "./version-check.mjs";
+
+// The PR under test. `allOpenPrs` is EVERY open PR INCLUDING this one: the guard
+// fails closed if it cannot see itself in the list, because an empty or wrong-repo
+// list would otherwise read as "nothing to collide with".
+const SELF = 810;
+const alone = [{ number: SELF, version: "0.0.0" }];
+const withPeers = (...peers) => [{ number: SELF, version: "0.0.0" }, ...peers];
+
+const APP = ["packages/pwa/src/ts/MusicScore.ts"]; // ships
+const NOT_APP = ["packages/monitor/monitor-resources.mjs"]; // does not ship
+
+const at = (prVersion, mainVersion, changedPaths = APP, allOpenPrs = alone) => ({
+  prVersion,
+  mainVersion,
+  changedPaths,
+  allOpenPrs,
+  selfNumber: SELF,
+});
+
+describe("isAppSource: what actually ships", () => {
+  it("counts the PWA's shipped source", () => {
+    for (const p of [
+      "packages/pwa/src/ts/MusicScore.ts",
+      "packages/pwa/src/scss/style.scss",
+      "packages/pwa/index.ts",
+      "packages/pwa/index.html",
+      "packages/pwa/public/spem.json",
+      "packages/pwa/vite.config.ts", // a resolver change DOES change the bundle (#610)
+    ]) {
+      assert.equal(isAppSource(p), true, p);
+    }
+  });
+
+  it("counts packages/scores/src, which vite aliases as @scores and bundles", () => {
+    assert.equal(isAppSource("packages/scores/src/lily/lilyData.json"), true);
+    assert.equal(isAppSource("packages/scores/src/lily/music-classes.ts"), true);
+  });
+
+  it("does NOT count things that cannot reach the bundle", () => {
+    for (const p of [
+      "packages/pwa/package.json", // the version file itself: counting it is circular
+      "packages/pwa/src/test/lily.test.ts",
+      "packages/pwa/e2e/splitter-cursor.spec.ts",
+      "packages/pwa/eslint.config.js",
+      "packages/pwa/playwright.config.ts",
+      "packages/scores/build/buildScores.mjs", // the LilyPond pipeline, not the app
+      "packages/monitor/monitor-resources.mjs",
+      ".github/workflows/version-check.yml",
+      "doc/CI.md",
+    ]) {
+      assert.equal(isAppSource(p), false, p);
+    }
+  });
+
+  // The lockfile IS build input. Everything the PWA builds with (vite, vite-plugin-pwa,
+  // sass-embedded, workbox-window) is a devDependency, so its output is the bundle.
+  // Without this, a dependency change is structurally invisible to the guard: it touches
+  // only the lockfile and the version file, and both were excluded.
+  it("counts pnpm-lock.yaml: a dependency change alters the bundle", () => {
+    assert.equal(isAppSource("pnpm-lock.yaml"), true);
+  });
+
+  it("a Dependabot dev-dep bump still owes no bump (internal intent), despite the lockfile", () => {
+    assert.equal(
+      owesBump(
+        ["[deps](deps-dev): bump prettier from 3.8.4 to 3.9.5 (#769)"],
+        ["packages/pwa/package.json", "pnpm-lock.yaml"],
+      ),
+      false,
+      "Dependabot cannot bump the app version and its PRs auto-merge",
+    );
+  });
+
+  it("but a HUMAN user-facing PR that changes dependencies DOES owe a bump", () => {
+    assert.equal(owesBump(["fix: upgrade vite to stop the stall"], ["pnpm-lock.yaml"]), true);
+  });
+});
+
+describe("classify: user-facing, internal, or unrecognised", () => {
+  it("has exactly the expected type memberships", () => {
+    assert.deepEqual([...USER_FACING_TYPES].sort(), ["feat", "feature", "fix", "perf", "revert"]);
+    assert.deepEqual(
+      [...INTERNAL_TYPES].sort(),
+      ["build", "chore", "ci", "docs", "refactor", "style", "test", "tooling"],
+    );
+  });
+
+  it("classifies the user-facing types", () => {
+    for (const t of ["feat", "feature", "fix", "perf", "revert"]) {
+      assert.equal(classify(`${t}: a change`), "user-facing", t);
+    }
+  });
+
+  it("classifies the internal types", () => {
+    for (const t of ["build", "chore", "ci", "docs", "refactor", "style", "test", "tooling"]) {
+      assert.equal(classify(`${t}: a change`), "internal", t);
+    }
+  });
+
+  // A capitalised type matched the regex, missed the lowercase lookup, and was a
+  // CONFIDENT internal: a user-facing change shipped unbumped with a green tick.
+  it("lowercases the type, so `Fix:` is not silently internal", () => {
+    assert.equal(classify("Fix: crash on cold load"), "user-facing");
+    assert.equal(classify("PERF: faster load"), "user-facing");
+  });
+
+  // A type it has never heard of must NOT collapse into "internal".
+  it("calls an unknown conventional type unrecognised, not internal", () => {
+    for (const s of ["bugfix: a crash", "hotfix: a crash", "patch: a thing", "wip"]) {
+      assert.equal(classify(s), "unrecognised", s);
+    }
+  });
+
+  // Neither `git revert` nor GitHub's button ever writes `revert:`. Matching only
+  // that literal type covered nothing this repo actually produces.
+  it("unwraps the real revert subject and inherits the reverted intent", () => {
+    assert.equal(
+      classify('Revert "fix: honour control changes during the audio load window (#805)"'),
+      "user-facing",
+    );
+    assert.equal(classify('Revert "ci: add metadata:read permission"'), "internal");
+  });
+
+  // Dependabot cannot bump the app version and its PRs auto-merge, so a red here is
+  // a red nobody can clear. Bumping prettier reformatted lily.ts in #769.
+  it("treats a dependabot DEV-dependency subject as internal", () => {
+    assert.equal(classify("[deps](deps-dev): bump prettier from 3.8.4 to 3.9.5 (#769)"), "internal");
+  });
+
+  // A RUNTIME dependency bump would change the bundle. None exists today; it must
+  // fail SAFE if one appears.
+  it("does NOT extend that exemption to a runtime dependency bump", () => {
+    assert.notEqual(classify("[deps](deps): bump vite from 8.1.0 to 9.0.0"), "internal");
+  });
+});
+
+describe("owesBump: BOTH signals must fire", () => {
+  it("owes a bump only when app source changes AND the intent is not internal", () => {
+    assert.equal(owesBump(["fix: a real bug"], APP), true);
+    assert.equal(owesBump(["fix: a real bug"], NOT_APP), false, "no app source: nothing ships");
+    assert.equal(owesBump(["chore: tidy"], APP), false, "internal intent");
+    assert.equal(owesBump(["chore: tidy"], NOT_APP), false);
+  });
+
+  // The five real merged commits my scope-based first attempt would have red-flagged.
+  it("does not red-flag an unscoped fix: outside the app (the false reds of the scope rule)", () => {
+    assert.equal(
+      owesBump(
+        ["fix: value-preserving merge for monitor-series.json mergedPRs (#802)"],
+        ["packages/monitor/merge-monitor-series.mjs"],
+      ),
+      false,
+    );
+    assert.equal(
+      owesBump(
+        ["fix: restore ESLint coverage for packages/monitor .mjs files (#617)"],
+        ["packages/pwa/eslint.config.js"],
+      ),
+      false,
+    );
+  });
+
+  // The Vera gate appends `fix: ... (Vera NNN-NN)` commits to the branch it reviews.
+  // Under a type-only rule that turned every gated CI-only PR red and told the author
+  // to bump the app version, burning a number a real PR was racing for.
+  it("does not red-flag a CI-only PR carrying the Vera gate's own fix: commits", () => {
+    const subjects = [
+      "ci: cache generated SVGs to skip LilyPond on unchanged inputs (#421)",
+      "fix: refuse a score cache key over zero inputs (Vera 421-02)",
+      "fix: fail the CI key step on an invalid cache key (Vera 421-01)",
+    ];
+    assert.equal(owesBump(subjects, [".github/workflows/pwa-ci.yml"]), false);
+  });
+
+  // The repo squash-merges, so the PR TITLE is what lands on main. The guard is fed
+  // [title, ...branchSubjects] and a user-facing intent in EITHER counts.
+  it("catches a user-facing PR title over throwaway branch commits", () => {
+    assert.equal(owesBump(["feat: add a metronome", "wip", "tweak"], APP), true);
+  });
+
+  it("catches a user-facing branch commit hidden under an internal title", () => {
+    assert.equal(owesBump(["chore: tidy up", "fix: the actual crash"], APP), true);
+  });
+
+  it("an unrecognised subject touching app source owes a bump (fail-safe)", () => {
+    assert.equal(owesBump(["bugfix: the crash"], APP), true);
+  });
+});
+
+describe("decideVersion: the version rule", () => {
+  it("fails a user-facing PR sitting at main's version (bump owed, none carried)", () => {
+    const r = decideVersion({ subjects: ["fix: repair the audio load window"], ...at("2.8.10", "2.8.10") });
+    assert.equal(r.pass, false);
+    assert.equal(r.code, "bump-owed");
+  });
+
+  it("fails #804 as it actually shipped: app source changed, version left at main's", () => {
+    const r = decideVersion({
+      subjects: ["perf: precompute the LilyPond parse at build time (#804)"],
+      ...at("2.8.10", "2.8.10"),
+    });
+    assert.equal(r.pass, false);
+    assert.equal(r.code, "bump-owed");
+  });
+
+  it("fails the #804/#805 collision: same version as another open PR", () => {
+    const r = decideVersion({
+      subjects: ["perf: precompute the LilyPond parse at build time (#804)"],
+      ...at("2.8.10", "2.8.9", APP, withPeers({ number: 805, version: "2.8.10" })),
+    });
+    assert.equal(r.pass, false);
+    assert.equal(r.code, "collision");
+    assert.match(r.message, /#805/);
+  });
+
+  it("passes a user-facing PR strictly above main and unique among open PRs", () => {
+    const r = decideVersion({
+      subjects: ["fix: repair the audio load window"],
+      ...at("2.8.11", "2.8.10", APP, withPeers({ number: 807, version: "2.8.12" })),
+    });
+    assert.equal(r.pass, true);
+    assert.equal(r.code, "ok");
+  });
+
+  it("passes an internal PR at main's version (the #808 regression guard)", () => {
+    const r = decideVersion({ subjects: ["test: cover the loader"], ...at("2.8.10", "2.8.10", NOT_APP) });
+    assert.equal(r.pass, true);
+  });
+
+  it("passes an internal PR BELOW main's version (main moved under the branch; #808)", () => {
+    const r = decideVersion({ subjects: ["test: cover the loader"], ...at("2.8.10", "2.8.11", NOT_APP) });
+    assert.equal(r.pass, true);
+  });
+
+  it("fails an internal PR carrying a bump (none owed)", () => {
+    const r = decideVersion({ subjects: ["test: cover the loader"], ...at("2.8.11", "2.8.10", NOT_APP) });
+    assert.equal(r.pass, false);
+    assert.equal(r.code, "no-bump-owed");
+  });
+
+  it("does not collide a PR with itself", () => {
+    const r = decideVersion({
+      subjects: ["fix: a bug"],
+      ...at("2.8.11", "2.8.10", APP, [{ number: SELF, version: "2.8.11" }]),
+    });
+    assert.equal(r.pass, true);
+  });
+
+  // A string compare ranks "2.8.10" BELOW "2.8.9". Named so the boundary is defended
+  // on purpose, not as a side effect of another test's fixture numbers.
+  it("orders version segments numerically, not as strings", () => {
+    const r = decideVersion({ subjects: ["fix: a bug"], ...at("2.8.10", "2.8.9") });
+    assert.equal(r.pass, true, "2.8.10 must rank ABOVE 2.8.9");
+  });
+});
+
+describe("decideVersion: it fails closed", () => {
+  it("fails a malformed version on a USER-FACING PR", () => {
+    const r = decideVersion({ subjects: ["fix: a bug"], ...at("next", "2.8.10") });
+    assert.equal(r.code, "malformed-version");
+  });
+
+  // The `cmp === null` guard is hoisted ahead of both branches. Moving it inside the
+  // owed branch leaves an internal PR reaching `if (cmp > 0)`, where `null > 0` is
+  // false, and it PASSES on a version it could not parse.
+  it("fails a malformed version on an INTERNAL PR too", () => {
+    const r = decideVersion({ subjects: ["ci: retune"], ...at("not-a-version", "2.8.12", NOT_APP) });
+    assert.equal(r.pass, false, "an unparseable version must never pass, bump owed or not");
+    assert.equal(r.code, "malformed-version");
+  });
+
+  // parseSemver was unanchored, so these read as 2.8.10 and passed while the code's
+  // own comment claimed they would not.
+  for (const bad of ["2.8.10-rc.1", "2.8.10.4", "2.8.10junk"]) {
+    it(`"${bad}" is not a plain x.y.z and fails closed`, () => {
+      const r = decideVersion({ subjects: ["fix: a bug"], ...at(bad, "2.8.9") });
+      assert.equal(r.pass, false, `${bad} must not be normalised to 2.8.10`);
+      assert.equal(r.code, "malformed-version");
+    });
+  }
+
+  it("fails closed when the open-PR list is unreadable, distinctly from a collision", () => {
+    const r = decideVersion({ subjects: ["fix: a bug"], ...at("2.8.11", "2.8.10", APP, null) });
+    assert.equal(r.code, "unreadable");
+    assert.doesNotMatch(r.message, /collid/i);
+  });
+
+  // The silent pass: an empty list used to mean "nothing to collide with". But the PR
+  // under test is ITSELF an open PR, so its absence proves the list cannot be trusted.
+  it("fails closed on an EMPTY open-PR list, because this PR must appear in it", () => {
+    const r = decideVersion({ subjects: ["fix: a bug"], ...at("2.8.11", "2.8.10", APP, []) });
+    assert.equal(r.pass, false, "an empty open-PR list must never read as 'no collision'");
+    assert.equal(r.code, "unreadable");
+  });
+
+  it("fails closed when the list does not contain this PR (a wrong-repo read)", () => {
+    const r = decideVersion({
+      subjects: ["fix: a bug"],
+      ...at("2.8.11", "2.8.10", APP, [{ number: 999, version: "2.8.10" }]),
+    });
+    assert.equal(r.code, "unreadable");
+    assert.match(r.message, /#810/);
+  });
+
+  // compareSemver returns null for an unparseable version, and null === 0 is false,
+  // so such a peer used to drop silently out of the collision set.
+  it("fails closed on a peer whose version will not parse", () => {
+    const r = decideVersion({
+      subjects: ["fix: a bug"],
+      ...at("2.8.13", "2.8.12", APP, withPeers({ number: 805, version: "null" })),
+    });
+    assert.equal(r.code, "unreadable-peer");
+    assert.match(r.message, /#805/);
+  });
+
+  it("fails closed when this PR's number is not an integer", () => {
+    const r = decideVersion({
+      subjects: ["fix: a bug"],
+      prVersion: "2.8.13",
+      mainVersion: "2.8.12",
+      changedPaths: APP,
+      allOpenPrs: alone,
+      selfNumber: "810",
+    });
+    assert.equal(r.pass, false);
+    assert.equal(r.code, "unreadable");
+  });
+
+  // An internal PR never consults the peer list, so it must not be failed for a peer
+  // it never needed to read. Carrying no new version, it cannot collide.
+  it("does NOT fail an internal PR when the peer list is unreadable", () => {
+    const r = decideVersion({
+      subjects: ["docs: fix a typo"],
+      ...at("2.8.12", "2.8.12", NOT_APP, null),
+    });
+    assert.equal(r.pass, true, "an internal PR asks no question the peer list could answer");
+  });
+});
+
+describe("exitCodeFor: the guard's contract with CI", () => {
+  it("maps every verdict code to the right exit code", () => {
+    const cases = [
+      [{ pass: true, code: "ok" }, 0],
+      [{ pass: false, code: "unreadable" }, 2],
+      [{ pass: false, code: "unreadable-peer" }, 2],
+      [{ pass: false, code: "bump-owed" }, 1],
+      [{ pass: false, code: "no-bump-owed" }, 1],
+      [{ pass: false, code: "collision" }, 1],
+      [{ pass: false, code: "malformed-version" }, 1],
+    ];
+    for (const [verdict, expected] of cases) {
+      assert.equal(exitCodeFor(verdict), expected, verdict.code);
+    }
+  });
+});
+
+describe("readOpenPrVersions: the layer where a silent pass originates", () => {
+  const quiet = (fn) => {
+    const err = console.error;
+    console.error = () => {};
+    try {
+      return fn();
+    } finally {
+      console.error = err;
+    }
+  };
+  const listOf = (...prs) => JSON.stringify(prs);
+
+  it("returns every open PR's version, self INCLUDED", () => {
+    const run = (cmd, args) =>
+      args[0] === "pr"
+        ? listOf({ number: 810, headRefOid: "aaa" }, { number: 811, headRefOid: "bbb" })
+        : args.join(" ").includes("ref=aaa")
+          ? "2.8.12\n"
+          : "2.8.13\n";
+    assert.deepEqual(readOpenPrVersions("wainwmr/spem-player", run), {
+      prs: [
+        { number: 810, version: "2.8.12" },
+        { number: 811, version: "2.8.13" },
+      ],
+      skipped: [],
+    });
+  });
+
+  it("fails closed when `gh pr list` throws", () => {
+    const run = () => {
+      throw Object.assign(new Error("boom"), { stderr: "HTTP 403 rate limited" });
+    };
+    assert.equal(quiet(() => readOpenPrVersions("r", run)), null);
+  });
+
+  it("fails closed when the list is not an array", () => {
+    const run = () => '{"not":"an array"}';
+    assert.equal(quiet(() => readOpenPrVersions("r", run)), null);
+  });
+
+  it("fails closed on a FULL page, because a full page is evidence of truncation", () => {
+    const full = Array.from({ length: PR_LIST_LIMIT }, (_, i) => ({ number: i + 1, headRefOid: "x" }));
+    const run = (cmd, args) => (args[0] === "pr" ? JSON.stringify(full) : "2.8.12\n");
+    assert.equal(quiet(() => readOpenPrVersions("r", run)), null);
+  });
+
+  it("fails closed on a transport error reading a peer's package.json", () => {
+    const run = (cmd, args) => {
+      if (args[0] === "pr") return listOf({ number: 811, headRefOid: "bbb" });
+      throw Object.assign(new Error("boom"), { stderr: "HTTP 403" });
+    };
+    assert.equal(quiet(() => readOpenPrVersions("r", run)), null);
+  });
+
+  // A 404 is INFORMATION, not the absence of it: that head carries no app
+  // package.json, so it declares no version and cannot collide. Failing the whole
+  // list would red every PR in the repo until that one stale PR was closed.
+  // A FORK peer must NEVER be skipped, even on a resolvable 404. GitHub keeps PR heads
+  // reachable in the base repo, so `commits/{forkHead}` resolves while
+  // `contents/...?ref={forkHead}` 404s. Without the isCrossRepository guard the peer is
+  // skipped, its real (possibly colliding) version drops out of the set, and the guard
+  // prints "unique among open PRs": a silent pass on the one question it answers.
+  it("FAILS CLOSED on a 404 from a FORK peer, even when the ref resolves", () => {
+    const run = (cmd, args) => {
+      const a = args.join(" ");
+      if (args[0] === "pr")
+        return JSON.stringify([
+          { number: 810, headRefOid: "aaa", isCrossRepository: false },
+          { number: 700, headRefOid: "fork", isCrossRepository: true },
+        ]);
+      // The ref DOES resolve: refResolves() is true, so the fork guard is the only thing
+      // standing between this and a silent skip.
+      if (a.includes("commits/fork")) return "fork\n";
+      if (a.includes("ref=fork")) {
+        throw Object.assign(new Error("boom"), { stderr: "gh: Not Found (HTTP 404)" });
+      }
+      return "2.8.12\n";
+    };
+    assert.equal(
+      quiet(() => readOpenPrVersions("r", run)),
+      null,
+      "a fork peer must never be dropped from the collision set",
+    );
+  });
+
+  // THE CRITICAL ONE. The contents API returns 404 for an UNRESOLVABLE REF as well as
+  // for a missing path (a fork head, a force-pushed SHA). Skipping that peer would drop
+  // a real, possibly colliding version out of the set and then print "unique among open
+  // PRs" over it: a silent pass on the exact question this guard answers. So a skip
+  // requires PROOF that the ref resolves.
+  it("FAILS CLOSED on a 404 whose ref does not resolve (a fork or force-pushed head)", () => {
+    const run = (cmd, args) => {
+      const a = args.join(" ");
+      if (args[0] === "pr")
+        return listOf({ number: 810, headRefOid: "aaa" }, { number: 700, headRefOid: "gone" });
+      if (a.includes("commits/gone")) {
+        // The ref itself does not resolve, so the 404 is NOT "the path is absent".
+        throw Object.assign(new Error("boom"), { stderr: "gh: Not Found (HTTP 404)" });
+      }
+      if (a.includes("ref=gone")) {
+        throw Object.assign(new Error("boom"), {
+          stderr: "gh: No commit found for the ref gone (HTTP 404)",
+        });
+      }
+      return "2.8.12\n";
+    };
+    assert.equal(
+      quiet(() => readOpenPrVersions("r", run)),
+      null,
+      "a peer we cannot resolve must not be silently dropped from the collision set",
+    );
+  });
+
+  it("SKIPS a peer whose package.json 404s, rather than failing every PR in the repo", () => {
+    const run = (cmd, args) => {
+      if (args[0] === "pr")
+        return listOf({ number: 810, headRefOid: "aaa" }, { number: 700, headRefOid: "old" });
+      if (args.join(" ").includes("ref=old")) {
+        throw Object.assign(new Error("boom"), { stderr: "gh: Not Found (HTTP 404)" });
+      }
+      return "2.8.12\n";
+    };
+    assert.deepEqual(quiet(() => readOpenPrVersions("r", run)), {
+      prs: [{ number: 810, version: "2.8.12" }],
+      skipped: [700],
+    });
+  });
+});
+
+describe("isAppSource: the non-shipping set is pinned by value", () => {
+  // Pinned by VALUE, not by iterating the exported list, or deleting a member would
+  // remove it from the loop rather than failing the test.
+  it("NON_SHIPPING_PWA_FILES has exactly the expected membership", () => {
+    assert.deepEqual(
+      [...NON_SHIPPING_PWA_FILES].sort(),
+      [
+        "packages/pwa/.dependency-cruiser.cjs",
+        "packages/pwa/.prettierignore",
+        "packages/pwa/.prettierrc",
+        "packages/pwa/eslint.config.js",
+        "packages/pwa/knip.json",
+        "packages/pwa/package.json",
+        "packages/pwa/playwright.config.ts",
+        "packages/pwa/tsconfig.e2e.json",
+        "packages/pwa/worktree-ports.ts",
+      ].sort(),
+    );
+  });
+
+  // The repo's Prettier config is `.prettierrc`, so a `prettier.config.*` pattern
+  // matched nothing and the file counted as app source: `fix: reformat` would have
+  // demanded a version bump. Pin the real filenames.
+  it("excludes the tooling configs this repo actually has", () => {
+    for (const p of NON_SHIPPING_PWA_FILES) assert.equal(isAppSource(p), false, p);
+  });
+
+  // The DEFAULT under packages/pwa/ is IN. A new file added there fails SAFE (a loud
+  // red) rather than silently shipping unbumped.
+  it("a new, unknown file under packages/pwa/ counts as shipping (fail-safe default)", () => {
+    assert.equal(isAppSource("packages/pwa/some-new-thing.ts"), true);
+  });
+
+  it("keeps .browserslistrc and .postcssrc.json IN: they shape the built CSS", () => {
+    assert.equal(isAppSource("packages/pwa/.browserslistrc"), true);
+    assert.equal(isAppSource("packages/pwa/.postcssrc.json"), true);
+  });
+});
+
+describe("main: the CLI wiring (Vera 810-27)", () => {
+  // This layer had NO test, and eight mutations of it survived the whole suite. The
+  // worst simply dropped the PR title from `subjects`, which silently reinstates the
+  // #804 false green. `env` and `run` are injected so the wiring is assertable.
+  const ENV = { PR_NUMBER: "810", PR_TITLE: "chore: tidy", GH_REPO: "wainwmr/spem-player" };
+
+  // A fake git+gh. `calls` records the argv so we can assert WHAT was asked, not just
+  // what came back.
+  const fake = ({ branchSubjects = ["chore: wip"], paths = ["packages/pwa/src/ts/x.ts"], head = "2.8.12", main: mainV = "2.8.12", peers = [] } = {}) => {
+    const calls = [];
+    const run = (cmd, args) => {
+      calls.push([cmd, ...args].join(" "));
+      if (cmd === "git" && args[0] === "log") return branchSubjects.join("\n") + "\n";
+      if (cmd === "git" && args[0] === "diff") return paths.join("\n") + "\n";
+      if (cmd === "git" && args[0] === "show")
+        return JSON.stringify({ version: args[1].startsWith("HEAD") ? head : mainV });
+      if (cmd === "gh" && args[0] === "pr")
+        return JSON.stringify([{ number: 810, headRefOid: "self" }, ...peers.map((p) => ({ number: p.number, headRefOid: `h${p.number}` }))]);
+      if (cmd === "gh" && args[0] === "api") {
+        if (args.join(" ").includes("ref=self")) return `${head}\n`;
+        const p = peers.find((x) => args.join(" ").includes(`ref=h${x.number}`));
+        return `${p.version}\n`;
+      }
+      throw new Error(`unexpected call: ${cmd} ${args.join(" ")}`);
+    };
+    return { run, calls };
+  };
+
+  const quiet = (fn) => {
+    const log = console.log;
+    const err = console.error;
+    console.log = () => {};
+    console.error = () => {};
+    try {
+      return fn();
+    } finally {
+      console.log = log;
+      console.error = err;
+    }
+  };
+
+  // THE ONE THAT MATTERS. Branch commits are all `chore:`; the PR TITLE is the
+  // user-facing thing, and it is what a multi-commit squash lands. Drop the title from
+  // `subjects` and this PR passes with no bump: #804, all over again.
+  it("reads the PR TITLE, so a `fix:` title over `chore:` commits owes a bump", () => {
+    const { run } = fake({ branchSubjects: ["chore: wip", "chore: tweak"] });
+    const code = quiet(() =>
+      main({ env: { ...ENV, PR_TITLE: "fix: stop the crash on cold load" }, run }),
+    );
+    assert.equal(code, 1, "a user-facing PR title over app source must owe a bump");
+  });
+
+  it("still reads the BRANCH commits, so a `fix:` commit under a `chore:` title owes a bump", () => {
+    const { run } = fake({ branchSubjects: ["chore: wip", "fix: the actual crash"] });
+    const code = quiet(() => main({ env: ENV, run }));
+    assert.equal(code, 1);
+  });
+
+  it("passes an internal PR that changes app source and carries no bump", () => {
+    const { run } = fake({ branchSubjects: ["refactor: extract a helper"] });
+    assert.equal(quiet(() => main({ env: ENV, run })), 0);
+  });
+
+  it("passes a user-facing PR that bumps correctly", () => {
+    const { run } = fake({ branchSubjects: ["fix: a bug"], head: "2.8.13", main: "2.8.12" });
+    assert.equal(quiet(() => main({ env: { ...ENV, PR_TITLE: "fix: a bug" }, run })), 0);
+  });
+
+  it("reads packages/pwa/package.json, NOT the root package.json", () => {
+    const { run, calls } = fake();
+    quiet(() => main({ env: ENV, run }));
+    assert.ok(
+      calls.some((c) => c === "git show HEAD:packages/pwa/package.json"),
+      "must read the PWA package's version",
+    );
+    assert.ok(!calls.some((c) => /git show \S+:package\.json$/.test(c)), "must not read the root");
+  });
+
+  it("diffs against the MERGE BASE (three dots) and skips merge commits", () => {
+    const { run, calls } = fake();
+    quiet(() => main({ env: ENV, run }));
+    assert.ok(calls.some((c) => c.includes("git diff --name-only origin/main...HEAD")));
+    assert.ok(calls.some((c) => c.includes("--no-merges")));
+  });
+
+  it("refuses to guess when PR_NUMBER, PR_TITLE or GH_REPO is missing", () => {
+    const { run } = fake();
+    for (const missing of ["PR_NUMBER", "PR_TITLE", "GH_REPO"]) {
+      const env = { ...ENV };
+      delete env[missing];
+      assert.equal(quiet(() => main({ env, run })), 2, missing);
+    }
+  });
+
+  it("returns 2 (not 1) when git cannot be read: an infra failure is not a version fault", () => {
+    const run = () => {
+      throw Object.assign(new Error("boom"), { stderr: "fatal: bad revision" });
+    };
+    assert.equal(quiet(() => main({ env: ENV, run })), 2);
+  });
+
+  it("fails a collision end to end", () => {
+    const { run } = fake({
+      branchSubjects: ["fix: a bug"],
+      head: "2.8.13",
+      main: "2.8.12",
+      peers: [{ number: 805, version: "2.8.13" }],
+    });
+    assert.equal(quiet(() => main({ env: { ...ENV, PR_TITLE: "fix: a bug" }, run })), 1);
+  });
+});

--- a/.github/workflows/push-helper-test.yml
+++ b/.github/workflows/push-helper-test.yml
@@ -9,17 +9,22 @@ on:
     paths:
       - ".github/scripts/**"
       - ".github/workflows/push-helper-test.yml"
+      - ".github/workflows/version-check.yml"
       - "packages/monitor/merge-monitor-series.mjs"
   pull_request:
     paths:
       - ".github/scripts/**"
       - ".github/workflows/push-helper-test.yml"
+      - ".github/workflows/version-check.yml"
       - "packages/monitor/merge-monitor-series.mjs"
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - name: Run push-with-rebase regression test
         run: bash .github/scripts/push-with-rebase.test.sh
+      - name: Run version-check unit tests
+        run: node --test .github/scripts/version-check.test.mjs

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,67 @@
+name: Version check
+
+# Guards the app version on every pull request (ticket #810), so two builds cannot
+# ship under one version string. A PR that changes app source with a user-facing
+# intent must carry a version strictly above main's and equal to no other open PR's;
+# any other PR must carry no bump. The rule lives in doc/CI.md.
+#
+# NOT PATH-FILTERED, deliberately: the guard must see every PR, or an internal PR
+# carrying a stray bump would slip through unguarded.
+#
+# `edited` is in the trigger list and is LOAD-BEARING. The repo squash-merges, so the
+# subject that lands on main is the PR TITLE, and the guard reads it. Without
+# `edited`, an author could pass green as `chore: tidy`, retitle to `feat: metronome`,
+# and merge unguarded: a retitle fires `edited`, not `synchronize`.
+#
+# NOT YET BLOCKING: this job reports a check named `version`, and the "Main should be
+# golden" ruleset requires only `test`. Until `version` is added to that ruleset's
+# required checks, a red result annotates the PR but does not stop a merge, and
+# Dependabot auto-merge will not see it. See doc/CI.md.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The PR head, not the merge ref, so the commit list and the diff are
+          # exactly the branch's own.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history is REQUIRED: `git log origin/main..HEAD` and
+          # `git diff origin/main...HEAD` both need the merge base, which a shallow
+          # fetch does not have. It is also nearly free here, because the repo's
+          # weight is blobs, not history.
+          fetch-depth: 0
+          # The weight IS the blobs: packages/pwa/public/audio is 775.8 MiB of the
+          # 791.5 MiB tip tree, and this job reads a 1,905-byte package.json.
+          # `blob:none` fetches commits and trees only, lazily pulling the two
+          # package.json blobs `git show` asks for; the commit walk and the
+          # name-only diff need no blobs at all.
+          #
+          # These two options are a PAIR. Removing `sparse-checkout` while keeping
+          # `filter` makes the checkout step lazily fetch every blob in the tip tree,
+          # re-introducing the full 775 MiB download.
+          filter: blob:none
+          sparse-checkout: .github
+      - name: Check app version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # The squash-merge subject is the PR title, so the title is what actually
+          # ships. The guard classifies it alongside the branch commits.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          # Pin the repo rather than letting `gh` resolve it from the ambient git
+          # remote. A wrong-repo read returns a confident EMPTY open-PR list, which is
+          # a silent pass on the one question this guard exists to answer.
+          GH_REPO: ${{ github.repository }}
+        run: |
+          git fetch origin main --no-tags
+          node .github/scripts/version-check-cli.mjs

--- a/doc/CI.md
+++ b/doc/CI.md
@@ -1,6 +1,6 @@
 # Continuous Integration
 
-The repository uses GitHub Actions for automated testing and dependency updates. All workflows run on Ubuntu latest and read the Node.js version from `.nvmrc`.
+The repository uses GitHub Actions for automated testing and dependency updates. All workflows run on Ubuntu latest. Those that build or test the app read the Node.js version from `.nvmrc`; the two that only run a dependency-free script (`version-check.yml` and `push-helper-test.yml`) use the runner's preinstalled Node instead, and so skip the `actions/setup-node` step.
 
 ## Philosophy
 
@@ -38,6 +38,119 @@ On failure, the Playwright HTML report is uploaded as an artifact and retained f
 
 This workflow is intentionally excluded from the PR gate. Playwright tests are slow and can flake on infrastructure issues. Running them nightly catches real regressions within 24 hours without blocking rapid fixes.
 
+### `version-check.yml`
+
+Triggers on every pull request to `main`, on `opened`, `synchronize`, `reopened` and
+`edited`. Not path-filtered: the guard must see every PR. It exists so two builds
+cannot ship under one version string
+([#810](https://github.com/wainwmr/spem-player/issues/810), after PR #804 and PR #805
+both shipped as 2.8.10 on 2026-07-13).
+
+**The version it guards is the one in `packages/pwa/package.json`.** The root
+`package.json` carries a different version and is not the app's. Vite injects the PWA
+package's version into `index.html` at build time.
+
+The rule, exactly as enforced:
+
+- A PR that **changes app source** with a **user-facing intent** must carry a version
+  strictly above `main`'s, and equal to no other open PR's.
+- Any other PR must carry **no bump**: its version must not be above `main`'s. It may
+  sit *below* `main`, which happens whenever `main` moves under a branch that
+  correctly did not bump.
+
+Both signals must fire. Either one alone misfires badly, and we have the evidence:
+classifying on the commit type alone would have demanded a bump on 11 of 21
+user-facing-typed commits that correctly shipped without one, because the common real
+shape is an unscoped `fix:` on the monitor package, on lint config, or on a build
+script.
+
+**App source** is anything that can change what a user downloads:
+
+- everything under `packages/pwa/`, including `index.html`, `index.ts`, `vite.config.ts`
+  and `tsconfig.json` (a resolver or target change alters the bundle) and
+  `.browserslistrc` / `.postcssrc.json` (they shape the emitted CSS);
+- `packages/scores/src/`, which `vite.config.ts` aliases as `@scores` and bundles;
+- `pnpm-lock.yaml`. The PWA declares `"dependencies": {}`, so everything it builds with
+  (`vite`, `vite-plugin-pwa`, `sass-embedded`, `workbox-window`) is a devDependency and
+  its output IS the bundle. Without the lockfile a dependency change would be
+  structurally invisible to the guard.
+
+It excludes, by exact path: `packages/pwa/package.json` (the version file itself, so
+counting it would be circular), `packages/pwa/src/test/`, `packages/pwa/e2e/`,
+`eslint.config.js`, `.prettierrc`, `.prettierignore`, `knip.json`,
+`.dependency-cruiser.cjs`, `playwright.config.ts`, `tsconfig.e2e.json` and
+`worktree-ports.ts`; plus `packages/scores/build/` (the LilyPond pipeline, which does not
+ship), `packages/monitor/`, `.github/` and `doc/`. Anything else newly added under
+`packages/pwa/` counts as shipping by default, which fails safe.
+
+**User-facing intent** means a commit subject typed `feat:`, `feature:`, `fix:`,
+`perf:` or `revert:`. `build:`, `chore:`, `ci:`, `docs:`, `refactor:`, `style:`, `test:`
+and `tooling:` are internal. The type is matched case-insensitively, a `Revert "<subject>"`
+inherits the intent of the subject it reverts, and a Dependabot dev-dependency subject
+(`[deps](deps-dev):`) is internal. A conventional type it does not recognise
+(`bugfix:`, `hotfix:`) is **not** treated as internal: it reads as user-facing, which
+is the fail-safe direction.
+
+**Which subjects it reads.** The repo squash-merges, so the subject that lands on
+`main` is the **PR title**. The guard classifies the title *and* the branch commits: a
+user-facing intent in either one counts. This is why `edited` is in the trigger list.
+Without it, an author could pass green as `chore: tidy`, retitle to `feat: metronome`,
+and merge unguarded.
+
+**Two known residuals, stated rather than hidden.** Both are deliberate, and closing
+either is a rule change for Andrew and Mark, not a bug fix.
+
+1. **The type signal.** An internally-typed change to app source owes no bump. Measured
+   against history, 12 of 122 passing commits changed app source, shipped no bump and
+   were green, and they are ordinary honest `refactor:` PRs. Roughly one commit in nine.
+   Closing it means "app source changed implies a bump", dropping the type signal
+   entirely, which would have flagged 18 of 128.
+2. **Dependabot.** A `[deps](deps-dev):` bump changes the lockfile, which IS app source,
+   but classifies as internal and so owes no bump. Since `vite` is a devDependency, a
+   bundler bump can ship a different build under an unchanged version. Without the
+   exemption every Dependabot PR goes red, and Dependabot can neither bump the version
+   nor clear the check, and its PRs auto-merge.
+
+It **fails closed**, reporting a failure rather than a silent pass, when: either
+version is not a plain `x.y.z`; the open-PR list cannot be read, is not a list, or
+comes back full and so may be truncated; the list comes back without this PR in it
+(which proves it is not the list we think it is, since the PR under test is itself an
+open PR, and an empty list would otherwise read as "nothing to collide with"); an open
+PR's version string will not parse; this PR's number or title is missing; or git cannot
+be read. A peer whose
+`packages/pwa/package.json` returns **404** is skipped rather than failed: that head
+declares no app version, so it cannot collide, and failing the list would red every PR
+in the repo until that one stale PR was closed.
+
+Exit codes: **`0`** pass; **`1`** the version is wrong (`bump-owed`, `no-bump-owed`,
+`collision`, `malformed-version`); **`2`** the guard could not tell (`unreadable`,
+`unreadable-peer`), which is an infrastructure failure, not a version violation.
+
+The decision lives in the pure function `decideVersion` in
+`.github/scripts/version-check.mjs`, unit-tested by
+`.github/scripts/version-check.test.mjs` (run by `push-helper-test.yml`, whose path
+filter this change extends to cover `version-check.yml` itself).
+`.github/scripts/version-check-cli.mjs` is the entry point the workflow runs; it exists
+so the module can be imported by its tests without a "was I invoked directly?"
+condition, which would be a fail-open guard on a fail-closed tool.
+
+> **This check does not yet block a merge.** It reports a check named `version`, and
+> the "Main should be golden" ruleset requires only `test` (see Branch Protection
+> below). Until `version` is added to that ruleset's required status checks, a red
+> result annotates the PR but does not prevent merging, and Dependabot auto-merge does
+> not see it. Adding it is a repository settings change, not a code change. It is safe
+> to require: the workflow has no path filter, so it runs on every PR to `main` and can
+> never be a permanently-pending required check.
+
+The job checks out with `filter: blob:none` and `sparse-checkout: .github`, because it
+reads a 1,905-byte `package.json` while the tip tree is 791.5 MiB, of which 775.8 MiB is
+the choir audio under `packages/pwa/public/audio/`. The two options are a pair: removing
+the sparse checkout while keeping the filter re-introduces the full download.
+`fetch-depth: 0` is kept and is required, because the commit walk and the diff both need
+the merge base.
+
+Permissions: `contents: read`, `pull-requests: read`.
+
 ### `scores-ci.yml`
 
 Triggers on push to `main` and on `pull_request`, both path-filtered to `packages/scores/**` and this workflow file.
@@ -52,7 +165,7 @@ Runs on `ubuntu-latest`.
 
 Steps:
 
-- `actions/checkout@v6` with `ref: ${{ github.head_ref || github.ref_name }}` — checkout the target branch so commits can be pushed back.
+- `actions/checkout@v7` with `ref: ${{ github.head_ref || github.ref_name }}` — checkout the target branch so commits can be pushed back.
 - `actions/setup-node@v6` from `.nvmrc` — install Node.js.
 - `pnpm install` — clean install from lockfile.
 - `pnpm run test:lilypond` — run the Lilypond-related test suite.
@@ -138,11 +251,14 @@ other's count ([#728](https://github.com/wainwmr/spem-player/issues/728)).
 
 `push-helper-test.yml` runs the helper's regression test
 (`.github/scripts/push-with-rebase.test.sh`) on any change under
-`.github/scripts/`.
+`.github/scripts/`, and also runs the `version-check.mjs` unit tests
+(`node --test .github/scripts/version-check.test.mjs`).
 
 ## Node.js Version
 
-The Node.js version is pinned in `.nvmrc`. All GitHub Actions workflows read this file via `node-version-file` in `actions/setup-node`. Netlify should be configured to use the same version.
+The Node.js version is pinned in `.nvmrc`. GitHub Actions workflows that build or test the app read this file via `node-version-file` in `actions/setup-node`. Netlify should be configured to use the same version.
+
+Two workflows are deliberate exceptions and run on the runner's preinstalled Node: `version-check.yml` and the version-check step of `push-helper-test.yml`. Both execute a single dependency-free script that uses only long-stable Node APIs, so pinning would add an `actions/setup-node` step to every pull request for determinism they do not need.
 
 ## Branch Protection
 
@@ -152,3 +268,11 @@ The `main` branch has a GitHub Ruleset ("Main should be golden") that enforces:
 - The `test` job (from `pwa-ci.yml` for PWA changes, `monitor-ci.yml` for monitor changes, `scores-ci.yml` for LilyPond changes, or `test-noop.yml` otherwise) must pass before merge
 - Branches must be up to date with `main` before merging
 - Force pushes and deletions are restricted
+
+`test` is currently the **only** required status check. The `version` job from
+`version-check.yml` is therefore advisory: it reports on every PR, but a red result
+does not block the merge button, and Dependabot auto-merge
+(`.github/workflows/dependabot-auto-merge.yml`, which merges once the required
+checks pass) does not see it. **To make the app-version guard actually guard, add
+`version` to this ruleset's required status checks.** That is a repository settings
+change and cannot be made from a pull request.

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -351,14 +351,22 @@ static method on each class handles registration.
 
 ## Commit Messages
 
-Use conventional commit format where possible:
+Use conventional commit format where possible.
 
-- `feature:` — new feature
-- `fix:` — bug fix
-- `docs:` — documentation
-- `test:` — tests
-- `refactor:` — code restructuring
-- `build:` — build system or tooling
+**User-facing** (`feat:` or `feature:` — new feature; `fix:` — bug fix; `perf:` —
+performance; `revert:`). **Internal** (`build:` — build system; `chore:`; `ci:`;
+`docs:` — documentation; `refactor:` — code restructuring; `style:`; `test:` — tests;
+`tooling:`).
+
+The distinction is enforced, so it is worth getting right. CI checks the app version on
+every pull request (`doc/CI.md` § `version-check.yml`): a PR that changes app source with
+a **user-facing** subject must bump `packages/pwa/package.json`, and one that does not
+must leave it alone. A type it does not recognise (`bugfix:`, `hotfix:`) is treated as
+user-facing, which fails safe.
+
+The check reads both the PR **title** and the branch commits, because a squash-merge lands
+whichever of them is the single subject. So the title matters as much as the commits: a
+user-facing change titled `chore:` is taken at its word and ships with no version bump.
 
 ## Best Practices
 


### PR DESCRIPTION
Fixes #810

On 2026-07-13, PR #804 and PR #805 each computed their version against `main` alone. Both claimed 2.8.10, and the second to merge shipped a different build under an already-published version. Nothing caught it: there is no CI check and no test on the version, and the only test that reads it asserts the string merely *matches* a semver shape, which a duplicate passes.

This adds a CI guard so that cannot recur.

## One thing I need from you

**The check does not block a merge yet, and it cannot until you change a repository setting.**

This adds a status check named `version`. The "Main should be golden" ruleset currently requires exactly one check, `test`:

```console
$ gh api repos/wainwmr/spem-player/rulesets/15878992 \
    --jq '[.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context]'
["test"]
```

So a red `version` check annotates a PR and the merge button stays green, and `dependabot-auto-merge.yml` (which merges as soon as the *required* checks pass) cannot see it at all. Had this branch been in place on 2026-07-13, it would have turned PR #805 red and #805 would have merged anyway.

**Please add `version` to that ruleset's required status checks.** It is safe to require: the workflow has no path filter, so it runs on every PR to `main` and can never become a permanently-pending required check (which is the reason `test-noop.yml` exists for `test`). `doc/CI.md` states the gap explicitly, so the code is honest about it until you do.

## The rule

A version bump is owed when **both** signals fire:

- the PR changes **app source** (something that can alter what a user downloads), **and**
- at least one commit subject is not plainly internal.

Such a PR must carry a version strictly above main's and equal to no other open PR's. Any other PR must carry **no** bump. It may sit *below* main, which happens whenever main moves under a branch that correctly did not bump; #808 was exactly that shape, so requiring equality would have failed it.

**App source** is everything under `packages/pwa/` (bar the version file, tests, e2e and the tooling configs, enumerated by exact path), plus `packages/scores/src/` (which `vite.config.ts` aliases as `@scores` and bundles) and `pnpm-lock.yaml` (the PWA declares `"dependencies": {}`, so `vite`, `vite-plugin-pwa`, `sass-embedded` and `workbox-window` are all devDependencies whose output *is* the bundle).

**Why the path, and not the commit type alone.** The type signal on its own does not work in this repo, and that is measured rather than asserted. A type-based classifier, replayed against `main`, demanded a bump on 11 of 21 user-facing-typed commits that correctly shipped without one, because the common real shape here is an unscoped `fix:` on the monitor package, on lint config, or on a build script. A guard that reds a third of legitimate PRs gets switched off, and then the bug comes back.

**Which subjects it reads.** The repo squash-merges with `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so the landed subject is the branch commit's on a single-commit PR and the PR title otherwise. Either can be what ships, so the guard reads both. That is also why `edited` is in the trigger list: a retitle fires `edited`, not `synchronize`, so without it an author could pass green as `chore:` and retitle to `feat:` before merging.

## Evidence

Replayed against **all 128 commits merged since `packages/pwa/package.json` was created**: it agrees with what actually happened **122 times, with zero false greens**, and reds 6.

Five of the six are the guard working, including **PR #804 itself**. Three others (`8467e3b`, `8acb303`, `d0127fc`) changed app source and shipped under an unchanged version, so this has happened more than once.

The sixth is a **false red**, named here rather than buried: `f2207fb fix: restore ESLint coverage` touches only `pnpm-lock.yaml` and ships nothing to a user. It is red because the lockfile counts as app source under a `fix:` subject. That is the measured cost of closing the dependency hole, one in 128, and the remedy is honest typing (a lint-dependency change is `build:`, not `fix:`), never a version burn.

## Two known residuals, stated rather than hidden

Both are deliberate. Closing either is a rule change rather than a bug fix, so I have not made it unilaterally.

1. **An internally-typed change to app source owes no bump.** Measured: 12 of the 122 passing commits changed app source, shipped no bump and were green, and they are ordinary honest `refactor:` PRs. Roughly one in nine. Closing it means "app source changed implies a bump", which would have flagged 18 of 128.
2. **A Dependabot dev-dependency bump owes no bump**, even though `vite` is a devDependency whose output is the bundle. Without the exemption every Dependabot PR goes red, and Dependabot can neither bump the app version nor clear the check, and its PRs auto-merge.

Both are documented in `doc/CI.md` and in the module header.

## It fails closed

A guard that passes when it cannot do its job is worse than no guard, because it manufactures the confidence it was built to earn. It reports a failure, never a silent pass, when: either version is not a plain `x.y.z`; the open-PR list cannot be read, is not a list, or comes back full and so may be truncated; the list comes back **without this PR in it** (the PR under test is itself an open PR, so its absence proves the list cannot be trusted, and an empty list would otherwise read as "nothing to collide with"); a peer's version will not parse; or git cannot be read. A peer whose `packages/pwa/package.json` 404s is skipped only on proof that its ref resolves, and a **fork** peer is never skipped, because a dropped peer could hide a collision.

Exit `1` means the version is wrong. Exit `2` means the guard could not tell. A crash is not a version violation.

## Structure and cost

`decideVersion` is a pure function with **62 unit tests**, run by `push-helper-test.yml`. `version-check-cli.mjs` is a separate entry point so the module can be imported by its tests without asking "was I invoked directly?", which would be a fail-open guard on a fail-closed tool.

The job checks out with `filter: blob:none` and `sparse-checkout: .github`, because it reads a 1,905-byte `package.json` while the tip tree is 791.5 MiB, of which 775.8 MiB is choir audio. The two options are a pair: dropping the sparse checkout while keeping the filter re-introduces the full download. `fetch-depth: 0` is kept and required, because the commit walk and the diff both need the merge base.

This branch passes its own guard.

- VERA
