### PR TITLE
refactor: remove dead monitor export paceBucket (#749)

### DIFF
--- a/packages/monitor/monitor-resources.mjs
+++ b/packages/monitor/monitor-resources.mjs
@@ -106,20 +106,6 @@ export function statusFromCurve(actualRemaining, t) {
 }
 
 /**
- * Classify a projected end-of-period percentage against the critical-pace
- * diagonal (100% at period-end). Distinct from the rate-relative status curve
- * and the watch/critical budget thresholds.
- *
- * @param {number} projectedPct - Projected end-of-period usage percentage.
- * @returns {"green"|"yellow"|"red"}
- */
-export function paceBucket(projectedPct) {
-  if (projectedPct > 100) return "red";
-  if (projectedPct >= 90) return "yellow";
-  return "green";
-}
-
-/**
  * @typedef {object} UsageRecord
  * @property {number} current - Consumed build minutes so far this period.
  * @property {number} limit - Build-minute quota for the period.

--- a/packages/monitor/monitor-resources.test.mjs
+++ b/packages/monitor/monitor-resources.test.mjs
@@ -16,7 +16,6 @@ import {
   getReportingSince,
   parseRepo,
   todayISO,
-  paceBucket,
   overallStatusName,
   loadSeries,
   saveSeries,
@@ -485,22 +484,6 @@ test("parseRepo throws when GITHUB_REPOSITORY is empty string", () => {
 // todayISO: returns UTC calendar date
 test("todayISO returns YYYY-MM-DD from a UTC timestamp", () => {
   assert.equal(todayISO(new Date("2026-06-12T14:23:00Z")), "2026-06-12");
-});
-
-// paceBucket: classify projected end-of-period percentage against critical pace
-test("paceBucket returns green when well under critical pace", () => {
-  assert.equal(paceBucket(0), "green");
-  assert.equal(paceBucket(89), "green");
-});
-
-test("paceBucket returns yellow at or near critical pace", () => {
-  assert.equal(paceBucket(90), "yellow");
-  assert.equal(paceBucket(100), "yellow");
-});
-
-test("paceBucket returns red when over critical pace", () => {
-  assert.equal(paceBucket(101), "red");
-  assert.equal(paceBucket(150), "red");
 });
 
  // overallStatusName: worse of two service statuses wins


### PR DESCRIPTION
Removes the dead `paceBucket` export from the monitor package: nothing imports it, and it survived an earlier refactor as unused surface. Pure deletion, no behaviour change.

## Tests

- Full local suite green (363 tests) plus the complete check gate (knip confirms no unused-export complaints remain), on a branch rebased onto current main this evening.
- Monitor-only change, so no version bump is owed.

Fixes #749
