### PR TITLE
test(e2e): stub Cloudflare Web Analytics beacon so it can't fail the suite (#822)

### DIFF
--- a/packages/pwa/e2e/helpers/page-errors.ts
+++ b/packages/pwa/e2e/helpers/page-errors.ts
@@ -43,7 +43,8 @@ const ALLOWLIST: string[] = [
   // DNS-blocked in test environments (net::ERR_NAME_NOT_RESOLVED); their
   // load failure is environmental, not an app defect. Matched on the URL
   // suffix this fixture appends, so the entries are browser-agnostic.
-  "at https://static.cloudflareinsights.com/",
+  // Cloudflare Web Analytics is not listed here: it is intercepted and
+  // stubbed below (#822) so its beacon never reaches the network at all.
   "at https://www.googletagmanager.com/",
   "at https://cdnjs.buymeacoffee.com/",
 ];
@@ -70,6 +71,17 @@ export const test = base.extend<{ pageErrorCapture: readonly string[] }>({
           captured.push(entry);
         }
       };
+
+      // Stub Cloudflare Web Analytics so its beacon never fires in e2e (#822).
+      // Under the preview server the cross-origin RUM POST to
+      // cloudflareinsights.com/cdn-cgi/rum is CORS-blocked (ERR_FAILED), which
+      // floods console.error and fails otherwise-unrelated tests. Fulfil with
+      // an empty 204 rather than abort() so no "Failed to load resource" error
+      // is logged — keeping the console-error gate strict with no allowlist.
+      // Covers both the static.* script host and the bare RUM endpoint.
+      await page.route(/cloudflareinsights\.com/, (route) =>
+        route.fulfill({ status: 204, body: "" })
+      );
 
       page.on("pageerror", (err) => {
         record(`pageerror: ${err.message}`);


### PR DESCRIPTION
Fixes #822.

## Problem

The nightly **PWA E2E** run on `main` failed **97/123 tests** ([run 29306369458](https://github.com/wainwmr/spem-player/actions/runs/29306369458)) — all from one external cause, not a regression. The app's Cloudflare Web Analytics beacon (`cloudflareinsights.com/cdn-cgi/rum`) is CORS-blocked under the preview server (`localhost:4173`), flooding `console.error`, and the page-error gate ([page-errors.ts](../blob/main/packages/pwa/e2e/helpers/page-errors.ts)) fails any test that emits a non-allowlisted `console.error`. The existing allowlist only covered `static.cloudflareinsights.com` (the script), not the RUM POST endpoint.

## Change

Intercept the whole `cloudflareinsights.com` domain in the auto page-error fixture and **fulfil with an empty 204** — not `abort()`, which would itself log `ERR_FAILED`. The beacon never reaches the network, so it produces no console error and the console-error gate stays strict with **no allowlist entry**. Removes the now-redundant `static.cloudflareinsights.com` allowlist line.

## Verification

- Ran previously-failing specs locally on chromium — **smoke (9), bar-navigation, pwa-update-toast all green**.
- Two `playback-toggle` #634 tests still fail locally, but I confirmed they **also fail on clean `main`** without this change: it's a local headless audio-autoplay quirk (`toBeVisible` on the pause icon), unrelated to the beacon. In CI those tests were only red due to beacon noise, which this removes.

## Acceptance criteria (from #822)

- [x] No E2E test issues a live request to `cloudflareinsights.com` (intercepted).
- [x] Console-error gate stays strict; no new allowlist entry for the beacon (one removed).
- [x] Real analytics still loads in production (test-only interception).
- [ ] Nightly PWA E2E on `main` green — verify on next scheduled run / a manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)