### PR TITLE
fix: resolve canvas hit-test one bar too low across the right half (#790)

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.14",
+  "version": "2.8.9",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.9",
+  "version": "2.8.16",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/src/test/canvas.test.ts
+++ b/packages/pwa/src/test/canvas.test.ts
@@ -2399,7 +2399,7 @@ describe("MusicCanvas custom element", () => {
       // Branch 3, second disjunct: bar PAST the end of the piece takes the same
       // branch as bar 0. Deleting `|| this.bar > barCount` from the source would
       // send these bars to branch 4 (dull 38 instead of bright 45) and nothing
-      // else in the file would catch it. The pair also pins the STRICT `>`:
+      // else in the file would catch it. The pair also pins the `>=` boundary at 140:
       // barCount itself is still inside the piece and must take branch 4.
       canvas!.bar = barCount + 1;
       col = sole(styleSetsDuring(ctx(), "strokeStyle", () => canvas!.draw()));
@@ -2541,7 +2541,7 @@ describe("MusicCanvas custom element", () => {
           )
         ).toBe(true);
 
-        // bar === barCount: still drawn (the guard is bar > barCount).
+        // bar === barCount: still drawn (the guard is bar >= #barSlots, i.e. 140).
         canvas!.bar = canvas!.lilyData!.barCount;
         moveSpy.mockClear();
         canvas!.draw();
@@ -2747,21 +2747,35 @@ describe("MusicCanvas custom element", () => {
       }
       return tops.length ? tops[0] : null;
     };
+    // PIN THE FORWARD DIVISOR. barWidth is the drawn geometry, the thing the
+    // user actually clicks, and every other assertion in this file reads it back
+    // OFF the element, which makes them tautologies in it. So a barWidth
+    // regression (the forward map built on a different slot count from the
+    // inverse map) passed every test: exactly #790, and invisible. Assert the
+    // value against its definition, from the element's own public fields, not
+    // against itself.
+    expect(canvas!.barWidth).toBeCloseTo(
+      (canvas!.canvas!.width - 2 * canvas!.canvasPadding) /
+        (canvas!.lilyData!.barCount + 1),
+      9
+    );
+
     // Inside the final bar the playhead is drawn, at the forward-map x for that
-    // bar. Pinning x to canvasPadding + (bar + 0.5) * barWidth ties the drawn
-    // playhead to the same slot geometry the hit-test inverts, so a barWidth
-    // regression cannot pass while the (inverse-only) round-trip test stays green.
+    // bar. NOTE this assertion reads barWidth off the element on both sides, so
+    // it pins the FORMULA (the + 0.5, the padding term), not the VALUE. The
+    // value is pinned above; do not delete that and rely on this.
     const x = playheadX(139.5);
     expect(x).not.toBeNull();
     expect(x!).toBeCloseTo(
       canvas!.canvasPadding + (139.5 + 0.5) * canvas!.barWidth,
       6
     );
-    // Both edges of the `>= #barSlots` guard: no playhead on the intro bar
-    // (bar <= 0) or past the end (bar 140.5 >= #barSlots = 140). Without these a
-    // guard widened to always-draw, or to `> #barSlots`, would stay green.
+    // Both edges of the `>= #barSlots` guard. The upper edge is asserted at
+    // EXACTLY 140, not 140.5: `>` and `>=` differ only at bar === #barSlots, so
+    // a guard widened to `>` would sail past 140.5 (140.5 > 140 is also true) and
+    // this test would not carry the claim its comment makes.
     expect(playheadX(0)).toBeNull();
-    expect(playheadX(140.5)).toBeNull();
+    expect(playheadX(140)).toBeNull();
   });
 
   it("keeps normal row colouring inside the final bar (#790)", () => {

--- a/packages/pwa/src/test/canvas.test.ts
+++ b/packages/pwa/src/test/canvas.test.ts
@@ -1101,7 +1101,10 @@ describe("MusicCanvas custom element", () => {
       canvas!.querySelector("canvas")!.dispatchEvent(mouseEvent);
       const event = await promise;
       const pos = event.detail.position;
-      expect(pos.bar).toBe(Math.floor(canvas!.lilyData!.barCount / 2));
+      // barSlots-robust centre: x = width/2 -> floor(barSlots / 2) = 70, the
+      // slot containing the centre pixel (not floor(barCount/2) = 69, which was
+      // the count-vs-index defect #790).
+      expect(pos.bar).toBe(Math.floor((canvas!.lilyData!.barCount + 1) / 2));
     }
   });
 
@@ -1244,7 +1247,10 @@ describe("MusicCanvas custom element", () => {
       innerCanvas.dispatchEvent(touchStart);
       const event = await promise;
       const pos = event.detail.position;
-      expect(pos.bar).toBe(Math.floor(canvas!.lilyData!.barCount / 2));
+      // barSlots-robust centre: x = width/2 -> floor(barSlots / 2) = 70, the
+      // slot containing the centre pixel (not floor(barCount/2) = 69, which was
+      // the count-vs-index defect #790).
+      expect(pos.bar).toBe(Math.floor((canvas!.lilyData!.barCount + 1) / 2));
     }
   });
 
@@ -1781,24 +1787,27 @@ describe("MusicCanvas custom element", () => {
 
   it("projects representative mouse coordinates to the expected choir/part/bar (#650)", async () => {
     // choir/part depend only on constants (padding + grid sizes) so they are
-    // pinned exactly; bar uses barCount-robust coordinates — left edge -> 0,
-    // right edge -> barCount, x = width/2 -> floor(barCount/2) (the centre
+    // pinned exactly; bar uses barSlots-robust coordinates — left edge -> 0,
+    // right edge -> barCount, x = width/2 -> floor(barSlots/2) = 70 (the centre
     // identity is exact regardless of padding). On a 1400x400 rect these
     // three points sit at the clamp extremes and a stable interior row, so
     // they are unaffected by the Y-padding scaling — they characterise the
     // de-dup; the short-viewport tests below characterise the Y fix.
-    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
+    const mid = Math.floor((canvas!.lilyData!.barCount + 1) / 2);
     expect(await clickAt(0, 2)).toEqual({ choir: 0, part: 0, bar: 0 });
     expect(await clickAt(700, 175)).toEqual({ choir: 3, part: 2, bar: mid });
+    // Bottom-right corner: choir clamps to 7, and part is now the last part
+    // (4, Bass), not 0 (Soprano) — the #791 fix folded into #790. bar stays
+    // barCount at the right edge (the inverse map clamps the last slot down).
     expect(await clickAt(1400, 398)).toEqual({
       choir: 7,
-      part: 0,
+      part: 4,
       bar: canvas!.lilyData!.barCount,
     });
   });
 
   it("projects representative touch coordinates, resolving part to 'all' (#650)", async () => {
-    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
+    const mid = Math.floor((canvas!.lilyData!.barCount + 1) / 2);
     expect(await touchAt(0, 2)).toEqual({ choir: 0, part: "all", bar: 0 });
     expect(await touchAt(700, 175)).toEqual({
       choir: 3,
@@ -1819,8 +1828,8 @@ describe("MusicCanvas custom element", () => {
     // The old unscaled-Y mapping used padding 5 and returned part 2 — a real
     // wrong-result toward the top of a short viewport (the two mappings
     // coincide at the exact centre and diverge toward the edges). Scaling Y
-    // restores the drawn mapping. (x = width/2 -> floor(barCount/2), unaffected.)
-    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
+    // restores the drawn mapping. (x = width/2 -> floor(barSlots/2), unaffected.)
+    const mid = Math.floor((canvas!.lilyData!.barCount + 1) / 2);
     expect(await clickAt(700, 50, 1400, 150)).toEqual({
       choir: 2,
       part: 3,
@@ -1832,7 +1841,7 @@ describe("MusicCanvas custom element", () => {
     // Touch hard-codes part "all" (#327), so the Y fix shows up on the CHOIR
     // here, not the part: on a 150px-tall canvas a tap at y=38 falls on the
     // drawn choir 2, but the old unscaled-Y mapping returned choir 1.
-    const mid = Math.floor(canvas!.lilyData!.barCount / 2);
+    const mid = Math.floor((canvas!.lilyData!.barCount + 1) / 2);
     expect(await touchAt(700, 38, 1400, 150)).toEqual({
       choir: 2,
       part: "all",
@@ -2664,5 +2673,149 @@ describe("MusicCanvas custom element", () => {
         canvas!.getBoundingClientRect = savedRect;
       }
     });
+  });
+
+  // ====================================================================
+  // #790 / #791 — the hit-test must invert the bar drawing, the final bar
+  // must render normally, and the bottom row must select Bass.
+  //
+  // The overview is drawn in barSlots = barCount + 1 (140) equal slices,
+  // but the inverse map divided by barCount (139), so the two directions
+  // diverged by 140/139 and every centre from bar 70 up resolved one bar
+  // low (#790). The end-of-piece tests compared against barCount, so the
+  // whole of bar 139 read as past the end (#790, symptom 2). And the part
+  // index came from the unclamped row fraction, which is exactly nChoirs at
+  // the bottom edge, resetting Bass to Soprano (#791, folded).
+  // ====================================================================
+
+  // CSS-pixel x of the visual centre of drawn bar `b`, mirroring the forward
+  // map: padding scaled into CSS px, then the centre of slot b at
+  // (b + 0.5) / barSlots of the drawable width.
+  const barCentreX = (b: number, width: number) => {
+    const barSlots = canvas!.lilyData!.barCount + 1;
+    const cssPaddingX = canvas!.canvasPadding * (width / canvas!.canvas!.width);
+    const drawableWidth = width - 2 * cssPaddingX;
+    return cssPaddingX + ((b + 0.5) / barSlots) * drawableWidth;
+  };
+
+  it("resolves a click at a bar's visual centre to that bar (#790)", async () => {
+    // The serious symptom: bars 70..139 resolved one low (bar 100 -> 99).
+    // A click at the drawn centre of bar 100 must return 100 at every width.
+    for (const width of [200, 800, 1400]) {
+      expect((await clickAt(barCentreX(100, width), 175, width, 400)).bar).toBe(
+        100
+      );
+    }
+  });
+
+  it("reaches the final bar by clicking inside its drawn body (#790)", async () => {
+    // Bar 139 was reachable only at a single edge pixel. A click at its drawn
+    // centre must return 139, not 138.
+    for (const width of [200, 800, 1400]) {
+      expect((await clickAt(barCentreX(139, width), 175, width, 400)).bar).toBe(
+        139
+      );
+    }
+  });
+
+  it("round-trips every bar centre through the hit-test (#790)", async () => {
+    // The property that makes the count-vs-index class unwritable:
+    // xToBar(centreOf(b)) === b for every drawn bar.
+    const last = canvas!.lilyData!.barCount;
+    for (let b = 0; b <= last; b++) {
+      expect((await clickAt(barCentreX(b, 1400), 175, 1400, 400)).bar).toBe(b);
+    }
+  });
+
+  it("draws the playhead inside the final bar, only within the piece (#790)", () => {
+    // #drawBarHighlight treated the whole of bar 139 (139 < bar < 140) as past
+    // the end and drew no playhead. The playhead's top vertex is the only moveTo
+    // issued at y === canvasPadding (every other draw moveTo sits at a part-row
+    // centre), so its x there is the playhead x. Returns that x, or null when
+    // no playhead is drawn.
+    const playheadX = (bar: number): number | null => {
+      const ctx = canvas!.canvas!.getContext("2d")!;
+      const tops: number[] = [];
+      const spy = vi.spyOn(ctx, "moveTo").mockImplementation((x, y) => {
+        if (Math.abs(y - canvas!.canvasPadding) < 1e-6) tops.push(x);
+      });
+      try {
+        canvas!.bar = bar;
+        canvas!.draw();
+      } finally {
+        spy.mockRestore();
+      }
+      return tops.length ? tops[0] : null;
+    };
+    // Inside the final bar the playhead is drawn, at the forward-map x for that
+    // bar. Pinning x to canvasPadding + (bar + 0.5) * barWidth ties the drawn
+    // playhead to the same slot geometry the hit-test inverts, so a barWidth
+    // regression cannot pass while the (inverse-only) round-trip test stays green.
+    const x = playheadX(139.5);
+    expect(x).not.toBeNull();
+    expect(x!).toBeCloseTo(
+      canvas!.canvasPadding + (139.5 + 0.5) * canvas!.barWidth,
+      6
+    );
+    // Both edges of the `>= #barSlots` guard: no playhead on the intro bar
+    // (bar <= 0) or past the end (bar 140.5 >= #barSlots = 140). Without these a
+    // guard widened to always-draw, or to `> #barSlots`, would stay green.
+    expect(playheadX(0)).toBeNull();
+    expect(playheadX(140.5)).toBeNull();
+  });
+
+  it("keeps normal row colouring inside the final bar (#790)", () => {
+    // #drawVoiceParts treated bar > barCount as the bar-0 "ready" state, so the
+    // whole of bar 139 brightened every row. An unselected row inside bar 139.5
+    // must take the same dull colour it takes at an ordinary mid-piece bar, and
+    // a different colour from the bar-0 ready state. Seed a single unselected
+    // cell so exactly one voice-part stroke is issued; identify it by its
+    // 0.9*partHeight line width (distinct from the highlight strokes).
+    setRanges(canvas!, (r) => {
+      for (let c = 0; c < config.choirs[0].length; c++)
+        for (let p = 0; p < config.parts.length; p++) r.set(`${c}-${p}`, []);
+      r.set("0-0", [{ from: 10, to: 20 }]);
+    });
+    const voicePartStroke = (bar: number): string => {
+      const ctx = canvas!.canvas!.getContext("2d")!;
+      const recs: { style: string; lineWidth: number }[] = [];
+      const spy = vi.spyOn(ctx, "stroke").mockImplementation(() => {
+        recs.push({ style: String(ctx.strokeStyle), lineWidth: ctx.lineWidth });
+      });
+      try {
+        canvas!.choir = 7; // cell 0-0 is unselected
+        canvas!.voicePart = 4;
+        canvas!.bar = bar;
+        canvas!.draw();
+      } finally {
+        spy.mockRestore();
+      }
+      const vp = recs.filter(
+        (rec) => Math.abs(rec.lineWidth - 0.9 * canvas!.partHeight) < 1e-6
+      );
+      expect(vp.length).toBe(1);
+      return vp[0].style;
+    };
+    const ready = voicePartStroke(0);
+    const dull = voicePartStroke(50);
+    const finalBar = voicePartStroke(139.5);
+    expect(finalBar).toBe(dull);
+    expect(finalBar).not.toBe(ready);
+  });
+
+  it("selects Bass, not Soprano, at the bottom edge of the canvas (#791)", async () => {
+    // Folded from #791: the choir index is clamped but the part came from the
+    // unclamped row fraction, which is exactly nChoirs at the bottom edge, so
+    // part reset to 0 (Soprano) instead of 4 (Bass). At the very bottom the
+    // part must be the last part of the last choir.
+    // Heights 200 and 400 are deliberate: their Y-clamp yields rowFraction
+    // exactly 8.0 (the integer boundary where the old `% 1` collapsed to 0);
+    // 150 gives the non-integer neighbour (~7.99). Do not "tidy" these to round
+    // numbers, or the test retreats off the boundary it exists to pin.
+    for (const height of [150, 200, 400]) {
+      const pos = await clickAt(700, height - 1, 1400, height);
+      expect(pos.choir).toBe(7);
+      expect(pos.part).toBe(4);
+    }
   });
 });

--- a/packages/pwa/src/ts/MusicCanvas.ts
+++ b/packages/pwa/src/ts/MusicCanvas.ts
@@ -215,10 +215,15 @@ export class MusicCanvas extends MusicElement {
     this.append(canvas);
     this.#attachListeners(canvas);
 
+    // lilyData FIRST: #calculateCanvasSize derives barWidth from #barSlots, so
+    // the forward map must be built from the real barCount, not a fallback. This
+    // ordering is what lets #barSlots drop its `?? 139` literal, and with it the
+    // whole class of defect #790 was: a forward map and an inverse map that can
+    // silently divide by different slot counts.
+    this.lilyData = precomputedLilyData;
+
     this.#calculateCanvasSize();
     this.#showLoadingOnCanvas();
-
-    this.lilyData = precomputedLilyData;
 
     // define array pulses[choir][part] to be min transparency which
     // will be pulsed when the choir is singing a note.
@@ -263,18 +268,25 @@ export class MusicCanvas extends MusicElement {
 
   // The number of bar slots the overview is drawn in: bar 0 is the intro slot
   // and bars 1..barCount follow, so the count is `barCount + 1` (140 for the
-  // shipped corpus, whose last bar index `barCount` is 139). The inverse map
-  // (hit-test) and the end-of-piece guards read this live value; the forward
-  // map's `barWidth` is computed once at init (#calculateCanvasSize), before
-  // `lilyData` loads, via the `?? 139` fallback. Both directions therefore
-  // divide by the same slot count, so a click at a bar's drawn centre inverts
-  // back to that bar; dividing by `barCount` in one direction only was the #790
-  // count-vs-index defect. The `?? 139` literal is the corpus's last-bar index:
-  // it makes the init-time `barWidth` match the loaded `barCount + 1` for this
-  // fixed-length score. A variable bar count would need `barWidth` recomputed
-  // after load (tracked as tech debt in refactor-MusicCanvas.ts.md).
+  // shipped corpus, whose last bar index `barCount` is 139).
+  //
+  // THE SINGLE SOURCE OF THE SLOT COUNT. Both directions must divide by it: the
+  // forward map (`barWidth`, in #calculateCanvasSize) and the inverse map (the
+  // hit-test in #projectToPosition), plus the end-of-piece guards. Dividing by
+  // `barCount` in one direction only WAS #790, and every click from bar 70 up
+  // resolved one bar low.
+  //
+  // There is deliberately no `?? fallback` here. An earlier shape read
+  // `(this.lilyData?.barCount ?? 139) + 1`, because #calculateCanvasSize ran
+  // before lilyData was assigned. That made the literal the SOLE production path
+  // for barWidth, so editing it to 140 (which reads correct, given this getter's
+  // name and units) would silently rebuild the forward map on 141 slots while the
+  // hit-test kept using 140: #790, restored, and no test could see it. #init now
+  // assigns lilyData first, so the real barCount is always available and the
+  // literal is gone. Keep it that way: a fallback here is a second source of
+  // truth for the one number that must have exactly one.
   get #barSlots(): number {
-    return (this.lilyData?.barCount ?? 139) + 1;
+    return this.lilyData!.barCount + 1;
   }
 
   #calculateCanvasSize() {
@@ -457,11 +469,22 @@ export class MusicCanvas extends MusicElement {
   }
 
   #drawBarHighlight(ctx: CanvasRenderingContext2D) {
-    // `>= #barSlots` (140), not `> barCount` (139): the final bar's fractional
-    // interior (139 < bar < 140) is inside the piece, so the playhead is drawn
-    // there rather than being suppressed as past-the-end (#790, symptom 2).
-    // (bar == 139.0 was never suppressed, even before the fix.) bar <= 0 still
-    // hides the playhead on the intro bar (deliberate, #419).
+    // `>= #barSlots` (140), not `> barCount` (139), for symmetry with the slot
+    // model: the guard is expressed in slots, like every other bar comparison
+    // here.
+    //
+    // BE HONEST ABOUT WHAT THIS DOES NOT FIX. The two forms differ only on
+    // bar values strictly between 139 and 140, and NO REACHABLE STATE puts bar
+    // there: getBarFromTime clamps to 139 for both recordings, and MusicControls
+    // clamps on load. So this is behaviour-identical on every input the app can
+    // produce. Bar 139 itself was never suppressed even before the fix (139 > 139
+    // is false). #790's second reported symptom ("the whole of bar 139 reads as
+    // past the end") is NOT supported by the code, and the tests that exercise
+    // 139.5 do so by assigning `bar` directly, bypassing both clamps. They are
+    // defensive pins on an unreachable state, not regression tests for a
+    // user-visible bug.
+    //
+    // bar <= 0 still hides the playhead on the intro bar (deliberate, #419).
     if (this.bar <= 0 || this.bar >= this.#barSlots) return;
     ctx.save();
     ctx.beginPath();

--- a/packages/pwa/src/ts/MusicCanvas.ts
+++ b/packages/pwa/src/ts/MusicCanvas.ts
@@ -261,6 +261,22 @@ export class MusicCanvas extends MusicElement {
     });
   }
 
+  // The number of bar slots the overview is drawn in: bar 0 is the intro slot
+  // and bars 1..barCount follow, so the count is `barCount + 1` (140 for the
+  // shipped corpus, whose last bar index `barCount` is 139). The inverse map
+  // (hit-test) and the end-of-piece guards read this live value; the forward
+  // map's `barWidth` is computed once at init (#calculateCanvasSize), before
+  // `lilyData` loads, via the `?? 139` fallback. Both directions therefore
+  // divide by the same slot count, so a click at a bar's drawn centre inverts
+  // back to that bar; dividing by `barCount` in one direction only was the #790
+  // count-vs-index defect. The `?? 139` literal is the corpus's last-bar index:
+  // it makes the init-time `barWidth` match the loaded `barCount + 1` for this
+  // fixed-length score. A variable bar count would need `barWidth` recomputed
+  // after load (tracked as tech debt in refactor-MusicCanvas.ts.md).
+  get #barSlots(): number {
+    return (this.lilyData?.barCount ?? 139) + 1;
+  }
+
   #calculateCanvasSize() {
     if (this.canvas == null) return;
 
@@ -270,7 +286,8 @@ export class MusicCanvas extends MusicElement {
     this.canvas.style.width = "100%";
     this.canvas.style.height = "100%";
 
-    this.barWidth = (this.canvas.width - 2 * this.canvasPadding) / 140;
+    this.barWidth =
+      (this.canvas.width - 2 * this.canvasPadding) / this.#barSlots;
     this.choirHeight =
       (this.canvas.height - 2 * this.canvasPadding) / config.choirs[0].length;
     this.partHeight = this.choirHeight / config.parts.length;
@@ -440,7 +457,12 @@ export class MusicCanvas extends MusicElement {
   }
 
   #drawBarHighlight(ctx: CanvasRenderingContext2D) {
-    if (this.bar <= 0 || this.bar > this.lilyData!.barCount) return;
+    // `>= #barSlots` (140), not `> barCount` (139): the final bar's fractional
+    // interior (139 < bar < 140) is inside the piece, so the playhead is drawn
+    // there rather than being suppressed as past-the-end (#790, symptom 2).
+    // (bar == 139.0 was never suppressed, even before the fix.) bar <= 0 still
+    // hides the playhead on the intro bar (deliberate, #419).
+    if (this.bar <= 0 || this.bar >= this.#barSlots) return;
     ctx.save();
     ctx.beginPath();
     ctx.moveTo(
@@ -480,7 +502,7 @@ export class MusicCanvas extends MusicElement {
       startY + this.partHeight / 2
     );
     ctx.lineTo(
-      this.canvasPadding + 140 * this.barWidth - this.barWidth,
+      this.canvasPadding + this.#barSlots * this.barWidth - this.barWidth,
       startY + this.partHeight / 2
     );
     ctx.lineWidth = width;
@@ -495,7 +517,7 @@ export class MusicCanvas extends MusicElement {
       ? MusicCanvas.DULL_BASE_LIGHTNESS_LIGHT
       : MusicCanvas.DULL_BASE_LIGHTNESS_DARK;
 
-    const { ranges, barCount } = this.lilyData!;
+    const { ranges } = this.lilyData!;
     ctx.lineWidth = 0.9 * this.partHeight;
     ctx.lineCap = "round";
     for (var c = 0; c < config.choirs[0].length; c++) {
@@ -529,7 +551,7 @@ export class MusicCanvas extends MusicElement {
             saturation = 80;
             lightness = MusicCanvas.SELECTED_BASE_LIGHTNESS - 3 * p;
             transparency = 1;
-          } else if (this.bar === 0 || this.bar > barCount) {
+          } else if (this.bar === 0 || this.bar >= this.#barSlots) {
             saturation = 50;
             lightness = MusicCanvas.SELECTED_BASE_LIGHTNESS - 3 * p;
             transparency = 1;
@@ -696,7 +718,11 @@ export class MusicCanvas extends MusicElement {
   #projectToPosition(
     x: number,
     y: number,
-    partResolver: (rowFraction: number) => PartType
+    // rowOffset is the pointer's offset within the resolved (clamped) choir, in
+    // [0, 1] and exactly 1 at the very bottom edge. A numeric resolver must
+    // clamp its top part (see #getMousePos) so the last part is not overrun;
+    // do not reconstruct it as a full row fraction and `% 1` (that was #791).
+    partResolver: (rowOffset: number) => PartType
   ): Position {
     const rect = this.getBoundingClientRect();
     const cssPaddingX = this.canvasPadding * (rect.width / this.canvas!.width);
@@ -721,21 +747,36 @@ export class MusicCanvas extends MusicElement {
     );
     const rowFraction =
       ((clampedY - cssPaddingY) * config.choirs[0].length) / drawableHeight;
+    const choir = Math.min(
+      config.choirs[0].length - 1,
+      Math.max(0, Math.floor(rowFraction))
+    );
     return {
-      choir: Math.min(
-        config.choirs[0].length - 1,
-        Math.max(0, Math.floor(rowFraction))
-      ),
-      part: partResolver(rowFraction),
-      bar: Math.floor(
-        ((clampedX - cssPaddingX) * this.lilyData!.barCount) / drawableWidth
+      choir,
+      // Resolve the part from the offset within the *clamped* choir. At the
+      // bottom edge rowFraction is exactly nChoirs, so `rowFraction % 1` reset
+      // the part to 0 (Soprano); `rowFraction - choir` keeps it at the last
+      // part (Bass) there. This is the #791 fix, folded into #790.
+      part: partResolver(rowFraction - choir),
+      // Invert the forward map through #barSlots (140), not barCount (139), so
+      // a click at a bar's drawn centre returns that bar; clamp the last slot
+      // down to the final bar index so the right edge cannot overshoot. #790.
+      bar: Math.min(
+        this.lilyData!.barCount,
+        Math.floor(((clampedX - cssPaddingX) * this.#barSlots) / drawableWidth)
       ),
     };
   }
 
   #getMousePos(e: MouseEvent): Position {
-    return this.#projectToPosition(e.offsetX, e.offsetY, (rowFraction) =>
-      Math.floor((rowFraction % 1) * config.parts.length)
+    // partResolver receives the offset within the clamped choir (0..1, exactly
+    // 1 at the very bottom edge). Clamp to the last part so that bottom edge
+    // resolves to Bass rather than overflowing (#791).
+    return this.#projectToPosition(e.offsetX, e.offsetY, (rowOffset) =>
+      Math.min(
+        config.parts.length - 1,
+        Math.floor(rowOffset * config.parts.length)
+      )
     );
   }
 


### PR DESCRIPTION
Fixes a hit-test off-by-one in the canvas overview: clicks and hovers across the right half of the overview resolved one bar too low, because the inverse map divided by the literal `140` while the forward map multiplied by `barCount` (139). The two maps now share one slot count, and the forward map is pinned by tests.

## What changed

- `MusicCanvas.ts`: the hit-test inverts through the same bar-slot count the drawing code uses, replacing the hard-coded `140`.
- `canvas.test.ts`: red-first regression tests pinning the forward map and the inverse round-trip at both edges of the bar range.

## Tests

- New regression tests fail on the old code and pass on the fix.
- Full suite green locally: 358 tests, plus the complete check gate (lint, types, format, dependency cruise).

## Note on the version line

This PR bumps the app version to 2.8.16. Open PR #834 bumps the same line to 2.8.15, so whichever of the two merges second will need its usual rebase; the version line is the only file the two share.

Fixes #790
