### PR TITLE
fix: stop a Telegram failure suppressing dispatchAlert's tracking issue

### DIFF
--- a/packages/monitor/monitor-resources.mjs
+++ b/packages/monitor/monitor-resources.mjs
@@ -536,9 +536,11 @@ export async function openIssue(title, body) {
 
 /**
  * Dispatch a monitor alert: optionally send a Telegram message, then open a
- * tracking issue. A failure in either is logged with `onErrorLog` and
- * swallowed, so a secondary alert failure never masks the caller's own in-flight
- * error.
+ * tracking issue. The two legs are attempted independently: a failure in
+ * either is logged with `onErrorLog` (tagged with the failing leg) and
+ * swallowed, so a Telegram outage
+ * cannot suppress the durable tracking issue (#748) and a secondary alert
+ * failure never masks the caller's own in-flight error.
  *
  * @param {object} alert
  * @param {string} [alert.telegramText] - Telegram message. Omit it (or pass any
@@ -554,11 +556,21 @@ export async function dispatchAlert({
   issueBody,
   onErrorLog,
 }) {
+  // Each log line tags its leg: a network-level fetch failure carries the
+  // bare message "fetch failed" with no host, so without the tag the two legs
+  // are indistinguishable in a CI log exactly when it matters, namely whether
+  // the durable issue opened or not (Vera 748-01).
+  if (telegramText) {
+    try {
+      await sendTelegram(telegramText);
+    } catch (alertErr) {
+      console.error(`${onErrorLog}: [telegram] ${alertErr.message}`);
+    }
+  }
   try {
-    if (telegramText) await sendTelegram(telegramText);
     await openIssue(issueTitle, issueBody);
   } catch (alertErr) {
-    console.error(`${onErrorLog}: ${alertErr.message}`);
+    console.error(`${onErrorLog}: [issue] ${alertErr.message}`);
   }
 }
 

--- a/packages/monitor/monitor-resources.test.mjs
+++ b/packages/monitor/monitor-resources.test.mjs
@@ -919,6 +919,58 @@ describe("dispatchAlert", () => {
       m.restore();
     }
   });
+
+  test("still opens the issue when Telegram fails (#748)", async () => {
+    // The issue is the durable channel; a Telegram outage must not suppress it.
+    const m = startMock([
+      ["/sendMessage", () => res("down", { ok: false, status: 500 })],
+      ["/issues", () => res({ id: 1 })],
+    ]);
+    const errs = [];
+    const origErr = console.error;
+    console.error = (msg) => errs.push(msg);
+    try {
+      await dispatchAlert({
+        telegramText: "x",
+        issueTitle: "T",
+        issueBody: "B",
+        onErrorLog: "Failed to send alert for Netlify failure",
+      });
+      assert.ok(m.calls.some((c) => /\/issues$/.test(c.url)));
+      assert.equal(errs.length, 1);
+      assert.match(errs[0], /^Failed to send alert for Netlify failure: \[telegram\] /);
+    } finally {
+      console.error = origErr;
+      m.restore();
+    }
+  });
+
+  test("logs both failures when both legs fail (#748)", async () => {
+    const m = startMock([
+      ["/sendMessage", () => res("down", { ok: false, status: 500 })],
+      ["/issues", () => res("nope", { ok: false, status: 500 })],
+    ]);
+    const errs = [];
+    const origErr = console.error;
+    console.error = (msg) => errs.push(msg);
+    try {
+      await dispatchAlert({
+        telegramText: "x",
+        issueTitle: "T",
+        issueBody: "B",
+        onErrorLog: "p",
+      });
+      // The legs must be tellable apart even when both messages are a bare
+      // "fetch failed" (network-level errors carry no host): the tag is the
+      // only reliable discriminator in a CI log (Vera 748-01).
+      assert.equal(errs.length, 2);
+      assert.match(errs[0], /^p: \[telegram\] /);
+      assert.match(errs[1], /^p: \[issue\] /);
+    } finally {
+      console.error = origErr;
+      m.restore();
+    }
+  });
 });
 
 // --- api -------------------------------------------------------------------


### PR DESCRIPTION
Fixes #748

`dispatchAlert` does two things when the monitor detects a problem: it sends a Telegram message, and it files a tracking issue. They ran in sequence, so a Telegram failure threw before the issue was ever created, and the problem the alert existed to report went unrecorded. The louder channel silenced the durable one.

The two are now decoupled: each is attempted independently, and a failure in one is logged without preventing the other. The tracking issue is filed whether or not the Telegram send succeeds.

`packages/monitor/monitor-resources.test.mjs` covers the case that mattered: a failing Telegram send, and the issue still filed.
