### PR TITLE
test(e2e): exempt cancelled /audio/ loads from the page-error gate (#830)

### DIFF
--- a/packages/pwa/e2e/helpers/page-errors.ts
+++ b/packages/pwa/e2e/helpers/page-errors.ts
@@ -105,11 +105,18 @@ export const test = base.extend<{ pageErrorCapture: readonly string[] }>({
         }
       });
       page.on("requestfailed", (req) => {
-        if (isAudioUrl(req.url())) {
-          record(
-            `audio request failed: ${req.url()} (${req.failure()?.errorText})`
-          );
-        }
+        if (!isAudioUrl(req.url())) return;
+        const errorText = req.failure()?.errorText ?? "";
+        // A load cancelled by a deliberate control change during the audio
+        // load window (#805) is a legitimate outcome, not a broken audio path:
+        // toggling pause mid-load aborts the in-flight fetch. Webkit surfaces
+        // this as a requestfailed with "Load request cancelled" (and a
+        // status-0 response, exempted below); chromium/firefox do not report
+        // it at all. Exempt cancellations only — genuine failures (the
+        // self-test's route.abort() → ERR_FAILED, DNS errors, decode failures)
+        // still record. See #830.
+        if (/cancel/i.test(errorText)) return;
+        record(`audio request failed: ${req.url()} (${errorText})`);
       });
       page.on("response", (res) => {
         if (!isAudioUrl(res.url())) return;
@@ -120,11 +127,16 @@ export const test = base.extend<{ pageErrorCapture: readonly string[] }>({
         // 304 revalidations legitimately carry no content-type (probe-verified
         // against vite preview, which serves audio with ETag + no-cache) and
         // are exempt — the followed-to or originally-cached response is the
-        // one that gets content-type-checked.
+        // one that gets content-type-checked. A status-0 response is a
+        // cancelled load (webkit emits one when a control change aborts the
+        // in-flight fetch, #805/#830) — a legitimate outcome, exempt like the
+        // matching requestfailed above.
         const contentType = res.headers()["content-type"] ?? "";
         if (
           res.status() >= 400 ||
-          (res.status() < 300 && !contentType.startsWith("audio/"))
+          (res.status() > 0 &&
+            res.status() < 300 &&
+            !contentType.startsWith("audio/"))
         ) {
           record(
             `audio response ${res.status()} (${contentType || "no content-type"}): ${res.url()}`


### PR DESCRIPTION
Fixes #830. Final step of the E2E stabilisation (after #823, #826) — takes the nightly from 4 failures to green.

## Problem

Since #805 ("honour control changes during the audio load window"), toggling pause mid-load aborts the in-flight audio fetch — correct behaviour. On **webkit** that cancellation surfaces as a `requestfailed` ("Load request cancelled") and a **status-0 response**; the strict `/audio/` channel in [page-errors.ts](../blob/main/packages/pwa/e2e/helpers/page-errors.ts) flagged both, failing all 4 webkit `playback-toggle` tests. chromium/firefox don't report the cancellation.

CI confirmed all 4 failed via the gate (`audio response 0 (no content-type)`), not a product assertion.

## Change

Exempt **cancellations only**:
- `requestfailed`: skip when `errorText` matches `/cancel/i`.
- `response`: skip `status() === 0` (guarded `status() > 0`), like the existing 3xx/304 exemptions.

Genuine failures still record — the self-test's `route.abort()` (ERR_FAILED), DNS errors, 404s, and wrong-content-type `/audio/` responses.

## Verification (local)

- **page-errors self-test — 7/7 on chromium, firefox, and webkit.** The "captures a network-failed /audio/ request" case (deliberate `route.abort()`) still fails red as intended, proving the gate isn't over-loosened.
- webkit `playback-toggle` no longer trips the audio gate.

### Note on #634 tests

`playback-toggle:54/:77` (#634) fail *locally* on all three browsers with a `toBeVisible` timeout on the pause icon — the local headless environment doesn't autoplay audio, so the icon never flips. This is unrelated to this change (and to the beacon work); those tests are green in CI, where audio plays. Their CI failure was the audio-cancel gate, which this PR fixes.

## Acceptance criteria (#830)

- [x] webkit playback-toggle no longer trips the audio gate; no other browser regresses.
- [x] Gate still flags a real missing/404/wrong-content-type/aborted `/audio/` response (self-test green on all browsers).
- [ ] Nightly PWA E2E on `main` fully green — verify on next run / manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)