### PR TITLE
test(e2e): fix allowlist self-test probe broken by beacon removal (#822)

### DIFF
--- a/packages/pwa/e2e/page-errors.spec.ts
+++ b/packages/pwa/e2e/page-errors.spec.ts
@@ -91,7 +91,7 @@ test.describe("page-error capture fixture (self-test)", () => {
     await page.goto("/");
     await page.evaluate(() => {
       console.error(
-        "allowlist probe at https://static.cloudflareinsights.com/beacon.min.js"
+        "allowlist probe at https://www.googletagmanager.com/gtag/js"
       );
       console.error("page-errors self-test: sentinel after allowlisted");
     });


### PR DESCRIPTION
Follow-up to #823 (both under #822).

## Problem

The reran nightly E2E dropped from **97 failures to 7**, confirming the beacon fix worked. Of the remaining 7:

- **3× `page-errors.spec.ts › does not capture an allowlisted message`** (chromium/firefox/webkit) — a **regression from #823**. That self-test probes the allowlist by emitting `console.error("allowlist probe at https://static.cloudflareinsights.com/beacon.min.js")` and asserting it's suppressed. #823 removed that allowlist entry (the beacon is now intercepted instead), so the probe is captured and the test fails.
- **4× `playback-toggle` on webkit only** — a **separate, pre-existing** webkit audio-autoplay issue (same class as the chromium #634 failures that also fail on clean `main`), unrelated to the beacon. Not addressed here.

## Change

Repoint the self-test probe at `https://www.googletagmanager.com/gtag/js`, which is still in the allowlist, so the suppression mechanism is again tested against a live entry.

## Verification

`playwright test --project=chromium e2e/page-errors.spec.ts` → **7/7 passed** locally (was failing on the allowlist case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)