### PR TITLE
fix: reveal the app when the stylesheet fails to load (#801)

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -148,18 +148,60 @@ environments, and the feedback submit handler's `console.error` on a failed send
 `src/test/feedback.test.ts`, not in the spec. Service workers are blocked
 suite-wide (`playwright.config.ts`) so page-level network events stay observable.
 
-**Simulate a network failure by stubbing `fetch`, not by aborting the route.**
-`route.abort()` makes the browser log its own `Failed to load resource:
-net::ERR_FAILED`, which the fixture captures. Allowlisting it means adding an
-entry for a failed load of the site root `/`, and the fixture's convention is to
-keep an entry as narrow as the URL: that URL is the port-dependent `baseURL`
-(`worktree-ports.ts` gives each worktree its own offset), so a conforming entry
-is not portable, and the broad text-only alternative would mask a genuine failure
-to load the document itself. Reject the call in the page instead
-(`page.addInitScript` replacing `window.fetch`, bound to `window`), which issues
-no request and raises the same `TypeError` a genuinely offline fetch raises.
-`failTheSend` in `e2e/feedback-modal.spec.ts` is the implementation; it points
-here for the reason rather than restating it.
+#### Injecting a failure: which technique, and why they differ
+
+Two specs inject failures and appear to reach opposite conclusions about
+`route.abort()`. They are not in conflict. The question is not whether aborting is
+allowed; it is **what is actually failing**.
+
+**Simulating an app-level network call: stub `fetch`, do not abort the route.**
+Here the *call* is what must fail, and the browser's own resource error is an
+artefact of the injection rather than part of the failure. `route.abort()` makes
+the browser log `Failed to load resource: net::ERR_FAILED`, which the fixture
+captures. Allowlisting it means adding an entry for a failed load of the site root
+`/`, and the fixture's convention is to keep an entry as narrow as the URL: that
+URL is the port-dependent `baseURL` (`worktree-ports.ts` gives each worktree its
+own offset), so a conforming entry is not portable, and the broad text-only
+alternative would mask a genuine failure to load the document itself. Reject the
+call in the page instead (`page.addInitScript` replacing `window.fetch`, bound to
+`window`), which issues no request and raises the same `TypeError` a genuinely
+offline fetch raises. `failTheSend` in `e2e/feedback-modal.spec.ts` is the
+implementation; it points here for the reason rather than restating it.
+
+**Injecting a failed resource load: intercept the route.** Here the *resource* is
+what fails, so there is nothing to stub, and the browser's resource error is part
+of the condition rather than an artefact. Intercept it: `route.abort()` for a
+request that never arrives, or `route.fulfill()` with a bad body for one that
+arrives wrong. `e2e/fouc-fallback.spec.ts` (#801) does both, because a stylesheet
+can fail in either shape and they take different paths through the fix.
+
+**Escape to the spec's own page when the expected errors cannot be allowlisted
+narrowly.** This is a separate decision from the one above, and it is easy to get
+the reason wrong. It is not simply "because the browser logs a resource error": the
+#801 backstop case fulfils a valid 200 and produces no resource error at all, and
+it still needs the escape, because on that path *the app itself* deliberately logs
+a `console.error`. Allowlisting either message suite-wide would blind every other
+spec to a real regression on it. So open the page with `context.newPage()` and keep
+the expected noise off the shared capture.
+
+An escaped page inherits none of the fixture's listeners, nor its `auto` teardown
+assertion, so it is not a free pass. Put a comment at the open site saying why the
+page escapes, and re-attach the channels the spec still needs.
+
+**Filter the console channel; do not drop it.** Dropping it wholesale is the easy
+mistake, and it blinds the one page in the suite whose whole purpose is to exercise
+the failing path. Re-attach `pageerror` and `console`, then assert positively: the
+message the failure is *supposed* to produce must be present, the injection's own
+resource error is allowed by URL, and anything else fails the test. A deliberate
+diagnostic then cannot be deleted without a test going red, and an unrelated error
+cannot hide. `e2e/fouc-fallback.spec.ts` shows the pattern
+(`expectOnlyTheFoucDiagnostic`). Its injection pages do **not** re-attach the two
+`/audio/` listeners, because they never touch audio and every other spec covers
+that channel; drop a channel only when you can say that of it.
+
+The fixture's *routes* (the Cloudflare beacon stub) are registered on the context,
+not the page, so another page in the same context does still inherit those; only
+the listeners are lost.
 
 ### E2E Prerequisites
 

--- a/packages/pwa/e2e/fouc-fallback.spec.ts
+++ b/packages/pwa/e2e/fouc-fallback.spec.ts
@@ -1,0 +1,374 @@
+import { test, expect, isAllowlisted } from "./helpers/page-errors";
+import type { BrowserContext, Page } from "@playwright/test";
+
+// #801 — FOUC-guard fallback.
+//
+// index.html hides .viewportDiv behind an inline <style id="fouc-guard">, and
+// the bundled stylesheet releases it (style.scss, `.viewportDiv { visibility:
+// visible }`). A visit whose CSS request fails never got that release: the page
+// stayed permanently blank. The fix removes the guard node instead, by either of
+// two paths — the stylesheet link's `error` event, or a window-load backstop —
+// and records which one fired in `data-fouc-fallback` on <html>.
+//
+// That marker is what lets these tests pin each path SEPARATELY. Asserting only
+// "the app ends up visible" would pass with either path deleted, which is how
+// the MutationObserver could rot unnoticed: it is the only thing that arms the
+// error path in the built page, because Vite appends the stylesheet <link> at
+// the end of <head>, after the inline script. The last test pins that build fact
+// too, since the discrimination depends on it.
+//
+// Assertions read computed style, never the inline style string: a style-string
+// assertion reads the write, not the rendered result, and has been falsely green
+// before (#709).
+//
+// The failure-injection cases open their own page via context.newPage(), because
+// a failed stylesheet legitimately logs console errors and the page-errors
+// auto-fixture would fail the test on them. An own page inherits the fixture's
+// context ROUTES but none of its LISTENERS, so `newInjectionPage` re-attaches
+// both channels and `expectOnlyTheFoucDiagnostic` filters them: the FOUC
+// diagnostic must be present, the injection's own resource error is allowed, and
+// anything else fails. That keeps the escape from becoming a blind spot, and it
+// is also what pins the Cloudflare stub being CONTEXT-scoped in
+// helpers/page-errors.ts — were it page-scoped, this page would run the real
+// beacon and its CORS failure would surface here as an unexpected console error.
+
+interface InjectionPage {
+  page: Page;
+  pageErrors: string[];
+  consoleErrors: string[];
+}
+
+/**
+ * Opens a page outside the error-capture fixture, keeping both error channels.
+ *
+ * Own page: the injected stylesheet failure is the test's premise, so the console
+ * errors it raises are expected and must not fail the test at the fixture's
+ * teardown. See doc/TESTING.md, "Injecting a failure".
+ */
+async function newInjectionPage(
+  context: BrowserContext
+): Promise<InjectionPage> {
+  const page = await context.newPage();
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      const loc = msg.location().url;
+      consoleErrors.push(`${msg.text()}${loc ? ` (at ${loc})` : ""}`);
+    }
+  });
+  return { page, pageErrors, consoleErrors };
+}
+
+const FOUC_DIAGNOSTIC = "the stylesheet did not release the FOUC guard";
+
+/**
+ * Asserts the page raised no uncaught exception, logged the FOUC diagnostic for
+ * `source`, and logged nothing else beyond messages matching `allow`.
+ */
+async function expectOnlyTheFoucDiagnostic(
+  { page, pageErrors, consoleErrors }: InjectionPage,
+  source: string,
+  allow: RegExp[]
+): Promise<void> {
+  // The same flush the fixture does (helpers/page-errors.ts): event delivery to
+  // the Playwright client is asynchronous, and this no-op round trip delivers
+  // anything the browser had already raised.
+  await page.evaluate(() => undefined).catch(() => {});
+
+  expect(
+    pageErrors,
+    "an uncaught exception on the page (the guard script, or the app running unstyled)"
+  ).toEqual([]);
+
+  // The diagnostic is the app's ONLY signal that the fallback fired; there is no
+  // error reporting anywhere else. Without this assertion it could be deleted as
+  // noise and every test would stay green, which is the silent failure the whole
+  // fallback exists to avoid.
+  expect(
+    consoleErrors.filter(
+      (e) => e.includes(FOUC_DIAGNOSTIC) && e.includes(`(${source})`)
+    ),
+    `the FOUC diagnostic for "${source}" was not logged`
+  ).toHaveLength(1);
+
+  // Filter through the FIXTURE's allowlist, not a private copy: the third-party
+  // script hosts it excuses (DNS-blocked in test environments) fail on this page
+  // exactly as they do on any other, and a second copy of that list would drift.
+  const unexpected = consoleErrors.filter(
+    (e) =>
+      !e.includes(FOUC_DIAGNOSTIC) &&
+      !isAllowlisted(e) &&
+      !allow.some((re) => re.test(e))
+  );
+  expect(unexpected, "unexpected console errors on the injection page").toEqual(
+    []
+  );
+}
+
+/** The browser's own resource error for the stylesheet we deliberately broke. */
+const BROKEN_CSS = [/\/assets\/[^\s)]*\.css/];
+
+const GUARD = "#fouc-guard";
+const VIEWPORT = ".viewportDiv";
+
+test.describe("FOUC-guard fallback (#801)", () => {
+  test("an aborted stylesheet reveals the app via the error path", async ({
+    context,
+  }) => {
+    const injection = await newInjectionPage(context);
+    const { page } = injection;
+
+    // Count the aborts. Without this the glob is unverified: if Vite's asset path
+    // ever moves, route.abort() silently intercepts nothing, the stylesheet loads
+    // normally, and this test passes green while exercising none of the fix.
+    let aborted = 0;
+    await page.route("**/assets/*.css", (route) => {
+      aborted++;
+      return route.abort();
+    });
+
+    await page.goto("/");
+
+    expect(
+      aborted,
+      "no stylesheet was aborted: the route glob no longer matches the built CSS " +
+        "path, so this test is not injecting the failure it claims to inject"
+    ).toBeGreaterThan(0);
+
+    await expect(page.locator(VIEWPORT)).toHaveCSS("visibility", "visible", {
+      timeout: 5000,
+    });
+    // The guard node is removed, not merely overridden, so no inline-style residue
+    // is left to outrank a later rule.
+    await expect(page.locator(GUARD)).toHaveCount(0);
+    // Pins the FAST path specifically. Remove the MutationObserver or the error
+    // listener and the load backstop still reveals the app, so the visibility
+    // assertion above still passes, but this one goes red with "load-backstop".
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-fouc-fallback",
+      "stylesheet-error"
+    );
+
+    await expectOnlyTheFoucDiagnostic(injection, "stylesheet-error", BROKEN_CSS);
+    await page.close();
+  });
+
+  test("a missing stylesheet (404) reveals the app via the error path", async ({
+    context,
+  }) => {
+    const injection = await newInjectionPage(context);
+    const { page } = injection;
+
+    // The realistic production trigger: a hashed asset that has gone, because a
+    // deploy landed under an open tab. Netlify serves that as a 404 (the SPA
+    // `[[redirects]]` block in netlify.toml is commented out), and a 404 fails the
+    // stylesheet, so this takes the fast path.
+    let served = 0;
+    await page.route("**/assets/*.css", (route) => {
+      served++;
+      return route.fulfill({ status: 404, contentType: "text/plain", body: "" });
+    });
+
+    await page.goto("/");
+
+    expect(
+      served,
+      "no stylesheet was intercepted: the route glob no longer matches the built CSS path"
+    ).toBeGreaterThan(0);
+
+    await expect(page.locator(VIEWPORT)).toHaveCSS("visibility", "visible", {
+      timeout: 5000,
+    });
+    await expect(page.locator(GUARD)).toHaveCount(0);
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-fouc-fallback",
+      "stylesheet-error"
+    );
+
+    await expectOnlyTheFoucDiagnostic(injection, "stylesheet-error", BROKEN_CSS);
+    await page.close();
+  });
+
+  test("a stylesheet served as HTML reveals the app, whichever path the engine takes", async ({
+    context,
+  }) => {
+    const injection = await newInjectionPage(context);
+    const { page } = injection;
+
+    // The other production shape: SPA-fallback hosting answers a missing hashed
+    // asset with 200 text/html (the index page) rather than a 404.
+    //
+    // THIS IS WHY THE FIX HAS TWO PATHS, and the reason is empirical, not
+    // theoretical. The engines do not agree about which event a wrong-MIME
+    // stylesheet fires, and neither agrees fully with the spec (measured
+    // 2026-07-14):
+    //
+    //   Chromium  refuses to apply the sheet but fires `load`  -> load-backstop
+    //   Firefox   fires `error`                                -> stylesheet-error
+    //   WebKit    fires `error`                                -> stylesheet-error
+    //
+    // So delete the backstop and this failure goes unhandled on Chromium; delete
+    // the error path and it goes unhandled on Firefox and WebKit. Neither path
+    // alone covers the most likely real-world failure on every engine. That is the
+    // whole argument for keeping both, and it is the thing to read before
+    // "simplifying" this fix.
+    //
+    // The assertion therefore pins what the FIX guarantees (the app is revealed, by
+    // one of the two paths) rather than freezing one engine's quirk, which a
+    // browser update could legitimately change with no defect in our code. The
+    // per-path pinning is done deterministically by the abort/404 and empty-CSS
+    // cases above and below.
+    let served = 0;
+    await page.route("**/assets/*.css", (route) => {
+      served++;
+      return route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!DOCTYPE html><html><body>index</body></html>",
+      });
+    });
+
+    await page.goto("/");
+
+    expect(
+      served,
+      "no stylesheet was intercepted: the route glob no longer matches the built CSS path"
+    ).toBeGreaterThan(0);
+
+    await expect(page.locator(VIEWPORT)).toHaveCSS("visibility", "visible", {
+      timeout: 5000,
+    });
+    await expect(page.locator(GUARD)).toHaveCount(0);
+
+    // The reveal has landed (the two assertions above waited for it), so the marker
+    // is set. It must name one of the two paths: a null marker would mean the
+    // fallback never ran and something else revealed the app.
+    const marker = await page
+      .locator("html")
+      .getAttribute("data-fouc-fallback");
+    expect(
+      ["stylesheet-error", "load-backstop"],
+      "the fallback did not fire on a stylesheet served as HTML"
+    ).toContain(marker);
+
+    // Engines log the MIME refusal differently (or not at all), so allow anything
+    // naming the stylesheet we broke.
+    await expectOnlyTheFoucDiagnostic(injection, marker as string, BROKEN_CSS);
+    await page.close();
+  });
+
+  test("a stylesheet that loads but carries no rules reveals the app via the load backstop", async ({
+    context,
+  }) => {
+    const injection = await newInjectionPage(context);
+    const { page } = injection;
+
+    // An empty body with a CSS content-type is the ONE construction that provably
+    // cannot fire `error`: a valid stylesheet that simply applies no rules. That is
+    // what isolates the backstop. It is an artificial shape, deliberately; it
+    // stands in for the real cases the backstop uniquely covers (a truncated body,
+    // or style.scss no longer carrying the release rule), both of which load
+    // cleanly and raise nothing.
+    let served = 0;
+    await page.route("**/assets/*.css", (route) => {
+      served++;
+      return route.fulfill({ status: 200, contentType: "text/css", body: "" });
+    });
+
+    await page.goto("/");
+
+    expect(
+      served,
+      "no stylesheet was intercepted: the route glob no longer matches the built CSS path"
+    ).toBeGreaterThan(0);
+
+    await expect(page.locator(VIEWPORT)).toHaveCSS("visibility", "visible", {
+      timeout: 5000,
+    });
+    await expect(page.locator(GUARD)).toHaveCount(0);
+    // Pins the BACKSTOP specifically: no error event can fire here, so if the
+    // window-load handler is removed this goes red.
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-fouc-fallback",
+      "load-backstop"
+    );
+
+    // No resource error is expected: the response is a perfectly good (empty)
+    // stylesheet.
+    await expectOnlyTheFoucDiagnostic(injection, "load-backstop", []);
+    await page.close();
+  });
+
+  test("a successful stylesheet releases the guard via the cascade, not the fallback", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.locator(VIEWPORT)).toHaveCSS("visibility", "visible", {
+      timeout: 5000,
+    });
+
+    // The control, and the reason this case is not a tautology. The fallback
+    // supplies "visible" unconditionally, so asserting visibility alone would stay
+    // green even if the stylesheet stopped releasing the guard. These assertions
+    // say the release came from the CASCADE: the guard node is still in the DOM,
+    // and the fallback never ran.
+    //
+    // This is what re-pins `.viewportDiv { visibility: visible }` in style.scss.
+    // That declaration reads like a redundant no-op (`visible` is the initial
+    // value) and is exactly the kind a tidy-up deletes; before this ticket,
+    // deleting it produced an instant permanent blank page, the loudest signal
+    // there is. The fallback now masks that, so without these assertions the signal
+    // would have been silently replaced by nothing.
+    //
+    // This case runs on the FIXTURE's page, so reveal()'s console.error would fail
+    // it at teardown too: a third pin on the same contract, and the only one with
+    // no ordering dependency.
+    await expect(page.locator(GUARD)).toHaveCount(1);
+    expect(
+      await page.locator("html").getAttribute("data-fouc-fallback"),
+      "the fallback fired on a healthy stylesheet: the stylesheet is no longer " +
+        "releasing the FOUC guard"
+    ).toBeNull();
+  });
+
+  test("the built page arms the observer, not the initial scan", async ({
+    page,
+  }) => {
+    // The error-path tests above discriminate only because Vite emits the
+    // stylesheet <link> AFTER the inline script, so the script's initial
+    // querySelectorAll finds nothing and the MutationObserver is the only thing
+    // that arms the error listener. Nothing else pins that build fact: if Vite's
+    // injection order changed, the initial scan would arm the path, the observer
+    // would become dead code, and the tests above would stay green with it deleted.
+    const html = await (await page.request.get("/")).text();
+    const guardAt = html.indexOf('id="fouc-guard"');
+    // Match the ELEMENT, not the bare attribute. The inline script's own
+    // `querySelectorAll('link[rel="stylesheet"]')` contains the attribute text and
+    // appears EARLIER in the document than the real link, so searching for
+    // `rel="stylesheet"` alone finds the script's source and the ordering
+    // assertion below passes while comparing against the wrong thing. (It did,
+    // until this was caught.)
+    const linkAt = html.indexOf('<link rel="stylesheet"');
+
+    // Guard the lookups. A missing needle returns -1, and -1 is less than
+    // anything, so an unguarded comparison would pass vacuously: the exact
+    // false-green class this suite is about.
+    expect(
+      guardAt,
+      'no id="fouc-guard" in the served HTML'
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      linkAt,
+      'no <link rel="stylesheet"> element in the served HTML'
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      guardAt,
+      "the bundled stylesheet <link> must come AFTER the inline guard script; if it " +
+        "moves before it, the initial scan arms the error path and the " +
+        "MutationObserver becomes untested dead code"
+    ).toBeLessThan(linkAt);
+  });
+});

--- a/packages/pwa/e2e/fouc-fallback.spec.ts
+++ b/packages/pwa/e2e/fouc-fallback.spec.ts
@@ -301,6 +301,58 @@ test.describe("FOUC-guard fallback (#801)", () => {
     await page.close();
   });
 
+  // #829 — the fallback must reveal the APP, not everything the stylesheet hides.
+  //
+  // style.scss is the ONLY thing hiding three groups: #help (display: none),
+  // #feedback-modal (display: none) and .tooltiptext (visibility: hidden). When it
+  // fails, revealing .viewportDiv also exposes all three, so the failure screen
+  // showed an expanded help panel, an expanded feedback dialog, and every tooltip
+  // string dumped inline down the page.
+  //
+  // The fix is a SECOND inline <style id="fallback-hide"> that the fallback does not
+  // remove, so those three stay hidden with no stylesheet. It cannot break the healthy
+  // page: #help and #feedback-modal are opened by an inline style.display write
+  // (index.ts), which outranks any stylesheet rule, and .tooltiptext is revealed by
+  // `.tooltip:hover .tooltiptext`, which outranks it on specificity.
+  test("the fallback does not expose the elements only the stylesheet hides (#829)", async ({
+    context,
+  }) => {
+    const injection = await newInjectionPage(context);
+    const { page } = injection;
+
+    let aborted = 0;
+    await page.route("**/assets/*.css", (route) => {
+      aborted++;
+      return route.abort();
+    });
+
+    await page.goto("/");
+
+    expect(
+      aborted,
+      "no stylesheet was aborted: the route glob no longer matches the built CSS " +
+        "path, so this test is not injecting the failure it claims to inject"
+    ).toBeGreaterThan(0);
+
+    // Premise: the fallback fired and the app IS revealed. Without this the
+    // assertions below would pass on a page that never revealed anything.
+    await expect(page.locator(VIEWPORT)).toHaveCSS("visibility", "visible", {
+      timeout: 5000,
+    });
+
+    // The point of the ticket: revealed, but not undressed. Computed style, never
+    // the inline style string (#709).
+    await expect(page.locator("#help")).toHaveCSS("display", "none");
+    await expect(page.locator("#feedback-modal")).toHaveCSS("display", "none");
+    await expect(page.locator(".tooltiptext").first()).toHaveCSS(
+      "visibility",
+      "hidden"
+    );
+
+    await expectOnlyTheFoucDiagnostic(injection, "stylesheet-error", BROKEN_CSS);
+    await page.close();
+  });
+
   test("a successful stylesheet releases the guard via the cascade, not the fallback", async ({
     page,
   }) => {

--- a/packages/pwa/e2e/fouc-fallback.spec.ts
+++ b/packages/pwa/e2e/fouc-fallback.spec.ts
@@ -303,17 +303,19 @@ test.describe("FOUC-guard fallback (#801)", () => {
 
   // #829 — the fallback must reveal the APP, not everything the stylesheet hides.
   //
-  // style.scss is the ONLY thing hiding three groups: #help (display: none),
-  // #feedback-modal (display: none) and .tooltiptext (visibility: hidden). When it
-  // fails, revealing .viewportDiv also exposes all three, so the failure screen
-  // showed an expanded help panel, an expanded feedback dialog, and every tooltip
-  // string dumped inline down the page.
+  // style.scss alone hides #help, #feedback-modal and the tooltip text, so revealing
+  // .viewportDiv also exposed all three: the failure screen showed an expanded help
+  // panel, an expanded feedback dialog, and every tooltip string inline down the page.
+  // The fix is a second, persistent <style id="fallback-hide"> the fallback does not
+  // remove. The cascade argument for why it cannot break the healthy page lives in ONE
+  // place, beside the code: index.html, the #fallback-hide block. Do not restate it
+  // here; two copies drift.
   //
-  // The fix is a SECOND inline <style id="fallback-hide"> that the fallback does not
-  // remove, so those three stay hidden with no stylesheet. It cannot break the healthy
-  // page: #help and #feedback-modal are opened by an inline style.display write
-  // (index.ts), which outranks any stylesheet rule, and .tooltiptext is revealed by
-  // `.tooltip:hover .tooltiptext`, which outranks it on specificity.
+  // NOTE the discrimination. All four assertions below are ALSO true on a healthy page,
+  // because style.scss hides the same three. What makes this a failure-page test rather
+  // than a tautology is `aborted > 0` (the failure really was injected), the GUARD count
+  // (the fallback really fired), and expectOnlyTheFoucDiagnostic (exactly one
+  // stylesheet-error diagnostic). Do not remove any of the three.
   test("the fallback does not expose the elements only the stylesheet hides (#829)", async ({
     context,
   }) => {
@@ -340,6 +342,10 @@ test.describe("FOUC-guard fallback (#801)", () => {
       timeout: 5000,
     });
 
+    // The fallback really fired: the guard node is gone. Third discriminator, and the
+    // one that separates this from a healthy page (see the note above).
+    await expect(page.locator(GUARD)).toHaveCount(0);
+
     // The point of the ticket: revealed, but not undressed. Computed style, never
     // the inline style string (#709).
     await expect(page.locator("#help")).toHaveCSS("display", "none");
@@ -351,6 +357,46 @@ test.describe("FOUC-guard fallback (#801)", () => {
 
     await expectOnlyTheFoucDiagnostic(injection, "stylesheet-error", BROKEN_CSS);
     await page.close();
+  });
+
+  // The other half of #829, and the half that would hurt: the persistent
+  // #fallback-hide block must not survive into the OPEN path on a healthy page. If it
+  // did, the help panel and the feedback dialog would never open and the tooltips would
+  // never show — a permanent, silent breakage of three working features, shipped to fix
+  // a failure screen almost nobody sees.
+  //
+  // smoke.spec.ts, feedback-modal.spec.ts and tooltip.spec.ts each pin one of these
+  // already, but none of them knows it is now guarding #829, and a tidy-up of any one
+  // would remove the guard silently. This case makes fouc-fallback.spec.ts stand on its
+  // own for the block it introduces.
+  test("the persistent hide block does not break the healthy page (#829)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Premise: a healthy load, so the block is inert rather than load-bearing.
+    await expect(page.locator(VIEWPORT)).toHaveCSS("visibility", "visible");
+    await expect(page.locator(GUARD)).toHaveCount(1);
+
+    // Inline style.display writes outrank the block. Dismiss each panel before opening
+    // the next: both raise #backdrop, which covers the header and would intercept the
+    // following click. The backdrop IS the app's dismiss control (see smoke.spec.ts).
+    const backdrop = page.locator("#backdrop");
+
+    await page.locator("#info").click();
+    await expect(page.locator("#help")).toBeVisible();
+    await backdrop.click();
+    await expect(page.locator("#help")).toBeHidden();
+
+    await page.locator("#feedback-trigger").click();
+    await expect(page.locator("#feedback-modal")).toBeVisible();
+    await backdrop.click();
+    await expect(page.locator("#feedback-modal")).toBeHidden();
+
+    // The header-scoped hover rule outranks the block on specificity.
+    const tooltip = page.locator("header .tooltip").first();
+    await tooltip.hover();
+    await expect(tooltip.locator(".tooltiptext")).toBeVisible();
   });
 
   test("a successful stylesheet releases the guard via the cascade, not the fallback", async ({

--- a/packages/pwa/e2e/helpers/page-errors.ts
+++ b/packages/pwa/e2e/helpers/page-errors.ts
@@ -12,10 +12,17 @@ import { test as base, expect } from "@playwright/test";
  * the playback loop outright — either way every icon assertion stays green.
  * The un-mocked audio load is likewise silent on a 404 or decode failure.
  *
- * Scope: listeners attach to the per-test `page` fixture only. Popups, pages
- * opened via context.newPage(), and dedicated workers are NOT captured. No
- * spec opens any of these today; a spec that does must wire its extra pages
- * explicitly. Service workers are blocked suite-wide (playwright.config.ts
+ * Scope: the listeners attach to the per-test `page` fixture only, so popups,
+ * pages opened via context.newPage(), and dedicated workers are NOT captured. A
+ * spec that opens one must either wire the listeners onto it explicitly, or —
+ * when the extra page deliberately produces captured-class errors, as a
+ * failure-injection test does (e2e/fouc-fallback.spec.ts injects a stylesheet
+ * failure as its premise) — say so in a comment at the open site, and re-attach the
+ * channels with a filter rather than dropping them (see doc/TESTING.md). The ROUTES
+ * below are registered on the context, not the page, so another page IN THIS CONTEXT
+ * does still get them; only the listeners are lost.
+ *
+ * Service workers are blocked suite-wide (playwright.config.ts
  * `serviceWorkers: "block"`) — an active SW would intercept requests and
  * bypass page-level network events on Chromium, blinding the /audio/ channel.
  *
@@ -64,6 +71,19 @@ const ALLOWLIST: string[] = [
 // implements SPA fallback by redirecting /audio/ off-path, whose final hop
 // this filter would no longer match — update this too, or the audio channel
 // guards a dead path silently.
+/**
+ * True if a captured message is one the ALLOWLIST above expects.
+ *
+ * Exported so a spec that escapes the fixture (see the Scope note) filters its
+ * own re-attached console channel through the SAME list, rather than
+ * re-implementing it and diverging. A private copy immediately went out of step
+ * with this one: it re-flagged the DNS-blocked third-party script hosts the
+ * ALLOWLIST exists to excuse (#801).
+ */
+export function isAllowlisted(entry: string): boolean {
+  return ALLOWLIST.some((allowed) => entry.includes(allowed));
+}
+
 function isAudioUrl(url: string): boolean {
   try {
     return new URL(url).pathname.startsWith("/audio/");
@@ -74,10 +94,10 @@ function isAudioUrl(url: string): boolean {
 
 export const test = base.extend<{ pageErrorCapture: readonly string[] }>({
   pageErrorCapture: [
-    async ({ page }, use) => {
+    async ({ page, context }, use) => {
       const captured: string[] = [];
       const record = (entry: string) => {
-        if (!ALLOWLIST.some((allowed) => entry.includes(allowed))) {
+        if (!isAllowlisted(entry)) {
           captured.push(entry);
         }
       };
@@ -89,7 +109,15 @@ export const test = base.extend<{ pageErrorCapture: readonly string[] }>({
       // an empty 204 rather than abort() so no "Failed to load resource" error
       // is logged — keeping the console-error gate strict with no allowlist.
       // Covers both the static.* script host and the bare RUM endpoint.
-      await page.route(/cloudflareinsights\.com/, (route) =>
+      //
+      // Registered on the CONTEXT, not the page (#801): a page-scoped route
+      // would leave a context.newPage() spec running the real beacon, and the
+      // ALLOWLIST above deliberately carries no Cloudflare entry precisely
+      // BECAUSE the beacon is stubbed. A spec that wired its own listeners onto
+      // an unstubbed page would therefore hit the CORS flood with no allowlist
+      // to fall back on. Context scope makes the stub true for every page here,
+      // so that trap cannot be sprung.
+      await context.route(/cloudflareinsights\.com/, (route) =>
         route.fulfill({ status: 204, body: "" })
       );
 

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -10,12 +10,148 @@
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
     <link rel="manifest" href="site.webmanifest">
-    <style>
-        /* Prevent FOUC: hide main content until external CSS loads */
+    <style id="fouc-guard">
+        /* Prevent FOUC: hide main content until external CSS loads. The bundled
+           stylesheet releases it (style.scss `.viewportDiv { visibility: visible }`);
+           the script below removes this whole node if that release never arrives. */
         .viewportDiv {
             visibility: hidden;
         }
     </style>
+    <script>
+        /* FOUC-guard fallback (#801).
+
+           If the bundled stylesheet fails, the release above never arrives and the
+           page would stay blank forever. Reveal the unstyled app instead.
+
+           Reveal by REMOVING the guard node, not by writing an inline style on
+           .viewportDiv. That element lives in <body> and this script runs in <head>,
+           so when a stylesheet error fires the element may not exist yet: a query for
+           it would silently find nothing and the reveal would be lost. (The parser can
+           still be inside <head> at that point, because a pending stylesheet blocks the
+           inline gtag script below, which in turn blocks parsing.) Removing the guard
+           node is element-independent, order-independent and idempotent, and it leaves
+           no inline-style specificity residue to outrank a later rule.
+
+           TWO PATHS, AND BOTH ARE LOAD-BEARING. Do not "simplify" this to one.
+
+           The link's `error` event is the fast path; a window-load backstop covers the
+           failures that raise no error. It is tempting to think the error path is
+           enough, and reading the HTML link-processing algorithm encourages that. The
+           browsers say otherwise, and they do not even agree with each other. Measured
+           on 2026-07-14, for the most likely real failure (a hashed asset that has gone
+           because a deploy landed under an open tab, served back as 200 text/html by
+           SPA-fallback hosting):
+
+               Chromium   refuses to apply the sheet, but fires `load`  -> backstop
+               Firefox    fires `error`                                 -> fast path
+               WebKit     fires `error`                                 -> fast path
+
+           So removing the backstop leaves that failure unhandled on Chromium, and
+           removing the error path leaves it unhandled on Firefox and WebKit. Neither
+           path alone is sufficient. e2e/fouc-fallback.spec.ts pins each path with a
+           case that fails if that path is deleted; trust those over this comment.
+
+           The error path also catches an outright failure: a network error, or a 404
+           (which is what our host actually returns for a missing hashed asset, since
+           the SPA `[[redirects]]` block in netlify.toml is commented out).
+
+           The backstop also catches a stylesheet that loads cleanly but carries no
+           rules (a truncated body), and one that no longer contains the release rule at
+           all. `load` cannot fire early on a slow-but-successful stylesheet, so no
+           timer is needed.
+
+           A request that HANGS raises neither event until the network stack finally
+           times out, so the page stays blank in the meantime. That case is NOT covered:
+           see #828.
+
+           The backstop is armed FIRST, before anything that can throw, so a failure in
+           the fast-path setup cannot take the universal path down with it.
+
+           Nothing enforces the ordering rule below; this comment is all there is.
+
+           Vite appends the bundled stylesheet <link> at the END of <head>, after this
+           script, so the initial scan below finds nothing in the built page and the
+           MutationObserver is what actually arms the error path. Under `vite dev` there
+           is no <link> at all (the SCSS arrives as an injected <style>), so in dev the
+           error path is inert and the backstop is what covers it.
+
+           Keep this script ABOVE the Google Fonts @import below: a parser-blocking
+           inline script placed after a pending stylesheet must wait for that
+           stylesheet's CSSOM before it runs, which would put this behind a
+           cross-origin round trip. */
+        (function () {
+            var observer = null;
+            var revealed = false;
+
+            function reveal(source) {
+                if (revealed) return;
+                revealed = true;
+                if (observer) observer.disconnect();
+                /* Report BEFORE acting, and unconditionally. If the guard node is
+                   somehow already gone while the app is still hidden, that is a blank
+                   page we cannot fix, and it must scream rather than return quietly:
+                   returning early here is how #801 would come back, silent. */
+                var guard = document.getElementById('fouc-guard');
+                if (guard) guard.remove();
+                document.documentElement.setAttribute(
+                    'data-fouc-fallback', guard ? source : source + '-noguard');
+                console.error('[spem] the stylesheet did not release the FOUC guard (' +
+                    source + ')' + (guard
+                        ? '; revealing the unstyled app'
+                        : '; the guard node was already gone, so nothing could be revealed') +
+                    ' (#801)');
+            }
+
+            /* Armed first: this is the path that must never be lost. */
+            window.addEventListener('load', function () {
+                var el = document.querySelector('.viewportDiv');
+                if (!el) {
+                    /* The class name is shared by the guard rule above, style.scss and
+                       the markup. If it is ever renamed and this query is missed, the
+                       backstop dies; say so rather than no-op. */
+                    console.error('[spem] FOUC backstop: .viewportDiv not found, so the ' +
+                        'guard could not be checked (#801)');
+                } else if (getComputedStyle(el).visibility === 'hidden') {
+                    reveal('load-backstop');
+                }
+                if (observer) observer.disconnect();
+            });
+
+            try {
+                /* Only OUR stylesheet withholds the release, so only watch same-origin
+                   links. A third-party sheet failing (a blocked font CDN, an adblocker)
+                   says nothing about our CSS: treating it as our failure would tear the
+                   guard out while our CSS was still loading, which is the very flash the
+                   guard prevents, and would log an app error that is not ours. */
+                var ours = function (link) {
+                    try {
+                        return new URL(link.href, location.href).origin === location.origin;
+                    } catch (e) {
+                        return false;
+                    }
+                };
+                var watch = function (link) {
+                    if (!ours(link)) return;
+                    link.addEventListener('error', function () { reveal('stylesheet-error'); });
+                };
+                /* Observe before scanning, so a throw in the scan cannot cost us the
+                   observer as well: in the built page the observer is the only path that
+                   ever arms, because Vite appends the link after this script. */
+                observer = new MutationObserver(function (records) {
+                    records.forEach(function (record) {
+                        record.addedNodes.forEach(function (node) {
+                            if (node.nodeName === 'LINK' && node.rel === 'stylesheet') watch(node);
+                        });
+                    });
+                });
+                observer.observe(document.head, { childList: true });
+                document.querySelectorAll('link[rel="stylesheet"]').forEach(watch);
+            } catch (e) {
+                console.error('[spem] FOUC fast-path setup failed; the load backstop is still armed (#801)', e);
+            }
+        })();
+    </script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400..900;1,400..900&family=Quintessential&display=swap&family=EB+Garamond&display=swap&family=Macondo&display=swap&family=Eagle+Lake&display=swap&family=Macondo+Swash+Caps&display=swap');
     </style>

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -18,6 +18,36 @@
             visibility: hidden;
         }
     </style>
+    <style id="fallback-hide">
+        /* #829 — keep the closed things closed when there is no stylesheet.
+
+           style.scss is the ONLY thing hiding these three. So when it fails and the
+           guard above is removed to reveal the app, it also reveals an expanded help
+           panel, an expanded feedback dialog, and every tooltip string inline down the
+           page. Revealing the app should not undress it.
+
+           This is a SEPARATE node from #fouc-guard, and deliberately so: the fallback
+           removes that one, and must not remove this one. These rules are the floor
+           the failure screen stands on.
+
+           It cannot break the healthy page, which is why it is safe to leave in place:
+             - #help and #feedback-modal are opened by an inline `style.display` write
+               (index.ts), and an inline style outranks any stylesheet rule;
+             - .tooltiptext is revealed by `.tooltip:hover .tooltiptext`, which outranks
+               the bare `.tooltiptext` selector below on specificity.
+           Both are pinned by e2e/fouc-fallback.spec.ts. */
+        #help {
+            display: none;
+        }
+
+        #feedback-modal {
+            display: none;
+        }
+
+        .tooltiptext {
+            visibility: hidden;
+        }
+    </style>
     <script>
         /* FOUC-guard fallback (#801).
 

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -27,15 +27,36 @@
            page. Revealing the app should not undress it.
 
            This is a SEPARATE node from #fouc-guard, and deliberately so: the fallback
-           removes that one, and must not remove this one. These rules are the floor
-           the failure screen stands on.
+           removes that one by id and must not remove this one. These rules are the
+           floor the failure screen stands on. Merging the two <style> blocks is the
+           tempting tidy-up, and it is wrong: the fallback would remove both and #help
+           would compute to visible. The new case in e2e/fouc-fallback.spec.ts goes red
+           if you try it.
+
+           EACH RULE MIRRORS ITS SOURCE SELECTOR EXACTLY. Do not broaden them. A bare
+           `.tooltiptext` would also hide any tooltip placed OUTSIDE <header>, which the
+           header-scoped hover rule could then never reveal: permanently invisible, with
+           no error and no red test. Before this block, that same tooltip would have been
+           permanently VISIBLE, which a developer sees at once. Broadening the mirror
+           trades a loud failure for a silent one.
 
            It cannot break the healthy page, which is why it is safe to leave in place:
              - #help and #feedback-modal are opened by an inline `style.display` write
-               (index.ts), and an inline style outranks any stylesheet rule;
-             - .tooltiptext is revealed by `.tooltip:hover .tooltiptext`, which outranks
-               the bare `.tooltiptext` selector below on specificity.
-           Both are pinned by e2e/fouc-fallback.spec.ts. */
+               (index.ts), and an inline style outranks any non-!important stylesheet
+               rule;
+             - `header .tooltip .tooltiptext` (0,2,1) is outranked by style.scss's
+               `header .tooltip:hover .tooltiptext` (0,3,1), so hover still reveals.
+
+           WHICH TESTS PIN WHAT, because it matters and the obvious answer is wrong.
+           e2e/fouc-fallback.spec.ts pins the FAILURE page (these three stay hidden). It
+           says nothing about the healthy page and would stay green if the healthy page
+           broke. The healthy-page claims above are pinned by e2e/smoke.spec.ts ("help
+           panel opens and closes"), e2e/feedback-modal.spec.ts, and e2e/tooltip.spec.ts
+           (hovers each tooltip). Those three are load-bearing for #829 now. Weaken one
+           and this block loses its only guard.
+
+           #backdrop is knowingly NOT mirrored: style.scss alone hides it, but unstyled
+           it is an empty div with no size and no background, so it renders nothing. */
         #help {
             display: none;
         }
@@ -44,7 +65,7 @@
             display: none;
         }
 
-        .tooltiptext {
+        header .tooltip .tooltiptext {
             visibility: hidden;
         }
     </style>

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.14",
+  "version": "2.8.15",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/src/scss/style.scss
+++ b/packages/pwa/src/scss/style.scss
@@ -184,6 +184,12 @@ header {
     display: inline-block;
   }
 
+  // MIRRORED in index.html's `<style id="fallback-hide">` block (#829). This rule is
+  // the ONLY thing hiding the tooltip text, so if this stylesheet fails to load the
+  // FOUC fallback would reveal every tooltip string inline down the page. Keep the two
+  // selectors identical. If you add another element that ONLY this stylesheet hides,
+  // mirror it there too, or it appears expanded on every failure screen with no test
+  // to catch it.
   .tooltip .tooltiptext {
     visibility: hidden;
     width: 120px;
@@ -207,6 +213,9 @@ header {
   }
 }
 
+// MIRRORED in index.html's `<style id="fallback-hide">` block (#829): this rule is the
+// only thing hiding the help panel, so without it the FOUC fallback shows the panel
+// expanded. Keep both in step.
 #help {
   display: none;
   padding: 0 5px;
@@ -576,6 +585,9 @@ kbd {
   }
 }
 
+// MIRRORED in index.html's `<style id="fallback-hide">` block (#829): this rule is the
+// only thing hiding the feedback dialog, so without it the FOUC fallback shows the
+// dialog expanded. Keep both in step.
 #feedback-modal {
   display: none;
   padding: 0 10px 10px;

--- a/packages/pwa/src/test/fouc-guard-markup.test.ts
+++ b/packages/pwa/src/test/fouc-guard-markup.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * #829 — pin the two-node structure of the FOUC guard, on every PR.
+ *
+ * `index.html` carries TWO inline <style> nodes and the difference is load-bearing:
+ *
+ *   #fouc-guard    hides .viewportDiv, and the fallback script REMOVES this node to
+ *                  reveal the app when the bundled stylesheet never arrives (#801).
+ *   #fallback-hide keeps #help, #feedback-modal and the tooltips hidden, and the
+ *                  fallback must NEVER remove it (#829). style.scss is otherwise the
+ *                  only thing hiding those, so without it the failure screen shows an
+ *                  expanded help panel, an expanded feedback dialog, and every tooltip
+ *                  string inline down the page.
+ *
+ * "Tidy those two adjacent <style> blocks into one" is the tempting refactor, and it is
+ * wrong: the fallback would remove both.
+ *
+ * e2e/fouc-fallback.spec.ts already catches that — but the e2e suite runs NIGHTLY, not
+ * on pull requests (a settled trade: e2e is slow, we accept the lag). So the tidy-up PR
+ * would go green, merge, and the regression would surface the following morning. This
+ * test runs in the unit suite on every PR and costs milliseconds, which turns a
+ * next-morning catch into a same-PR one.
+ */
+describe("FOUC guard markup (#801/#829)", () => {
+  const html = readFileSync(resolve(__dirname, "../../index.html"), "utf-8");
+
+  const styleBlock = (id: string): string => {
+    const m = html.match(
+      new RegExp(`<style id="${id}">([\\s\\S]*?)</style>`, "i")
+    );
+    expect(m, `<style id="${id}"> is missing from index.html`).not.toBeNull();
+    return m![1];
+  };
+
+  it("keeps the guard and the persistent hide as two SEPARATE style nodes", () => {
+    // Merge them and the fallback (which removes #fouc-guard by id) takes both.
+    expect(html).toContain('<style id="fouc-guard">');
+    expect(html).toContain('<style id="fallback-hide">');
+  });
+
+  it("puts .viewportDiv in the node the fallback REMOVES", () => {
+    expect(styleBlock("fouc-guard")).toMatch(/\.viewportDiv/);
+  });
+
+  it("puts the three hidden elements in the node the fallback KEEPS", () => {
+    const keep = styleBlock("fallback-hide");
+    expect(keep).toMatch(/#help/);
+    expect(keep).toMatch(/#feedback-modal/);
+    expect(keep).toMatch(/\.tooltiptext/);
+
+    // ...and NOT in the node that gets torn out, or they go with it.
+    const removed = styleBlock("fouc-guard");
+    expect(removed).not.toMatch(/#help/);
+    expect(removed).not.toMatch(/#feedback-modal/);
+    expect(removed).not.toMatch(/\.tooltiptext/);
+  });
+
+  it("scopes the tooltip mirror to header, exactly as style.scss does", () => {
+    // A bare `.tooltiptext` would hide a tooltip placed OUTSIDE <header>, which the
+    // header-scoped hover rule in style.scss could then never reveal: permanently
+    // invisible, silently. The mirror must not reach further than its source.
+    expect(styleBlock("fallback-hide")).toMatch(
+      /header\s+\.tooltip\s+\.tooltiptext/
+    );
+  });
+
+  it("removes the guard node by id, not by clearing its rules", () => {
+    // The reveal is `guard.remove()`. If that ever became a style rewrite, it could
+    // take the sibling's rules with it.
+    expect(html).toMatch(/getElementById\(['"]fouc-guard['"]\)/);
+  });
+});


### PR DESCRIPTION
The inline FOUC guard in `index.html` hides `.viewportDiv` until the bundled stylesheet releases it (`style.scss`, `.viewportDiv { visibility: visible }`). A visit whose CSS request failed never got that release, so the page stayed permanently blank.

This reveals the app instead, by removing the guard node.

## Why there are two reveal paths, and why neither can be removed

The fix listens on two things: the stylesheet link's `error` event, and a `window.load` backstop. That looks like belt and braces. It is not, and the reason is measured rather than argued.

For the most likely real failure, a hashed asset that has gone because a deploy landed under an open tab, hosting answers with the index page (200 `text/html`). The engines disagree about which event the link then fires:

- **Chromium** refuses to apply the sheet but fires `load`, so the **backstop** reveals the app.
- **Firefox** fires `error`, so the **fast path** reveals it.
- **WebKit** fires `error`, so the **fast path** reveals it.

So neither path alone covers that failure everywhere: delete the backstop and Chromium stays blank, delete the error path and Firefox and WebKit stay blank.

This is worth stating plainly because reading the HTML link-processing algorithm suggests the opposite (a non-CSS Content-Type fails the sheet, therefore fires `error`, therefore the fast path suffices). Four independent reviewers reached that conclusion during review, and the browser disagreed with all of them. `e2e/fouc-fallback.spec.ts` pins it, and the per-engine table is recorded in the `index.html` comment so the next person to reach the same tidy conclusion is stopped by evidence.

## How the reveal works

`reveal()` removes the guard `<style id="fouc-guard">` node rather than writing an inline style on `.viewportDiv`. That element lives in `<body>` and the script runs in `<head>`, so when a stylesheet error fires it may not exist yet (a pending stylesheet blocks the inline `gtag` script, which blocks parsing before `<body>`). A query for it would silently find nothing and the reveal would be lost. Removing the node is element-independent, order-independent and idempotent, and leaves no inline-style specificity residue.

The `window.load` backstop is armed **first**, before anything that can throw, so a failure in the fast-path setup cannot take the universal path down with it. The fallback logs a `console.error` and marks the document (`data-fouc-fallback`), because an unstyled app that reports nothing is a silent failure and this app collects no errors anywhere else.

## The tests

Six cases, and each pins one thing so a regression cannot hide behind another path:

- an aborted stylesheet reveals via the error path;
- a 404 reveals via the error path (what our host actually returns: the SPA `[[redirects]]` block in `netlify.toml` is commented out);
- a stylesheet served as HTML reveals via whichever path the engine takes (the divergence above);
- a stylesheet that loads but carries no rules reveals via the load backstop;
- a healthy stylesheet releases the guard via the **cascade**, with the fallback not firing;
- the built page arms the MutationObserver, not the initial scan.

Two of those need highlighting.

The healthy-stylesheet case asserts the guard node **survives** and the fallback did **not** run. That re-pins `.viewportDiv { visibility: visible }` in `style.scss`, which reads like a redundant no-op (`visible` is the initial value) and is exactly the kind of line a tidy-up deletes. Before this change, deleting it blanked the page instantly, which is the loudest possible signal. The fallback would otherwise have silently masked that.

The injection cases **count** their route hits and assert the injection actually fired, so a future change to Vite's asset path cannot quietly turn the tests into no-ops that pass while exercising nothing.

## Other changes

`e2e/helpers/page-errors.ts`: the Cloudflare beacon stub moves from `page.route` to `context.route`, so a spec that opens its own page inherits it. The allowlist filter is exported as `isAllowlisted` so an escaping spec filters through the same list rather than a private copy that drifts.

`doc/TESTING.md`: documents when to stub `fetch` versus intercept the route, and how to escape the page-error fixture without going blind (filter the console channel, do not drop it).

## Not covered

A stylesheet request that **hangs** raises neither event until the network stack times out, so the page stays blank in the meantime. That is out of scope here: a bounded timer would fix it but changes the user-visible contract on slow networks, so it is filed as #828 for a decision rather than settled unilaterally. #829 covers the quality of the unstyled fallback page, which reveals `#help` and `#feedback-modal` because `style.scss` is the only thing hiding them.

## Verification

`pnpm run ci` green. Unit: 352 passed. E2E: 157 passed, 0 failed, across Chromium, Firefox and WebKit. Note that `pwa-e2e.yml` runs on a schedule and `workflow_dispatch` only, never on `pull_request`, so the new spec does not gate this PR; it was run locally on all three engines.

Fixes #801
Fixes #829 (the fallback-hide block: the fold agreed 2026-07-14)

