### PR TITLE
fix: keep the user's feedback when the send fails

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -139,11 +139,27 @@ channels, so without the fixture a test can pass while the page under it is
 broken. `e2e/page-errors.spec.ts` is the fixture's self-test: each positive
 case injects one error class and polls the capture array, and a final
 `test.fail()`-annotated case pins that a non-empty capture fails at teardown.
-If a spec ever legitimately produces a captured message, add a narrow,
-commented entry to the module's `ALLOWLIST` (the current entries cover
-third-party script hosts that are absent or DNS-blocked in test environments)
-rather than reverting the import. Service workers are blocked suite-wide
-(`playwright.config.ts`) so page-level network events stay observable.
+If a spec legitimately produces a captured message, add a narrow, commented entry
+to the module's `ALLOWLIST` rather than reverting the import. The current entries
+cover third-party script hosts that are absent or DNS-blocked in test
+environments, and the feedback submit handler's `console.error` on a failed send
+(#798), which is an expected byproduct of the failure path
+`e2e/feedback-modal.spec.ts` drives; that log is asserted in
+`src/test/feedback.test.ts`, not in the spec. Service workers are blocked
+suite-wide (`playwright.config.ts`) so page-level network events stay observable.
+
+**Simulate a network failure by stubbing `fetch`, not by aborting the route.**
+`route.abort()` makes the browser log its own `Failed to load resource:
+net::ERR_FAILED`, which the fixture captures. Allowlisting it means adding an
+entry for a failed load of the site root `/`, and the fixture's convention is to
+keep an entry as narrow as the URL: that URL is the port-dependent `baseURL`
+(`worktree-ports.ts` gives each worktree its own offset), so a conforming entry
+is not portable, and the broad text-only alternative would mask a genuine failure
+to load the document itself. Reject the call in the page instead
+(`page.addInitScript` replacing `window.fetch`, bound to `window`), which issues
+no request and raises the same `TypeError` a genuinely offline fetch raises.
+`failTheSend` in `e2e/feedback-modal.spec.ts` is the implementation; it points
+here for the reason rather than restating it.
 
 ### E2E Prerequisites
 

--- a/packages/pwa/e2e/feedback-modal.spec.ts
+++ b/packages/pwa/e2e/feedback-modal.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "./helpers/page-errors";
+import {
+  getComputedStyleValue,
+  expectComputedStyle,
+} from "./helpers/computed-style";
 
 test.describe("Feedback modal mobile viewport", () => {
   test("does not overflow horizontally on iPhone SE viewport (375px)", async ({ page }) => {
@@ -44,5 +48,204 @@ test.describe("Feedback modal mobile viewport", () => {
     expect(box).not.toBeNull();
     expect(box!.width).toBeGreaterThan(0);
     expect(box!.height).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * A failed send must not destroy what the user typed (#798).
+ *
+ * These are e2e rather than jsdom because the fix turns on the cascade: the
+ * failure message is the same #feedback-result element as the confirmation,
+ * distinguished only by a class that changes its computed height and colour.
+ * jsdom reads the inline write, not the rendered result, so it cannot tell a
+ * legible error from an invisible one (the #1074 rule; see helpers/computed-style).
+ */
+test.describe("Feedback send failure (#798)", () => {
+  const MESSAGE = "Bar 42 will not scroll on the early score";
+
+  /**
+   * Fail the send the way an offline browser does: a rejected fetch.
+   *
+   * Deliberately a fetch stub rather than `route.abort()`; `doc/TESTING.md`
+   * (Page-error capture) carries the reason. This rejects with the same TypeError
+   * a genuinely offline fetch rejects with, and issues no request.
+   */
+  async function failTheSend(page: import("@playwright/test").Page) {
+    await page.addInitScript(() => {
+      // bind: fetch throws "Illegal invocation" if called detached from window.
+      const realFetch = window.fetch.bind(window);
+      window.fetch = (input: RequestInfo | URL, init?: RequestInit) =>
+        init?.method === "POST"
+          ? Promise.reject(new TypeError("Failed to fetch"))
+          : realFetch(input, init);
+    });
+  }
+
+  async function submitFailingFeedback(page: import("@playwright/test").Page) {
+    await page.locator("#feedback-trigger").click();
+    await page.locator("#feedback-message").fill(MESSAGE);
+    await page.locator("label[for='star4']").click();
+    await page.locator("#feedback-submit").click();
+    // toBeVisible, not just toHaveText: getComputedStyle answers happily on a
+    // display:none element, so every style assertion below would pass on a page
+    // where the user is shown nothing at all (#798).
+    await expect(page.locator("#feedback-result")).toBeVisible();
+    await expect(page.locator("#feedback-result")).toHaveText(
+      "Couldn't send, please try later"
+    );
+  }
+
+  test("keeps the modal open with the message and rating intact", async ({
+    page,
+  }) => {
+    await failTheSend(page);
+    await page.goto("/");
+    await submitFailingFeedback(page);
+
+    // The modal stays up, the form stays with it, and nothing the user typed is
+    // gone: they can press Send again without retyping a word.
+    await expect(page.locator("#feedback-modal")).toBeVisible();
+    await expect(page.locator("#feedback-form")).toBeVisible();
+    await expect(page.locator("#feedback-message")).toHaveValue(MESSAGE);
+    await expect(page.locator("#star4")).toBeChecked();
+
+    // The success path's 1500 ms auto-close must not be running. There is no
+    // web-first way to assert that nothing happens within a window, so the wait is
+    // the assertion, not a substitute for one.
+    await page.waitForTimeout(1800);
+    await expect(page.locator("#feedback-modal")).toBeVisible();
+    await expect(page.locator("#feedback-message")).toHaveValue(MESSAGE);
+
+    // Press Send AGAIN, through the real button. This is the only layer that can
+    // catch a Send left disabled: every jsdom test dispatches a synthetic submit
+    // event on the form, which never consults the button. Playwright auto-waits for
+    // an enabled element, so a dead button fails here by timing out.
+    await page.locator("#feedback-submit").click();
+    await expect(page.locator("#feedback-result")).toHaveText(
+      "Couldn't send, please try later"
+    );
+  });
+
+  // Only a real browser can see this: it is a cascade fact (the :hover rule sits at
+  // equal specificity below :disabled, so without :not(:disabled) a hovered disabled
+  // Send renders identically to a live one) and jsdom has no cascade and no hover.
+  // Playwright leaves the pointer on the element after click(), so hover is live.
+  test("greys Send out while the POST is in flight, even under the pointer", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      const realFetch = window.fetch.bind(window);
+      window.fetch = (input: RequestInfo | URL, init?: RequestInit) =>
+        init?.method === "POST"
+          ? new Promise<Response>(() => {}) // never settles
+          : realFetch(input, init);
+    });
+    await page.goto("/");
+
+    await page.locator("#feedback-trigger").click();
+    await page.locator("#feedback-message").fill("hangs forever");
+    await page.locator("#feedback-submit").click();
+
+    await expect(page.locator("#feedback-submit")).toBeDisabled();
+    await expectComputedStyle(page, "#feedback-submit", "opacity", "0.55");
+  });
+
+  test("announces the error to assistive technology", async ({ page }) => {
+    await failTheSend(page);
+    await page.goto("/");
+    await submitFailingFeedback(page);
+
+    // The failure no longer closes the modal, so nothing about the page's shape tells
+    // a screen-reader user it failed. The live region is the announcement. Asserted
+    // here, against the real index.html: the jsdom fixture builds its own
+    // #feedback-result and would pass without the attribute.
+    await expect(page.locator("#feedback-result")).toHaveAttribute(
+      "role",
+      "alert"
+    );
+  });
+
+  // The modal's background (--color-background-lighter) is light blue in BOTH themes,
+  // so the error colour is fixed rather than theme-dependent. A red chosen for the
+  // dark page background would land at ~1.6:1 here, which is the defect #569 already
+  // fixed once for the buttons in this same modal.
+  //
+  // Both themes therefore measure the same two colours today, and the light case
+  // looks like a duplicate. It is not. It fails the day someone overrides
+  // --color-error in body.light-theme (the colour is pinned exactly below), or
+  // overrides --color-background-lighter in a way that drops the error below AA.
+  // Do not delete it as redundant.
+  for (const theme of ["dark", "light"] as const) {
+    test(`error text meets WCAG AA against the modal in ${theme} mode`, async ({
+      page,
+    }) => {
+      await failTheSend(page);
+      await page.goto("/");
+
+      // Prove the theme actually flipped. Without this, a silently-failed click
+      // would measure dark mode twice and the light-mode case would pass vacuously.
+      const body = page.locator("body");
+      if (theme === "light") {
+        await page.locator("#darkswitch").click();
+        await expect(body).toHaveClass(/light-theme/);
+      } else {
+        await expect(body).not.toHaveClass(/light-theme/);
+      }
+
+      await submitFailingFeedback(page);
+
+      const ratio = await page
+        .locator("#feedback-result")
+        .evaluate((el: HTMLElement) => {
+          const parse = (c: string) =>
+            (c.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number);
+          const luminance = (rgb: number[]) => {
+            const [r, g, b] = rgb.map((v) => {
+              const s = v / 255;
+              return s <= 0.03928
+                ? s / 12.92
+                : Math.pow((s + 0.055) / 1.055, 2.4);
+            });
+            return 0.2126 * r! + 0.7152 * g! + 0.0722 * b!;
+          };
+          const modal = document.getElementById("feedback-modal")!;
+          const fg = luminance(parse(getComputedStyle(el).color));
+          const bg = luminance(
+            parse(getComputedStyle(modal).backgroundColor)
+          );
+          const [hi, lo] = fg > bg ? [fg, bg] : [bg, fg];
+          return (hi! + 0.05) / (lo! + 0.05);
+        });
+
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+
+      // The ratio alone does not pin that --color-error is applied: delete the rule
+      // and #feedback-result inherits --color-text, which in LIGHT mode still clears
+      // 4.5:1 against the modal, so the light case would pass with the fix gone
+      // (#798). Pin the resolved colour too.
+      await expectComputedStyle(
+        page,
+        "#feedback-result",
+        "color",
+        "rgb(156, 22, 22)"
+      );
+    });
+  }
+
+  test("the error does not claim the confirmation's full height", async ({
+    page,
+  }) => {
+    await failTheSend(page);
+    await page.goto("/");
+    await submitFailingFeedback(page);
+
+    // The confirmation is a 140px panel that replaces the form. The error sits
+    // beneath a form that is still on screen, so it must not reserve that block.
+    const minHeight = await getComputedStyleValue(
+      page,
+      "#feedback-result",
+      "min-height"
+    );
+    expect(minHeight).toBe("0px");
   });
 });

--- a/packages/pwa/e2e/helpers/page-errors.ts
+++ b/packages/pwa/e2e/helpers/page-errors.ts
@@ -31,13 +31,15 @@ import { test as base, expect } from "@playwright/test";
  * and fails the test at teardown if any arrived. Every spec imports
  * `test`/`expect` from this module instead of `@playwright/test`.
  *
- * If a spec ever legitimately produces one of these (none does today), add an
- * explicit, commented entry to ALLOWLIST rather than reverting its import —
- * silent suppression is the failure mode this fixture exists to remove.
+ * If a spec legitimately produces one of these, add an explicit, commented entry
+ * to ALLOWLIST rather than reverting its import: silent suppression is the failure
+ * mode this fixture exists to remove. The feedback failure specs drive a path that
+ * logs deliberately (#798); their entry is below.
  */
 
 // Substrings of captured messages that are expected and must not fail a test.
-// Keep each entry commented with the reason and keep it as narrow as the URL.
+// Keep each entry commented with the reason, and narrow enough that only the
+// expected message can match it (a URL, or a prefix only one call site emits).
 const ALLOWLIST: string[] = [
   // Third-party scripts loaded by index.html are routinely absent or
   // DNS-blocked in test environments (net::ERR_NAME_NOT_RESOLVED); their
@@ -47,6 +49,14 @@ const ALLOWLIST: string[] = [
   // stubbed below (#822) so its beacon never reaches the network at all.
   "at https://www.googletagmanager.com/",
   "at https://cdnjs.buymeacoffee.com/",
+  // The feedback-modal failure specs reject the POST by stubbing window.fetch in
+  // the page (never route.abort(), which would make the browser log its own
+  // resource error; see doc/TESTING.md). The submit handler then logs the cause
+  // (#798) so an unregistered form is distinguishable from a network blip. That
+  // log is an expected byproduct of the failure path those specs drive; it is
+  // asserted in src/test/feedback.test.ts, not there. Kept to the exact prefix
+  // index.ts emits, so a genuinely unexpected console error still fails the test.
+  "console.error: Feedback send failed:",
 ];
 
 // "/audio/" mirrors config.audio_prefix (src/ts/config.ts, value pinned by

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -148,7 +148,10 @@
                     </div>
                 </div>
             </form>
-            <div id="feedback-result" style="display: none;"></div>
+            <!-- Live region: a failed send shows its error in place, with no dismissal.
+                 showFeedbackError moves focus to the textarea BEFORE writing here, so the
+                 alert is the last event and is not cut off by the focus move (#798). -->
+            <div id="feedback-result" role="alert" style="display: none;"></div>
         </div>
 
         <form name="feedback" netlify netlify-honeypot="bot-field" hidden>

--- a/packages/pwa/index.ts
+++ b/packages/pwa/index.ts
@@ -46,14 +46,23 @@ const controls = document.querySelector("music-controls") as MusicControls;
 const info = document.getElementById("info") as HTMLSpanElement;
 const help = document.getElementById("help") as HTMLDivElement;
 const backdrop = document.getElementById("backdrop") as HTMLDivElement;
-const feedbackTrigger = document.getElementById("feedback-trigger") as HTMLSpanElement;
-const feedbackIcon = document.getElementById("feedback-icon") as HTMLSpanElement;
-const feedbackModal = document.getElementById("feedback-modal") as HTMLDivElement;
-const feedbackCancel = document.getElementById("feedback-cancel") as HTMLButtonElement;
-const feedbackMessage = document.getElementById("feedback-message") as HTMLTextAreaElement;
-const feedbackResult = document.getElementById("feedback-result") as HTMLDivElement;
-const feedbackForm = document.getElementById("feedback-form") as HTMLFormElement;
-const hiddenFeedbackForm = document.querySelector('form[name="feedback"]') as HTMLFormElement;
+// Null in the jsdom fixtures that do not build the feedback markup (the darkmode,
+// keyboard and setbar tests), so the guards on them are load-bearing rather than
+// defensive; feedback.test.ts injects the markup, so they are non-null there.
+// #feedback-modal is in the shared fixture, empty, because keyboard.test.ts's KeyF
+// and Escape tests need it. Every use is already guarded or optional-chained, so
+// typing them honestly costs nothing and stops the next unguarded write compiling.
+// The elements above are a different case: the app asserts them and uses them
+// unguarded, so typing them would force guards everywhere.
+const feedbackTrigger = document.getElementById("feedback-trigger") as HTMLSpanElement | null;
+const feedbackIcon = document.getElementById("feedback-icon") as HTMLSpanElement | null;
+const feedbackModal = document.getElementById("feedback-modal") as HTMLDivElement | null;
+const feedbackCancel = document.getElementById("feedback-cancel") as HTMLButtonElement | null;
+const feedbackSubmit = document.getElementById("feedback-submit") as HTMLButtonElement | null;
+const feedbackMessage = document.getElementById("feedback-message") as HTMLTextAreaElement | null;
+const feedbackResult = document.getElementById("feedback-result") as HTMLDivElement | null;
+const feedbackForm = document.getElementById("feedback-form") as HTMLFormElement | null;
+const hiddenFeedbackForm = document.querySelector('form[name="feedback"]') as HTMLFormElement | null;
 const darkswitch = document.getElementById("darkswitch") as HTMLElement;
 const scoreswitch = document.getElementById("scoreswitch") as HTMLElement;
 const helpIcon = document.getElementById("help-icon") as HTMLElement;
@@ -409,9 +418,38 @@ function showHelp(show = true) {
   }
 }
 
+// The modal's send state (#798). A pending close timer means a confirmation is on
+// screen. The session stamps each submit, so a response whose modal is gone renders
+// nothing. The in-flight flag admits one send at a time. There is no fetch timeout a
+// page can rely on, so the deadline is what stops a hung POST holding the lock in
+// silence.
+//
+// resetFeedbackForm bumps the session, aborts the request, clears the timer and
+// releases the lock. The chain's .finally also releases the lock, guarded by the
+// session, so the two cannot fight.
+//
+// The deadline is generous on purpose. It can only fire once the request is out and
+// we are waiting on an answer, so a short one converts a merely-slow network into a
+// reported failure, and the user then re-sends feedback Netlify has already filed.
+const FEEDBACK_SEND_TIMEOUT_MS = 30_000;
+let feedbackCloseTimer: ReturnType<typeof setTimeout> | undefined;
+let feedbackAbort: AbortController | undefined;
+let feedbackSession = 0;
+let feedbackSending = false;
+
 function showFeedback(show = true) {
   if (!feedbackModal) return;
   if (show) {
+    // A pending close timer means a confirmation is on screen. Reopening adopts it:
+    // hand the form back, rather than only cancelling the timer that would have done
+    // so, or the modal is left showing "Thank you" with no form and no buttons (Send
+    // and Cancel both live inside the form).
+    //
+    // Conditional on the timer, and only on the timer. Reopening an already-open
+    // modal is routine (the icon, and KeyF once focus has left the textarea, where
+    // keyboardTapped's input-guard would otherwise swallow it), so an unconditional
+    // reset here would wipe a half-typed message: #798 by another route.
+    if (feedbackCloseTimer !== undefined) resetFeedbackForm();
     backdrop.style.display = "block";
     feedbackModal.style.display = "block";
     updateFeedbackContext();
@@ -423,7 +461,21 @@ function showFeedback(show = true) {
   }
 }
 
+// The teardown: the only writer that ends a session. It must release the send lock
+// as well as the rest, or a send the user walked away from leaves the next modal
+// with a dead Send button.
 function resetFeedbackForm() {
+  // Cancel the request, not merely its result. An abandoned POST that has not yet
+  // reached Netlify is dropped, so the user cannot file the same message twice by
+  // reopening and sending again. One already delivered is still filed: abort stops
+  // us waiting on it, it does not un-send it.
+  feedbackAbort?.abort();
+  feedbackAbort = undefined;
+  feedbackSession++;
+  feedbackSending = false;
+  if (feedbackSubmit) feedbackSubmit.disabled = false;
+  clearTimeout(feedbackCloseTimer);
+  feedbackCloseTimer = undefined;
   if (feedbackForm) {
     feedbackForm.style.display = "";
     feedbackForm.reset();
@@ -433,16 +485,51 @@ function resetFeedbackForm() {
   if (feedbackResult) {
     feedbackResult.style.display = "none";
     feedbackResult.textContent = "";
+    feedbackResult.classList.remove("feedback-error");
   }
 }
 
+// Success only. The form has done its job, so replace it with the confirmation and
+// tidy up. A failed send must NOT come through here: this teardown destroys the
+// message the user is being asked to send again (#798).
+//
+// Both writers set every property they share, rather than relying on the state the
+// other left behind, and both set the region's display before its text, so the live
+// region (role="alert") is in the accessibility tree before its content lands.
 function showFeedbackResult(message: string) {
-  if (feedbackForm) feedbackForm.style.display = "none";
+  // Arm the close FIRST, so a throw while rendering below still closes the modal.
+  // An empty modal closing is not a good outcome; it is the less bad one. It bounds
+  // the window in which the user, left on an unchanged form, presses Send again and
+  // files the same feedback twice, rather than leaving that window open.
+  clearTimeout(feedbackCloseTimer);
+  feedbackCloseTimer = setTimeout(() => showFeedback(false), 1500);
   if (feedbackResult) {
-    feedbackResult.textContent = message;
+    feedbackResult.classList.remove("feedback-error");
     feedbackResult.style.display = "flex";
+    feedbackResult.textContent = message;
   }
-  setTimeout(() => showFeedback(false), 1500);
+  if (feedbackForm) feedbackForm.style.display = "none";
+}
+
+// Failure. Leave the form, the message and the rating exactly as they are and show
+// the error beneath them, so "please try later" costs the user nothing.
+function showFeedbackError(message: string) {
+  // No close timer may survive into a failure: it would auto-close the modal and
+  // reset the very message the user is being asked to send again.
+  clearTimeout(feedbackCloseTimer);
+  feedbackCloseTimer = undefined;
+  if (feedbackForm) feedbackForm.style.display = "";
+  // After a CLICK, focus was on Send, and disabling it moved focus to <body>, where
+  // Enter reaches the global key handler and toggles playback. Put it back in the
+  // textarea. (Submitting with Enter never left the textarea, so this is a no-op
+  // there.) Before the alert text lands, not after: a focus move after the write
+  // would flush the screen reader's speech queue and cut the announcement off.
+  feedbackMessage?.focus();
+  if (feedbackResult) {
+    feedbackResult.classList.add("feedback-error");
+    feedbackResult.style.display = "flex";
+    feedbackResult.textContent = message;
+  }
 }
 
 // Derive the playback status from the audio element at read time, rather than
@@ -644,6 +731,7 @@ function init(): void {
     });
     feedbackForm.addEventListener("submit", (e) => {
       e.preventDefault();
+      if (feedbackSending) return;
       syncFeedbackRating();
       syncFeedbackMessage();
       updateFeedbackContext();
@@ -660,16 +748,104 @@ function init(): void {
         message,
         context,
       });
-      fetch("/", {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: data.toString(),
-      })
+      // The modal session this send belongs to. A response whose session is gone
+      // renders nothing (#798).
+      const session = feedbackSession;
+      const onScreen = () => session === feedbackSession;
+      // Blank the previous attempt's error before the lock, so a retry that fails the
+      // same way is visible rather than rewriting an identical string into a region
+      // already showing it. This makes the SIGHTED change reliable; whether a screen
+      // reader re-announces an identical alert depends on the reader. Done
+      // synchronously and before the lock: a throw here wedges nothing.
+      if (feedbackResult) {
+        feedbackResult.style.display = "none";
+        feedbackResult.textContent = "";
+        feedbackResult.classList.remove("feedback-error");
+      }
+      const controller = new AbortController();
+      feedbackAbort = controller;
+      let timedOut = false;
+      const deadline = setTimeout(() => {
+        timedOut = true;
+        controller.abort(new Error("feedback send timed out"));
+      }, FEEDBACK_SEND_TIMEOUT_MS);
+      feedbackSending = true;
+      if (feedbackSubmit) feedbackSubmit.disabled = true;
+      // Disabling the button blurs it, so focus would otherwise fall to <body> for
+      // the whole send, where Space and Enter reach the global key handler and
+      // toggle playback behind the open modal. Park it in the textarea instead.
+      feedbackMessage?.focus();
+      // Everything from the fetch onward runs inside the chain, so a throw becomes a
+      // rejection the handler below logs and the .finally releases. A synchronous throw
+      // outside it would escape before the chain existed, leaving Send disabled until
+      // the user dismissed the modal, losing what they typed.
+      Promise.resolve()
+        .then(() =>
+          fetch("/", {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: data.toString(),
+            signal: controller.signal,
+          })
+        )
         .then((res) => {
-          if (!res.ok) throw new Error();
-          showFeedbackResult("Thank you");
+          // The status distinguishes an unregistered Netlify form's permanent 404
+          // from a network blip.
+          if (!res.ok) {
+            throw new Error(`feedback POST failed: HTTP ${res.status}`);
+          }
         })
-        .catch(() => showFeedbackResult("Couldn't send, please try later"));
+        // Two sibling handlers, not then-catch: a throw inside the success
+        // handler must not fall into the failure handler, which would tell the
+        // user their feedback had not been sent when in fact it had.
+        .then(
+          () => {
+            if (onScreen()) showFeedbackResult("Thank you");
+          },
+          (err: unknown) => {
+            // The send log and the error render are wrapped, so a DOM throw while
+            // rendering the error is logged here rather than mislabelled by the tail
+            // catch.
+            try {
+              // The user walked away and we cancelled the request. That is not a
+              // failure, and logging it as one makes a cancellation indistinguishable
+              // from a real fault to anyone reading the console later.
+              if (!onScreen() && controller.signal.aborted && !timedOut) return;
+              console.error(
+                timedOut ? "Feedback send timed out:" : "Feedback send failed:",
+                err
+              );
+              if (onScreen()) {
+                // On a timeout the request is out and we are waiting on an answer, so
+                // "couldn't send" would assert the opposite of the likeliest truth and
+                // invite the user to file the same feedback twice. Report the
+                // observation, not a conclusion the code cannot support.
+                showFeedbackError(
+                  timedOut
+                    ? "No answer from the server. Your feedback may already have been sent, so please check before sending it again."
+                    : "Couldn't send, please try later"
+                );
+              }
+            } catch (renderErr: unknown) {
+              console.error("Feedback error failed to render:", renderErr);
+            }
+          }
+        )
+        // Reached when rendering the confirmation throws: the send succeeded, so log
+        // it rather than report a failure that did not happen.
+        .catch((err: unknown) =>
+          console.error("Feedback confirmation failed to render:", err)
+        )
+        .finally(() => {
+          clearTimeout(deadline);
+          // Session-guarded: an abandoned send must not release the lock that a
+          // send started in a later session is holding. The teardown that ended its
+          // session already released the lock this send took.
+          if (!onScreen()) return;
+          feedbackAbort = undefined;
+          feedbackSending = false;
+          if (feedbackSubmit) feedbackSubmit.disabled = false;
+        });
     });
   }
 

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.13",
+  "version": "2.8.14",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/src/scss/style.scss
+++ b/packages/pwa/src/scss/style.scss
@@ -15,6 +15,14 @@ body {
   --color-text: hsl(0, 0%, 92%);
   --color-title: hsl(210, 65%, 80%);
   --color-highlight: hsl(210, 65%, 25%);
+  // Do NOT use outside the feedback modal. It is 4.9:1 on the modal
+  // (--color-background-lighter, light blue in BOTH themes, so this red is fixed
+  // rather than theme-dependent, like --color-on-light above), but only 1.6:1 on
+  // the dark --color-background. A red chosen for the page would be unreadable on
+  // the modal, which is #569 over again; this one is unreadable off it. The guard
+  // ("error text meets WCAG AA against the modal", e2e/feedback-modal.spec.ts)
+  // measures against the modal, so it would not catch a reuse elsewhere.
+  --color-error: hsl(0, 75%, 35%);
 }
 /* Dev-only badge: visible when deployed from a non-main branch */
 body[data-branch]:not([data-branch=""])::before {
@@ -640,6 +648,15 @@ kbd {
     justify-content: center;
     min-height: 140px;
     font-size: 1.2rem;
+
+    // The failure variant sits beneath the form the user is about to resend, so
+    // it must not claim the form's height the way the confirmation does (#798).
+    &.feedback-error {
+      min-height: 0;
+      margin-top: 8px;
+      font-size: 1rem;
+      color: var(--color-error);
+    }
   }
 
   .feedback-context-note {
@@ -672,6 +689,15 @@ kbd {
       font-size: 1rem;
       font-family: inherit;
 
+      // Send is disabled while a send is in flight. Without this it stays
+      // pixel-identical to a live button, because the author-set background and
+      // colour below override the browser's default greying, so a user on a slow
+      // connection clicks a normal-looking button that does nothing (#798).
+      &:disabled {
+        opacity: 0.55;
+        cursor: default;
+      }
+
       &[type="submit"] {
         background: var(--color-active-button);
         color: var(--color-on-light);
@@ -682,7 +708,12 @@ kbd {
         color: var(--color-on-light);
       }
 
-      &:hover {
+      // :not(:disabled), or this wins on source order at equal specificity and a
+      // hovered disabled Send renders identically to a hovered live one. Disabled
+      // controls suppress events, not selector matching, and the pointer is still
+      // on the button the user just clicked, which is the whole window the disabled
+      // styling exists for (#798).
+      &:hover:not(:disabled) {
         opacity: 0.85;
       }
     }

--- a/packages/pwa/src/test/feedback.test.ts
+++ b/packages/pwa/src/test/feedback.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterEach,
+  vi,
+  type MockInstance,
+} from "vitest";
 import { MusicControls } from "../ts/MusicControls";
 import { setupIntegrationFixture } from "./helpers";
 
@@ -132,19 +140,67 @@ describe("Feedback modal", () => {
   });
 
   describe("form submission", () => {
+    // A failed send now logs, so capture console.error rather than letting the
+    // failure tests spray real errors across the run.
+    let errorLog: MockInstance<typeof console.error>;
+
+    // Start each test from the app's OWN post-condition, not a hand-written
+    // approximation of it. index.ts keeps its send state (the close timer, the
+    // session, the in-flight lock, the abort handle) in module variables that no
+    // DOM write can reach, and a test leaving a send unsettled would otherwise
+    // poison every test after it: the next submit would return early at the
+    // in-flight guard and every absence assertion would pass for the wrong reason.
+    // A Cancel click routes through resetFeedbackForm, which is the teardown.
     beforeEach(() => {
       vi.useFakeTimers();
-      const form = document.getElementById("feedback-form") as HTMLFormElement;
-      const result = document.getElementById("feedback-result")!;
-      form.style.display = "";
-      result.style.display = "none";
-      result.textContent = "";
+      errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
     });
 
     afterEach(() => {
       vi.useRealTimers();
       vi.unstubAllGlobals();
+      // Restore only what this describe installed. vi.restoreAllMocks() would also
+      // tear down the rAF and HTMLMediaElement spies that setupIntegrationFixture
+      // installs once in beforeAll, and nothing re-installs them (#798).
+      errorLog.mockRestore();
     });
+
+    // The submit handler is a promise chain, so its result lands several microtasks
+    // after dispatch. Fake timers do not fake microtasks, so awaiting drains them.
+    //
+    // The count must exceed the chain's depth, which is an implementation detail of
+    // index.ts, not of this file: adding one link there silently under-drains a
+    // tightly-tuned count, and every absence assertion then passes for the wrong
+    // reason. (That is not hypothetical. A `Promise.resolve()` added to index.ts
+    // during this ticket broke a six-tick drain.) So drain generously, and let every
+    // test anchor on a positive fact, so an under-drain fails loudly rather than
+    // going green.
+    async function settle() {
+      for (let i = 0; i < 25; i++) await Promise.resolve();
+    }
+
+    function submit() {
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      form.dispatchEvent(new Event("submit", { bubbles: true }));
+    }
+
+    function typeFeedback(text: string, rating: string) {
+      const message = document.getElementById(
+        "feedback-message"
+      ) as HTMLTextAreaElement;
+      const star = document.querySelector<HTMLInputElement>(
+        `#feedback-form input[name="rating"][value="${rating}"]`
+      )!;
+      message.value = text;
+      star.checked = true;
+      return { message, star };
+    }
 
     it("shows 'Thank you' and hides form on successful fetch", async () => {
       vi.stubGlobal(
@@ -154,8 +210,7 @@ describe("Feedback modal", () => {
       const form = document.getElementById("feedback-form") as HTMLFormElement;
       const result = document.getElementById("feedback-result")!;
       form.dispatchEvent(new Event("submit", { bubbles: true }));
-      await Promise.resolve();
-      await Promise.resolve();
+      await settle();
       expect(result.textContent).toBe("Thank you");
       expect(form.style.display).toBe("none");
     });
@@ -165,8 +220,7 @@ describe("Feedback modal", () => {
       const form = document.getElementById("feedback-form") as HTMLFormElement;
       const result = document.getElementById("feedback-result")!;
       form.dispatchEvent(new Event("submit", { bubbles: true }));
-      await Promise.resolve();
-      await Promise.resolve();
+      await settle();
       expect(result.textContent).toBe("Couldn't send, please try later");
     });
 
@@ -178,9 +232,731 @@ describe("Feedback modal", () => {
       const form = document.getElementById("feedback-form") as HTMLFormElement;
       const result = document.getElementById("feedback-result")!;
       form.dispatchEvent(new Event("submit", { bubbles: true }));
-      await Promise.resolve();
-      await Promise.resolve();
+      await settle();
       expect(result.textContent).toBe("Couldn't send, please try later");
+    });
+
+    // Netlify silently discards a submission whose fields it does not recognise, so
+    // a drift here is invisible at every layer: the POST returns 200 and the user is
+    // thanked, while the feedback goes nowhere.
+    //
+    // This pins the CLIENT half only: what index.ts sends. The beforeAll fixture at
+    // the top of this file builds its own hidden form, so a rename in the real
+    // index.html (which is what Netlify registers) still passes. That gap is
+    // "Source the fixture from production markup" in the project wiki's
+    // refactor-feedback.test.ts.md.
+    it("posts the Netlify form contract: url, method, encoding and fields", async () => {
+      const send = vi.fn().mockResolvedValue({ ok: true } as Response);
+      vi.stubGlobal("fetch", send);
+      typeFeedback("Contract", "2");
+
+      submit();
+      await settle();
+
+      expect(send).toHaveBeenCalledTimes(1);
+      const [url, init] = send.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("/");
+      expect(init.method).toBe("POST");
+      expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+        "application/x-www-form-urlencoded"
+      );
+
+      const body = new URLSearchParams(init.body as string);
+      expect(body.get("form-name")).toBe("feedback");
+      expect(body.get("bot-field")).toBe("");
+      expect(body.get("rating")).toBe("2");
+      expect(body.get("message")).toBe("Contract");
+      expect(JSON.parse(body.get("context")!)).toMatchObject({
+        recording: expect.any(Number),
+        choir: expect.any(Number),
+        bar: expect.any(Number),
+      });
+    });
+
+    // #798. The failure path used to share the success path's teardown, so the
+    // message telling the user to retry was the same message that destroyed what
+    // they had typed. The tests below cover both halves of the split, and the close
+    // timer that the success path now holds, cancels and hands back.
+
+    it("keeps the modal open with the message and rating intact when the send fails", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      const modal = document.getElementById("feedback-modal")!;
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      const { message, star } = typeFeedback("Bar 42 will not scroll", "4");
+
+      submit();
+      await settle();
+      // The old code closed the modal and called form.reset() on this tick.
+      vi.advanceTimersByTime(1500);
+
+      expect(modal.style.display).toBe("block");
+      expect(form.style.display).not.toBe("none");
+      expect(message.value).toBe("Bar 42 will not scroll");
+      expect(star.checked).toBe(true);
+    });
+
+    it("shows the failure message beside the form rather than replacing it", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      const result = document.getElementById("feedback-result")!;
+      typeFeedback("Still here?", "3");
+
+      submit();
+      await settle();
+
+      expect(result.textContent).toBe("Couldn't send, please try later");
+      expect(result.style.display).not.toBe("none");
+      expect(form.style.display).not.toBe("none");
+    });
+
+    it("logs the HTTP status when the server rejects the send", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response)
+      );
+      typeFeedback("An unregistered form is not a network blip", "5");
+
+      submit();
+      await settle();
+
+      expect(errorLog).toHaveBeenCalledWith(
+        "Feedback send failed:",
+        expect.objectContaining({
+          message: expect.stringContaining("HTTP 404"),
+        })
+      );
+    });
+
+    it("does not report a network failure when the send itself succeeded", async () => {
+      // The catch used to sit downstream of the success branch, so a throw inside
+      // the confirmation rendering was rebranded to the user as a failed send.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true } as Response)
+      );
+      const result = document.getElementById("feedback-result")!;
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      let displayAtWrite: string | undefined;
+      // Fault-inject the confirmation rendering. The property must be restored
+      // even when an assertion below fails, or the poisoned setter leaks into
+      // every test after this one.
+      try {
+        // Fire only on the CONFIRMATION render. A setter that throws on every write
+        // would also trip the submit handler's clear-the-previous-error write, and
+        // the throw would surface as a failed send, which is a different claim.
+        Object.defineProperty(result, "textContent", {
+          set(value: string) {
+            if (value === "Thank you") {
+              // Capture display AT the moment of the text write: the live region
+              // must already be in the accessibility tree when its text lands.
+              displayAtWrite = result.style.display;
+              throw new Error("rendering blew up");
+            }
+          },
+          get() {
+            return "";
+          },
+          configurable: true,
+        });
+
+        submit();
+        await settle();
+
+        // Assert the DISCRIMINATING prefix, not just that something was logged.
+        // Reverting to `.then().catch()` also logs "rendering blew up", via
+        // "Feedback send failed:", so a bare toContain passes on the mutated code
+        // (#798). The class is the DOM half of the same discrimination:
+        // showFeedbackError adds it before the poisoned write, so it survives the
+        // fault injection and is absent iff the failure path never ran.
+        expect(errorLog).toHaveBeenCalledWith(
+          "Feedback confirmation failed to render:",
+          expect.objectContaining({ message: "rendering blew up" })
+        );
+        expect(result.classList.contains("feedback-error")).toBe(false);
+        // The text is written before the form is hidden, so a throw mid-render
+        // leaves the form on screen rather than an empty box.
+        expect(form.style.display).not.toBe("none");
+        // And the region was already visible when its text landed, so the live
+        // region never carries a message nobody can see.
+        expect(displayAtWrite).toBe("flex");
+        // The close timer was armed BEFORE the render that threw, so the modal still
+        // closes rather than stranding the user on an unchanged form (where a second
+        // Send would file the same feedback twice).
+        vi.advanceTimersByTime(1500);
+        expect(document.getElementById("feedback-modal")!.style.display).toBe(
+          "none"
+        );
+      } finally {
+        delete (result as unknown as Record<string, unknown>).textContent;
+      }
+    });
+
+    it("confirms, then closes and resets the form 1500 ms after a successful send", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true } as Response)
+      );
+      const modal = document.getElementById("feedback-modal")!;
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      const result = document.getElementById("feedback-result")!;
+      const { message } = typeFeedback("Lovely, thank you", "5");
+
+      submit();
+      await settle();
+
+      expect(result.textContent).toBe("Thank you");
+      expect(form.style.display).toBe("none");
+
+      vi.advanceTimersByTime(1500);
+
+      expect(modal.style.display).toBe("none");
+      expect(form.style.display).toBe("");
+      expect(message.value).toBe("");
+    });
+
+    it("does not let the pending close timer shut a modal reopened within the window", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true } as Response)
+      );
+      const modal = document.getElementById("feedback-modal")!;
+      const message = document.getElementById(
+        "feedback-message"
+      ) as HTMLTextAreaElement;
+      typeFeedback("First note", "5");
+
+      submit();
+      await settle();
+      // Anchor: the confirmation really rendered, so a close timer really was armed.
+      expect(document.getElementById("feedback-result")!.textContent).toBe(
+        "Thank you"
+      );
+
+      // The user dismisses the confirmation and reopens to add a second thought,
+      // all inside the 1500 ms the close timer is still counting down.
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      vi.advanceTimersByTime(500);
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
+      message.value = "Second note";
+
+      vi.advanceTimersByTime(1500);
+
+      expect(modal.style.display).toBe("block");
+      expect(message.value).toBe("Second note");
+    });
+
+    // The close is at 1500 ms, not "eventually". Advancing straight to 1500 also
+    // passes if the delay were mutated to 1 ms, so walk the boundary (#598 is this
+    // project's own recurring off-by-one class).
+    it("holds the confirmation open until 1500 ms, then closes", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true } as Response)
+      );
+      const modal = document.getElementById("feedback-modal")!;
+      typeFeedback("Boundary", "3");
+
+      submit();
+      await settle();
+
+      vi.advanceTimersByTime(1499);
+      expect(modal.style.display).toBe("block");
+
+      vi.advanceTimersByTime(1);
+      expect(modal.style.display).toBe("none");
+    });
+
+    // Both preservation tests used a REJECTED fetch, so the non-ok
+    // branch (a permanent 404 from an unregistered Netlify form, which the submit
+    // handler singles out as the likely real failure) could be routed back through
+    // the success teardown with the whole suite green.
+    it.each([
+      ["a rejected fetch", () => Promise.reject(new Error("offline"))],
+      ["a 404 response", () => Promise.resolve({ ok: false, status: 404 })],
+      ["a 500 response", () => Promise.resolve({ ok: false, status: 500 })],
+    ])("preserves the message and rating on %s", async (_label, respond) => {
+      vi.stubGlobal("fetch", vi.fn().mockImplementation(respond));
+      const modal = document.getElementById("feedback-modal")!;
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      const result = document.getElementById("feedback-result")!;
+      const { message, star } = typeFeedback("Bar 42 will not scroll", "4");
+
+      submit();
+      await settle();
+      vi.advanceTimersByTime(1500);
+
+      // Anchor on the positive first: without it, every assertion below is also
+      // true of a chain that never ran at all.
+      expect(result.textContent).toBe("Couldn't send, please try later");
+      expect(modal.style.display).toBe("block");
+      expect(form.style.display).not.toBe("none");
+      expect(message.value).toBe("Bar 42 will not scroll");
+      expect(star.checked).toBe(true);
+    });
+
+    // Nothing pinned either `classList.remove("feedback-error")`.
+    it("clears the error styling when a retry succeeds", async () => {
+      const send = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockResolvedValueOnce({ ok: true } as Response);
+      vi.stubGlobal("fetch", send);
+      const result = document.getElementById("feedback-result")!;
+      typeFeedback("Retry me", "4");
+
+      submit();
+      await settle();
+      expect(result.classList.contains("feedback-error")).toBe(true);
+
+      // The user presses Send again without retyping a word. That is the user
+      // story of #798, and nothing executed it.
+      submit();
+      await settle();
+
+      expect(result.textContent).toBe("Thank you");
+      expect(result.classList.contains("feedback-error")).toBe(false);
+    });
+
+    it("clears the error styling when the modal is dismissed after a failure", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      const result = document.getElementById("feedback-result")!;
+      typeFeedback("Give up", "1");
+
+      submit();
+      await settle();
+      expect(result.classList.contains("feedback-error")).toBe(true);
+
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+
+      expect(result.classList.contains("feedback-error")).toBe(false);
+      expect(result.style.display).toBe("none");
+      expect(result.textContent).toBe("");
+    });
+
+    // A send outlives the modal it was sent from: Escape, Cancel and the backdrop
+    // all stay live while one is in flight, and on a dead connection the user has
+    // every reason to use them. The response must not then render into a modal
+    // they have walked away from (#798).
+    //
+    // Each of these anchors on a POSITIVE fact (the handler ran, or the button came
+    // back) before asserting an absence. Without that anchor every assertion below
+    // is also satisfied by a promise that never settled at all.
+    it("does not write a failure into a modal the user already dismissed", async () => {
+      const send = vi.fn().mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            // Reject with the signal's reason, as a real fetch does: rejecting with
+            // an error of our own would leave the timeout's reason unpinned.
+            init.signal?.addEventListener("abort", () =>
+              reject(init.signal!.reason)
+            );
+          })
+      );
+      vi.stubGlobal("fetch", send);
+      const result = document.getElementById("feedback-result")!;
+      typeFeedback("Slow connection", "2");
+
+      // Drain first: fetch is called inside the chain, so the signal is not handed
+      // over until a microtask after dispatch.
+      submit();
+      await settle();
+
+      // The send hangs. The user gives up and closes the modal.
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      await settle();
+
+      // The chain DID settle (the teardown aborted it), and still declined to render.
+      const signal = (send.mock.calls[0]![1] as RequestInit).signal!;
+      expect(signal.aborted).toBe(true);
+      expect(result.textContent).toBe("");
+      expect(result.classList.contains("feedback-error")).toBe(false);
+      expect(result.style.display).toBe("none");
+    });
+
+    it("lets the user send again after abandoning a hung send", async () => {
+      const send = vi
+        .fn()
+        .mockImplementationOnce(() => new Promise(() => {})) // never settles
+        .mockResolvedValueOnce({ ok: true } as Response);
+      vi.stubGlobal("fetch", send);
+      const submitButton = document.getElementById(
+        "feedback-submit"
+      ) as HTMLButtonElement;
+      typeFeedback("Hangs forever", "3");
+
+      submit();
+      await settle();
+      expect(submitButton.disabled).toBe(true);
+
+      // The user gives up and closes. The first send is STILL in flight, and its
+      // .finally will never run, so the teardown must release the lock itself or
+      // the next modal has a dead Send button and Enter is swallowed in silence.
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      expect(submitButton.disabled).toBe(false);
+
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
+      const result = document.getElementById("feedback-result")!;
+      typeFeedback("Second attempt", "4");
+      submit();
+      await settle();
+
+      expect(send).toHaveBeenCalledTimes(2);
+      expect(result.textContent).toBe("Thank you");
+    });
+
+    // The success guard's real job is not a stranded panel; it is protecting a fresh
+    // draft. Without it, an abandoned send's late "Thank you" hides the form the user
+    // has started retyping into and arms a timer that resets it 1500 ms later. That is
+    // #798 by another route, so the last assertion is the one that matters.
+    it("does not overwrite a fresh draft when an abandoned send succeeds late", async () => {
+      let resolveFirst: (value: unknown) => void = () => {};
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolveFirst = resolve;
+            })
+        )
+      );
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      const result = document.getElementById("feedback-result")!;
+      const message = document.getElementById(
+        "feedback-message"
+      ) as HTMLTextAreaElement;
+      typeFeedback("First", "3");
+
+      submit();
+      await settle();
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
+      message.value = "Second thought, still typing";
+
+      // The abandoned send lands in a session that is gone. Reading `ok` is the
+      // liveness anchor: without it every assertion below is equally true of a chain
+      // that never settled at all.
+      let okRead = false;
+      resolveFirst({
+        get ok() {
+          okRead = true;
+          return true;
+        },
+      });
+      await settle();
+      expect(okRead).toBe(true);
+
+      expect(result.textContent).toBe("");
+      expect(form.style.display).not.toBe("none");
+      vi.advanceTimersByTime(1500);
+      expect(message.value).toBe("Second thought, still typing");
+    });
+
+    // The session guard on the .finally. Its only live moment is a SECOND send in
+    // flight when the first one settles: without it, the abandoned send releases the
+    // live send's lock and the user can file the same message twice.
+    it("does not let an abandoned send unlock a modal that is sending again", async () => {
+      let settleFirst: (value: unknown) => void = () => {};
+      const send = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              settleFirst = resolve;
+            })
+        )
+        .mockImplementationOnce(() => new Promise(() => {}));
+      vi.stubGlobal("fetch", send);
+      const submitButton = document.getElementById(
+        "feedback-submit"
+      ) as HTMLButtonElement;
+
+      typeFeedback("First", "3");
+      submit();
+      await settle();
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
+      typeFeedback("Second", "4");
+      submit();
+      await settle();
+      expect(submitButton.disabled).toBe(true);
+
+      let okRead = false;
+      settleFirst({
+        get ok() {
+          okRead = true;
+          return true;
+        },
+      });
+      await settle();
+      expect(okRead).toBe(true);
+
+      expect(submitButton.disabled).toBe(true);
+      submit();
+      await settle();
+      expect(send).toHaveBeenCalledTimes(2);
+
+      // And the abandoned send must not have nulled the LIVE send's abort handle:
+      // if it had, Cancel could no longer cancel B, and B would land at Netlify
+      // behind the user's back. (Hoisting `feedbackAbort = undefined` above the
+      // session guard in the .finally is exactly that mutation.)
+      const liveSignal = (send.mock.calls[1]![1] as RequestInit).signal!;
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      expect(liveSignal.aborted).toBe(true);
+    });
+
+    // Reopening an ALREADY-OPEN modal (KeyF and the icon both do) must not reset it.
+    // Runs after a successful send, so feedbackCloseTimer is dirty: that also kills a
+    // mutation that drops `feedbackCloseTimer = undefined` from the teardown.
+    it("keeps a half-typed message when the modal is reopened over itself", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true } as Response)
+      );
+      typeFeedback("Sent", "5");
+      submit();
+      await settle();
+      vi.advanceTimersByTime(1500);
+
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
+      const message = document.getElementById(
+        "feedback-message"
+      ) as HTMLTextAreaElement;
+      message.value = "Half a thought";
+
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
+
+      expect(message.value).toBe("Half a thought");
+    });
+
+    it("blanks the previous error while a retry is in flight", async () => {
+      let rejectSecond: (reason: Error) => void = () => {};
+      const send = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockImplementationOnce(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectSecond = reject;
+            })
+        );
+      vi.stubGlobal("fetch", send);
+      const result = document.getElementById("feedback-result")!;
+      typeFeedback("Same failure twice", "2");
+
+      submit();
+      await settle();
+      expect(result.textContent).toBe("Couldn't send, please try later");
+
+      // Without the blank, the retry rewrites an identical string into a region
+      // already showing it, and the user sees nothing happen at all.
+      submit();
+      await settle();
+      expect(result.textContent).toBe("");
+      expect(result.style.display).toBe("none");
+
+      rejectSecond(new Error("offline"));
+      await settle();
+      expect(result.textContent).toBe("Couldn't send, please try later");
+    });
+
+    // A send the user walks away from is CANCELLED, not merely ignored. Without the
+    // abort it stays on the wire and Netlify files it, so abandoning and resending
+    // lodges the same feedback twice.
+    it("aborts the request when the user dismisses a send in flight", async () => {
+      const send = vi.fn().mockImplementation(() => new Promise(() => {}));
+      vi.stubGlobal("fetch", send);
+      typeFeedback("Cancel me", "1");
+
+      submit();
+      await settle();
+      const signal = (send.mock.calls[0]![1] as RequestInit).signal!;
+      expect(signal.aborted).toBe(false);
+
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+
+      expect(signal.aborted).toBe(true);
+    });
+
+    it("gives up on a hung send and tells the user, rather than sitting dead", async () => {
+      const send = vi.fn().mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            // Reject with the signal's reason, as a real fetch does: rejecting with
+            // an error of our own would leave the timeout's reason unpinned.
+            init.signal?.addEventListener("abort", () =>
+              reject(init.signal!.reason)
+            );
+          })
+      );
+      vi.stubGlobal("fetch", send);
+      const result = document.getElementById("feedback-result")!;
+      const submitButton = document.getElementById(
+        "feedback-submit"
+      ) as HTMLButtonElement;
+      const { message } = typeFeedback("Hangs forever", "3");
+
+      submit();
+      await settle();
+      expect(submitButton.disabled).toBe(true);
+      expect(result.textContent).toBe("");
+
+      // There is no fetch timeout a page can rely on, so without a deadline the button
+      // stays greyed out and the app never says anything at all. Walk the boundary: a
+      // SHORTENED deadline is its own regression, aborting slow-but-live sends.
+      vi.advanceTimersByTime(29_999);
+      await settle();
+      expect(submitButton.disabled).toBe(true);
+      expect(result.textContent).toBe("");
+
+      vi.advanceTimersByTime(1);
+      await settle();
+
+      // NOT "couldn't send". A deadline can only fire once the request is out and we
+      // are waiting on an answer, so claiming it failed asserts the opposite of the
+      // likeliest truth, and invites the user to file the same feedback twice.
+      expect(result.textContent).toContain("No answer from the server");
+      expect(result.textContent).not.toContain("Couldn't send");
+      expect(submitButton.disabled).toBe(false);
+      expect(message.value).toBe("Hangs forever");
+      expect(errorLog).toHaveBeenCalledWith(
+        "Feedback send timed out:",
+        expect.anything()
+      );
+    });
+
+    // The modal stays open on failure, so the caret must come back to the textarea.
+    // Clicking Send blurs it (disabling a focused control blurs it) and focus lands on
+    // <body>, where the user's natural retry key reaches the global handler and starts
+    // the music instead of resending.
+    //
+    // Do NOT advance timers before asserting: showFeedback(true) arms a 0 ms focus
+    // timer, so the beforeEach leaves one pending, and flushing it would focus the
+    // textarea anyway and make this pass with the fix deleted.
+    it("puts the caret back in the message box after a failed send", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      const message = document.getElementById(
+        "feedback-message"
+      ) as HTMLTextAreaElement;
+      typeFeedback("Retry me with Enter", "3");
+      (document.getElementById("feedback-submit") as HTMLButtonElement).focus();
+
+      submit();
+      await settle();
+
+      expect(document.activeElement).toBe(message);
+    });
+
+    // A user who changes their mind has not experienced a failure. Logging the abort
+    // as one makes a cancellation indistinguishable from a real fault to whoever reads
+    // the console later, and silently widens the e2e allowlist to cover three events.
+    it("does not log a cancelled send as a failure", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(
+          (_url: string, init: RequestInit) =>
+            new Promise((_resolve, reject) => {
+              init.signal?.addEventListener("abort", () =>
+                reject(new Error("aborted"))
+              );
+            })
+        )
+      );
+      typeFeedback("Changed my mind", "4");
+
+      submit();
+      await settle();
+      document
+        .getElementById("feedback-cancel")!
+        .dispatchEvent(new Event("click"));
+      await settle();
+
+      expect(errorLog).not.toHaveBeenCalled();
+    });
+
+    // Reopening DURING the confirmation window (KeyF works here, because the form
+    // is hidden so focus falls to body and the input-guard does not bite). The
+    // reopen must hand the form back: Send and Cancel both live inside it, so a
+    // stranded "Thank you" leaves a modal with no controls at all.
+    it("hands the form back when reopened during the confirmation", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true } as Response)
+      );
+      const form = document.getElementById("feedback-form") as HTMLFormElement;
+      const result = document.getElementById("feedback-result")!;
+      typeFeedback("Reopen on F", "5");
+
+      submit();
+      await settle();
+      expect(result.textContent).toBe("Thank you");
+      expect(form.style.display).toBe("none");
+
+      vi.advanceTimersByTime(500);
+      document
+        .getElementById("feedback-trigger")!
+        .dispatchEvent(new Event("click"));
+
+      expect(form.style.display).not.toBe("none");
+      expect(result.textContent).toBe("");
+    });
+
+    // Two clicks used to file two Netlify submissions. The guard is the in-flight
+    // lock, so the test must submit again while the first send is genuinely
+    // PENDING: two synchronous submits in one task would pass even if the lock were
+    // released in the first .then rather than at the end of the chain.
+    it("sends once when Send is clicked twice during a send", async () => {
+      let resolveSend: (value: unknown) => void = () => {};
+      const send = vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSend = resolve;
+          })
+      );
+      vi.stubGlobal("fetch", send);
+      const submitButton = document.getElementById(
+        "feedback-submit"
+      ) as HTMLButtonElement;
+      typeFeedback("Double tap", "5");
+
+      submit();
+      await settle();
+      expect(submitButton.disabled).toBe(true);
+
+      submit();
+      await settle();
+      expect(send).toHaveBeenCalledTimes(1);
+
+      resolveSend({ ok: true });
+      await settle();
+      expect(submitButton.disabled).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## The problem

When a feedback send failed, the user saw "Couldn't send, please try later" for
1.5 seconds, then the modal closed and everything they had typed was gone. The
message asked them to retry. Retrying meant retyping the whole message and
re-selecting the rating.

The failure path shared the success path's teardown. The catch routed into
`showFeedbackResult`, which hid the form and, after 1500 ms, called
`showFeedback(false)`, whose `resetFeedbackForm()` ran `feedbackForm.reset()`.
The pending timeout fired even if the user reopened the modal inside that
window.

Losing the user's typed work puts this on the harm floor
(`doc/CONTRIBUTING.md` § Harm floor), so it is fixed rather than accepted.

## What changes

- On a failed send the modal stays open, the message and the rating are
  untouched, and the error shows inline. The user can press Send again without
  retyping a word.
- Success is unchanged: confirm, then close.
- The failure is now logged with its cause, and the thrown error carries the
  HTTP status. An unregistered form (a permanent 404) is no longer
  indistinguishable from a network blip when debugging.
- Success and failure are handled by two sibling handlers rather than
  `then`/`catch`, so an exception raised while rendering the confirmation is no
  longer reported as a network failure.

## Tests

- `src/test/feedback.test.ts` pins the failure path: submit a typed message with
  `fetch` stubbed to reject, advance the timers past 1500 ms, then assert the
  modal is still open and the text is still there. It fails on the old code.
- `e2e/feedback-modal.spec.ts` drives the same path in a real browser.
- The e2e failure is simulated by stubbing `window.fetch` in the page rather
  than by aborting the route. An aborted route makes the browser log its own
  resource error, and allowlisting that needs a port-dependent entry which is
  not portable between worktrees. The reasoning is recorded in
  `doc/TESTING.md`.

Full suite green on this branch: 352 tests across 21 files, plus `check`.

Fixes #798
