### PR TITLE
fix: stop third-party hosts dead-locking render and interactivity (#799)

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -141,7 +141,7 @@ case injects one error class and polls the capture array, and a final
 `test.fail()`-annotated case pins that a non-empty capture fails at teardown.
 If a spec legitimately produces a captured message, add a narrow, commented entry
 to the module's `ALLOWLIST` rather than reverting the import. The current entries
-cover third-party script hosts that are absent or DNS-blocked in test
+cover the one third-party script host that is absent or DNS-blocked in test
 environments, and the feedback submit handler's `console.error` on a failed send
 (#798), which is an expected byproduct of the failure path
 `e2e/feedback-modal.spec.ts` drives; that log is asserted in
@@ -202,6 +202,45 @@ that channel; drop a channel only when you can say that of it.
 The fixture's *routes* (the Cloudflare beacon stub) are registered on the context,
 not the page, so another page in the same context does still inherit those; only
 the listeners are lost.
+
+### Simulate a slow host by stalling the route
+
+A third technique, and it tests a different failure from the two above: a host
+that is **slow**, not one that is **absent**. `e2e/third-party-stall.spec.ts`
+(#799) accepts the route and then never answers it:
+
+```ts
+await page.route(
+  (url) => url.hostname === "googletagmanager.com" ||
+    url.hostname.endsWith(".googletagmanager.com"),
+  () => new Promise(() => {})
+);
+```
+
+Match on the parsed **hostname**, never a substring of the whole URL: a regex
+like `/googletagmanager\.com/` also matches a same-origin URL that carries the
+host in a query string, and an over-broad match stalls the app's own origin, so
+every test hangs or passes vacuously. `matchesHost()` in
+`e2e/third-party-stall.spec.ts` is the reference predicate.
+
+The distinction is the whole point. An absent host fails fast, the parser
+resumes, and the app looks healthy, which is why a render-and-interactivity
+dead-lock survived across `index.html` and `index.ts` until a stall reproduced
+it. Two rules follow for any spec that stalls a host:
+
+- **Navigate with `waitUntil: "commit"`.** Playwright's default waits for the
+  window `load` event, and a stalled subresource is precisely what that event
+  waits on, so the navigation would hang rather than test anything.
+  `"domcontentloaded"` is no better: a stalled stylesheet blocks the deferred
+  module scripts, so DOMContentLoaded never fires either, and a regression that
+  reintroduced a parser-blocking script would hang the navigation instead of
+  failing an assertion.
+
+- **Register the stall inside the test, on the page.** Page routes are consulted
+  before context routes, so a `page.route` registered in the test takes
+  precedence over the Cloudflare stub `packages/pwa/e2e/helpers/page-errors.ts`
+  installs on the **context** (within one scope, the last-registered route is
+  the tie-break).
 
 ### E2E Prerequisites
 

--- a/packages/pwa/e2e/helpers/page-errors.ts
+++ b/packages/pwa/e2e/helpers/page-errors.ts
@@ -48,14 +48,17 @@ import { test as base, expect } from "@playwright/test";
 // Keep each entry commented with the reason, and narrow enough that only the
 // expected message can match it (a URL, or a prefix only one call site emits).
 const ALLOWLIST: string[] = [
-  // Third-party scripts loaded by index.html are routinely absent or
-  // DNS-blocked in test environments (net::ERR_NAME_NOT_RESOLVED); their
-  // load failure is environmental, not an app defect. Matched on the URL
-  // suffix this fixture appends, so the entries are browser-agnostic.
+  // The third-party script loaded by index.html is routinely absent or DNS-blocked
+  // in test environments (net::ERR_NAME_NOT_RESOLVED); its load failure is
+  // environmental, not an app defect. Matched on the URL suffix this fixture
+  // appends, so the entry is browser-agnostic.
   // Cloudflare Web Analytics is not listed here: it is intercepted and
   // stubbed below (#822) so its beacon never reaches the network at all.
+  // cdnjs.buymeacoffee.com is not listed here either, and must not be re-added: #799
+  // removed the donation vendor's script from the page, so nothing legitimately
+  // produces an error from that host. An entry for it would be a standing suppression
+  // for exactly the regression e2e/third-party-stall.spec.ts exists to catch.
   "at https://www.googletagmanager.com/",
-  "at https://cdnjs.buymeacoffee.com/",
   // The feedback-modal failure specs reject the POST by stubbing window.fetch in
   // the page (never route.abort(), which would make the browser log its own
   // resource error; see doc/TESTING.md). The submit handler then logs the cause

--- a/packages/pwa/e2e/third-party-stall.spec.ts
+++ b/packages/pwa/e2e/third-party-stall.spec.ts
@@ -1,0 +1,563 @@
+import { test, expect } from "./helpers/page-errors";
+import type { Page } from "@playwright/test";
+
+// WCAG AA for normal text. The label is 28px, but its wrapper scales it to 0.75, so
+// it renders at 21px (0.65 at narrow widths, ~18px, which only lowers it further) and
+// does not clear WCAG's 24px large-text threshold. 4.5 is the level that actually
+// applies, not a strict reading of a laxer one. The real ratio for #ffffff on #133354
+// is about 12.9:1, so there is ample headroom either way.
+const MIN_CONTRAST = 4.5;
+
+/**
+ * The real WCAG 2.x contrast ratio between an element's text colour and the first
+ * opaque background behind it.
+ *
+ * Deliberately NOT `assertReadableInMode` from ./helpers/computed-style: despite its
+ * name, that helper only asserts the two colours are not the *same string*, so text
+ * at rgb(18,51,84) on a rgb(19,51,84) background passes it with a real contrast ratio
+ * of 1.0012:1. That is exactly the bug this test exists to catch, and the helper waved
+ * it through. Tracked as #840, which will move this computation into the helper and
+ * have this spec import it back. Until then, do not "simplify" this into it.
+ *
+ * Two things it refuses to guess at, because guessing is how the first version of this
+ * function became the very false-green it was written to remove:
+ *
+ * - A colour it cannot parse. It reads legacy `rgb()`/`rgba()` only, which is what
+ *   browsers serialise computed colours as today. A modern colour function
+ *   (`oklch()`, `color(display-p3 ...)`) would have its numbers scraped out and
+ *   ranked as nonsense, so it throws instead.
+ * - A see-through background. Text usually has none of its own, so a naive read
+ *   returns `rgba(0, 0, 0, 0)`, whose first three numbers are *black*. White text
+ *   would then measure a perfect 21:1 against a background it does not have. So the
+ *   background is composited up the ancestor chain to the first opaque one, which is
+ *   also what a human eye does.
+ */
+async function contrastRatio(page: Page, selector: string): Promise<number> {
+  return page
+    .locator(selector)
+    .first()
+    .evaluate((el) => {
+      type Rgba = { r: number; g: number; b: number; a: number };
+
+      const parse = (colour: string): Rgba => {
+        const m = colour
+          .trim()
+          .match(
+            /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:\s*[,/]\s*([\d.]+))?\s*\)$/
+          );
+        if (!m) {
+          throw new Error(
+            `contrastRatio reads only rgb()/rgba(), and got "${colour}". A modern ` +
+              `colour function would be parsed as nonsense, so this refuses rather ` +
+              `than return a number it cannot justify.`
+          );
+        }
+        return {
+          r: Number(m[1]),
+          g: Number(m[2]),
+          b: Number(m[3]),
+          a: m[4] === undefined ? 1 : Number(m[4]),
+        };
+      };
+
+      // The first ancestor (self included) that actually paints something behind the
+      // text. An element with no background of its own is see-through, not black.
+      const backgroundBehind = (start: Element): Rgba => {
+        let node: Element | null = start;
+        while (node) {
+          const colour = parse(getComputedStyle(node).backgroundColor);
+          if (colour.a === 1) return colour;
+          if (colour.a !== 0) {
+            throw new Error(
+              `a partly transparent background (${getComputedStyle(node).backgroundColor}) ` +
+                `sits behind this text; the true ratio depends on what shows through, ` +
+                `which this does not model.`
+            );
+          }
+          node = node.parentElement;
+        }
+        throw new Error(
+          "no opaque background anywhere behind this text, so its contrast is undefined"
+        );
+      };
+
+      const luminance = ({ r, g, b }: Rgba): number => {
+        const [lr, lg, lb] = [r, g, b].map((v) => {
+          const channel = v / 255;
+          return channel <= 0.03928
+            ? channel / 12.92
+            : ((channel + 0.055) / 1.055) ** 2.4;
+        });
+        return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+      };
+
+      const text = parse(getComputedStyle(el).color);
+      if (text.a !== 1) {
+        throw new Error(
+          `the text colour is not opaque (${getComputedStyle(el).color}), so its ` +
+            `effective contrast depends on the backdrop, which this does not model.`
+        );
+      }
+
+      const fg = luminance(text);
+      const bg = luminance(backgroundBehind(el));
+      const [lighter, darker] = fg > bg ? [fg, bg] : [bg, fg];
+      return (lighter + 0.05) / (darker + 0.05);
+    });
+}
+
+/**
+ * #799 — the app's render and interactivity must not depend on third-party hosts.
+ *
+ * Two mechanisms coupled the app to strangers. A parser-blocking classic script
+ * (the donation embed) halted document construction, so the player elements never
+ * existed. And `init()` hung off `window load`, which waits for every subresource,
+ * so a painted page could still drop every click, key and deep link.
+ *
+ * Neither is reachable by an ordinary e2e run, which is why they survived so long:
+ * in CI these hosts fail *fast* (DNS-blocked) or are stubbed, and a fast failure
+ * lets parsing resume, so the app looks healthy. Only a *stall*, someone else's
+ * server accepting the connection and then saying nothing, exposes it. The
+ * generated tests below therefore hold the host's route open and never answer.
+ * (The three hand-written tests at the end do not stall: they pin the donation
+ * button, the absence of any parser-blocking classic script, and the
+ * completeness of the host list.)
+ *
+ * `waitUntil: "commit"` is load-bearing IN THE STALL TESTS. Playwright's default
+ * (`"load"`) waits for the window load event, which is the very thing this ticket is
+ * about, so the navigation would hang rather than test anything.
+ * `"domcontentloaded"` is no better: a stalled stylesheet blocks the deferred module
+ * scripts, so DOMContentLoaded never fires either, and a regression that
+ * reintroduced a parser-blocking script would hang the navigation instead of failing
+ * an assertion. `"commit"` assumes no lifecycle event at all, which is exactly the
+ * assumption under test. The hand-written tests stall nothing, so they navigate
+ * normally and wait for the app, which is what lets them read computed styles and
+ * press keys safely.
+ */
+
+/** A tracked, still-open defect: the ticket AND why this host in particular fails. */
+type KnownFailure = {
+  readonly ticket: number;
+  /** Why THIS host's stall is not fixed. Never assume one host's reason fits another. */
+  readonly why: string;
+};
+
+type ThirdPartyHost = {
+  /**
+   * The hostname. Also the test title, deliberately: a separate display name could
+   * disagree with the host it claims to describe, and a test titled for one host
+   * while stalling another is the confidently-mislabelled failure this file exists
+   * to stamp out.
+   */
+  readonly host: string;
+  /**
+   * Set when this host's stall is a known, still-open failure. Its tests run as
+   * `fixme`: declared, not deleted, so the suite states what it does not cover.
+   */
+  readonly knownFailure?: KnownFailure;
+};
+
+// The third-party hosts index.html references directly. The completeness of this
+// list is itself tested, at the bottom of this file, because a spec that silently
+// under-covers is worse than one that admits a gap.
+const THIRD_PARTY_HOSTS: readonly ThirdPartyHost[] = [
+  {
+    host: "fonts.googleapis.com",
+    knownFailure: {
+      ticket: 839,
+      why:
+        "it is a STYLESHEET, not a script. A stylesheet that is still loading blocks " +
+        "PAINT, and the deferred-script queue waits on it too, so the app's module " +
+        "never executes and init() cannot run wherever it is put. That much no change " +
+        "to script loading can reach. On top of it, and contingently, the parser also " +
+        "halts at the first inline script BELOW the pending stylesheet (the gtag " +
+        "config block, which sits ahead of every player element; the FOUC-fallback " +
+        "script sits above the @import and runs before it can block), so the elements " +
+        "are never even built; move that block and this leg goes away while the other " +
+        "two remain. #839 makes the font stylesheet non-blocking. Delete this " +
+        "knownFailure when it lands (src/test/third-party-markup.test.ts's premise " +
+        "pin goes red to remind you), and these three cases become its regression " +
+        "guard",
+    },
+  },
+  { host: "googletagmanager.com" },
+  { host: "cloudflareinsights.com" },
+  // cdnjs.buymeacoffee.com is deliberately NOT here. #799 removed the donation
+  // vendor's script from the page, so stalling that host would prove nothing: the
+  // page never calls it. Its absence is guarded directly, and twice, by the tests at
+  // the bottom of this file. Re-adding the vendor script fails both.
+  //
+  // fonts.gstatic.com is not here either, and that IS a gap worth naming. The font
+  // FILES come from it, referenced from inside the fonts.googleapis.com stylesheet
+  // rather than from our HTML, so the completeness check below (which reads the
+  // served markup) structurally cannot see it. A stalled font file blocks neither
+  // script execution nor paint, because the @import carries display=swap, so it is
+  // not a #799 deadlock. It belongs to #839's territory.
+];
+
+/**
+ * Does this URL belong to the host? Matched on the parsed HOSTNAME, not as a
+ * substring of the whole URL, and used by both the router and the completeness check
+ * so the two cannot disagree about what "this host" means.
+ *
+ * An empty or over-broad entry would otherwise stall the app's own origin, and every
+ * test in this file would hang or pass vacuously. `""` is refused explicitly: WHATWG
+ * URL preserves a trailing dot in a hostname, so `endsWith(".")` alone would let an
+ * empty entry match one (and an empty entry also trips the completeness check below).
+ */
+function matchesHost(hostname: string, host: ThirdPartyHost): boolean {
+  return (
+    host.host !== "" &&
+    (hostname === host.host || hostname.endsWith(`.${host.host}`))
+  );
+}
+
+/**
+ * Mark a host's tests `fixme` while its stall is a known open defect. The reason
+ * travels with the ticket, so a second known-failing host cannot inherit the first
+ * one's explanation.
+ */
+function fixmeIfKnownFailure(host: ThirdPartyHost): void {
+  const known = host.knownFailure;
+  if (!known) return;
+  test.fixme(true, `known failure, tracked as #${known.ticket}: ${known.why}`);
+}
+
+/**
+ * Hold every request to this host open forever: accept the route and never fulfil,
+ * continue, or abort it. This reproduces a slow host, which is the failure this
+ * ticket is about, rather than an unreachable one, which the app already survives.
+ *
+ * Registered inside the test on the PAGE, so it takes precedence over the Cloudflare
+ * stub the page-errors fixture installs on the CONTEXT: page routes are consulted
+ * before context routes, whatever the registration order (within one scope, the
+ * last-registered route wins). That coupling is worth knowing: if a
+ * pending stalled request ever starts producing a console error, the fixture will
+ * fail the test at teardown for an environmental reason.
+ */
+async function stall(page: Page, host: ThirdPartyHost): Promise<void> {
+  await page.route(
+    (url) => matchesHost(url.hostname, host),
+    () => new Promise(() => {})
+  );
+}
+
+test.describe("third-party script stalls do not gate render or interactivity (#799)", () => {
+  for (const host of THIRD_PARTY_HOSTS) {
+    // Grouped per host, with the fixme in a beforeEach rather than repeated in each
+    // test. A fourth test added to this group would otherwise inherit the stall but
+    // not the fixme, and on a known-failing host it would HANG rather than fail.
+    test.describe(host.host, () => {
+      test.beforeEach(() => fixmeIfKnownFailure(host));
+
+      test(`player renders while ${host.host} is stalled`, async ({ page }) => {
+        await stall(page, host);
+
+        await page.goto("/", { waitUntil: "commit" });
+
+        // The DOM is constructed: a parser-blocking third-party script would have
+        // halted document construction before these elements existed. On their own
+        // these three assert only that the static markup parsed, which needs no
+        // JavaScript at all, so they cannot be the whole test.
+        await expect(page.locator("music-score")).toBeAttached();
+        await expect(page.locator("music-canvas")).toBeAttached();
+        await expect(page.locator("music-controls")).toBeAttached();
+
+        // The elements were also UPGRADED, which means the app's module executed.
+        // `:defined` is the honest probe. Do not swap it for toBeVisible(): an
+        // un-upgraded <music-controls> is empty and `display: flex` with no
+        // min-height, so it happens to have a zero-size box today and reads as
+        // invisible. Give it a min-height in the stylesheet, as its two siblings
+        // already have, and a visibility assertion would go green on a dead page.
+        await expect(page.locator("music-controls:defined")).toBeAttached();
+
+        // And it paints: the app's own stylesheet loaded and lifted the inline
+        // .viewportDiv FOUC guard.
+        await expect(page.locator("music-controls")).toBeVisible();
+      });
+
+      test(`controls respond while ${host.host} is stalled`, async ({
+        page,
+      }) => {
+        await stall(page, host);
+
+        await page.goto("/", { waitUntil: "commit" });
+
+        const controls = page.locator("music-controls");
+        await expect(controls).toBeAttached();
+
+        // This is the line that makes the whole file non-vacuous, so protect it.
+        // <music-controls> carries no attributes in index.html; `choir` is written
+        // only by parseURL() inside init(). So this is a true "init() ran" probe,
+        // not merely an "element upgraded" one. A painted-but-dead page passes every
+        // visibility assertion and fails this, which is the entire defect.
+        await expect(controls).toHaveAttribute("choir", "0");
+        await page.keyboard.press("4");
+        await expect(controls).toHaveAttribute("choir", "3");
+
+        // Click: the header switches are wired by init() too. (The pre-click
+        // assertion is a precondition, not a guard: dark is the default, so a dead
+        // page would pass it too. The post-click one is what bites.)
+        await expect(page.locator("body")).not.toHaveClass(/light-theme/);
+        await page.locator("#darkswitch").click();
+        await expect(page.locator("body")).toHaveClass(/light-theme/);
+      });
+
+      test(`deep-link params apply while ${host.host} is stalled`, async ({
+        page,
+      }) => {
+        await stall(page, host);
+
+        // parseURL() runs inside init(), so a shared deep link paints the wrong
+        // state for as long as the slowest host takes to settle.
+        await page.goto("/?choir=3&part=2&bar=10", { waitUntil: "commit" });
+
+        const controls = page.locator("music-controls");
+        await expect(controls).toHaveAttribute("choir", "3");
+        await expect(controls).toHaveAttribute("part", "2");
+        await expect(controls).toHaveAttribute("bar", "10");
+      });
+    });
+  }
+
+  test("the coffee button is our own markup, and the donation host is never fetched", async ({
+    page,
+  }) => {
+    // The donation button used to come from a vendor script, and that script could
+    // not be made non-blocking: it renders with `document.writeln`, which the browser
+    // discards from any script that is not parser-inserted. So `async` deleted the
+    // button outright, and silently, because the discarded write is a console
+    // *warning* and nothing here records those; `defer` would have done the same.
+    // Parser-blocking was the only mode it worked in, and a parser-blocking script
+    // ahead of the player markup is precisely the defect #799 exists to remove.
+    //
+    // What it rendered was an anchor, a Cookie webfont link, and the CSS to style
+    // them. We now supply all three ourselves (the markup here, the @import in
+    // index.html, and .bmc-btn in style.scss), so the donation host has left the page
+    // entirely. This test pins both halves: the button is really there and really
+    // readable, and nothing is ever fetched from the vendor.
+    const donationRequests: string[] = [];
+    page.on("request", (r) => {
+      if (r.url().includes("buymeacoffee.com")) donationRequests.push(r.url());
+    });
+
+    await page.goto("/");
+
+    // Gate on the app actually running before reading a computed style or pressing a
+    // key. Everything below would otherwise be satisfied by static markup with no CSS
+    // and no JavaScript: the colours would read as an unstyled UA link, and a keypress
+    // would land before init() had bound the keydown listener.
+    await expect(page.locator("music-controls:defined")).toBeAttached();
+    await expect(page.locator("music-controls")).toHaveAttribute("choir", "0");
+
+    // One button per wrapper: the help footer and the feedback modal.
+    const buttons = page.locator(".bmc-wrapper .bmc-btn");
+    await expect(buttons).toHaveCount(2);
+    for (const button of await buttons.all()) {
+      await expect(button).toHaveAttribute(
+        "href",
+        "https://buymeacoffee.com/wainwmr"
+      );
+      // Reverse-tabnabbing guard on a target="_blank" link. Modern browsers imply it,
+      // but the markup is ours now and says so.
+      await expect(button).toHaveAttribute("rel", "noopener");
+    }
+
+    // Visible is not the same as READABLE, and the difference is not academic here:
+    // the first cut of this button drew its label in the help panel's link colour,
+    // which is the same dark blue as the button's own background. It was perfectly
+    // "visible" and utterly unreadable, and only an eyeball caught it.
+    //
+    // BOTH buttons are measured. A container rule (`#help a`) outranks a bare
+    // `.bmc-btn` class rule on specificity, and #feedback-modal is exactly such a
+    // container too, so guarding one and not the other would leave the same bug a
+    // home. And the LABEL is measured, not the anchor: the visible text is painted by
+    // <span class="bmc-btn-text">, so a rule reaching the span would recolour it while
+    // the anchor's own `color` stayed white.
+    const labels = ["#help", "#feedback-modal"].map(
+      (panel) => `${panel} .bmc-btn .bmc-btn-text`
+    );
+
+    for (const label of labels) {
+      expect(
+        await contrastRatio(page, label),
+        `the coffee button's label is unreadable in ${label} (dark theme)`
+      ).toBeGreaterThanOrEqual(MIN_CONTRAST);
+    }
+
+    // And in light mode. The button's own colours are fixed, but the rule that
+    // hijacked them uses --color-on-light, which stays dark in light mode too.
+    await page.keyboard.press("d");
+    await expect(page.locator("body")).toHaveClass(/light-theme/);
+    for (const label of labels) {
+      expect(
+        await contrastRatio(page, label),
+        `the coffee button's label is unreadable in ${label} (light theme)`
+      ).toBeGreaterThanOrEqual(MIN_CONTRAST);
+    }
+    await page.keyboard.press("d");
+    await expect(page.locator("body")).not.toHaveClass(/light-theme/);
+
+    // And it is genuinely visible to a user who opens the help panel, rather than
+    // merely present in a hidden subtree.
+    await page.locator("#info").click();
+    await expect(page.locator("#help .bmc-btn")).toBeVisible();
+
+    // The modal's twin too, and for the same reason: getComputedStyle happily
+    // returns colours inside a display:none subtree, so the contrast loop above
+    // passes on a hidden button. Only an open-and-look catches a collapsed
+    // .bmc-wrapper or a stray display rule scoped to the modal. The open help
+    // panel raised #backdrop over the header, so close it first, as a user
+    // would, by clicking the backdrop.
+    await page.locator("#backdrop").click();
+    await expect(page.locator("#help .bmc-btn")).not.toBeVisible();
+    await page.locator("#feedback-trigger").click();
+    await expect(page.locator("#feedback-modal .bmc-btn")).toBeVisible();
+
+    // Wait for the page to finish loading before ruling on what was requested, so a
+    // late fetch cannot slip in after the last assertion resolved.
+    await page.waitForLoadState("load");
+    expect(
+      donationRequests,
+      "the page must not fetch anything from the donation vendor: the button is our own markup"
+    ).toEqual([]);
+  });
+
+  test("no parser-blocking classic script sits on the page", async ({
+    page,
+  }) => {
+    // The host list guards the hosts we know about. THIS guards the defect class
+    // itself, and it cannot rot: a parser-blocking classic script anywhere halts
+    // document construction, whoever serves it, and an unbuilt player is the worse
+    // half of #799. A same-origin one, or one on a host already in the list, would
+    // walk straight past every other test in this file.
+    //
+    // Module scripts are deferred by definition and so are exempt. The gtag config
+    // block is inline and has no src, so it is not matched here; it IS a real parser
+    // barrier, but only while a stylesheet is pending, which is #839.
+    //
+    // Read from the live DOM, so a script inserted at runtime (async by IDL
+    // default, usually with no attribute) can be flagged on a networked dev run
+    // where gtag.js actually loads and injects. Accepted: the false positive is
+    // loud, CI is DNS-blocked so nothing injects there, and reading the live DOM
+    // keeps the probe honest about everything the parser really saw.
+    await page.goto("/");
+
+    const blocking = await page.$$eval(
+      "script[src]:not([type='module']):not([async]):not([defer])",
+      (scripts) => scripts.map((s) => s.getAttribute("src"))
+    );
+
+    expect(
+      blocking,
+      "a parser-blocking classic script is back on the page, which is the #799 deadlock"
+    ).toEqual([]);
+
+    // The beacon must also still be async, asserted on its attributes directly.
+    // The stall tests above catch a defer revert only while Vite emits the app
+    // bundle BELOW the beacon tag (the index.html comment admits the
+    // contingency); this check does not care where the bundle lands. Twinned
+    // with src/test/third-party-markup.test.ts, which pins the same attribute
+    // in the source at PR time.
+    const beacon = await page.$eval(
+      'script[src*="cloudflareinsights"]',
+      (s) => ({ async: s.hasAttribute("async"), defer: s.hasAttribute("defer") })
+    );
+    expect(
+      beacon,
+      "the Cloudflare beacon must stay async: as defer it rejoins the ordered " +
+        "queue the app's module scripts wait in"
+    ).toEqual({ async: true, defer: false });
+  });
+
+  test("every third-party host NAMED in the served page is covered above", async ({
+    page,
+  }) => {
+    // The value of this file is that it is COMPLETE, and completeness left to a
+    // comment rots the first time someone adds an embed. So the list checks itself
+    // against the page.
+    //
+    // Scope, stated honestly: this reads the hosts NAMED in the served markup. A host
+    // reached transitively (fonts.gstatic.com, referenced from inside the Google Fonts
+    // stylesheet) is invisible to it, which is why that one is called out in
+    // THIRD_PARTY_HOSTS rather than silently missing.
+    await page.goto("/");
+
+    // Wait for the app before scraping. A bare `commit` would resolve while the
+    // document is still only <head>: the inline gtag script is a parser barrier that
+    // waits on the font stylesheet. The body is where the donation embeds lived, so a
+    // scrape taken too early is blind at the exact site of the defect, and it fails
+    // OPEN, because finding fewer tags means finding nothing uncovered.
+    await expect(page.locator("music-controls:defined")).toBeAttached();
+
+    const referenced: string[] = await page.evaluate(() => {
+      const urls = new Set<string>();
+      for (const el of document.querySelectorAll("script[src], link[href]")) {
+        const url = el.getAttribute("src") ?? el.getAttribute("href");
+        if (url) urls.add(url);
+      }
+      // The font @import lives inside an inline <style>, not on an element.
+      for (const style of document.querySelectorAll("style")) {
+        for (const m of (style.textContent ?? "").matchAll(
+          /url\(['"]?([^'")]+)/g
+        )) {
+          urls.add(m[1]);
+        }
+      }
+      return [...urls];
+    });
+
+    // Resolved against the document, so a protocol-relative URL (//unpkg.com/...) is
+    // not silently skipped by an http-only filter. Anything off our own origin is
+    // third-party. A URL that will not parse is NOT silently dropped: a mangled
+    // third-party reference would otherwise vanish from coverage accounting, which
+    // is the blindness this test exists to prevent.
+    const ourHostname = new URL(page.url()).hostname;
+    const unparseable: string[] = [];
+    const externalHosts = [
+      ...new Set(
+        referenced
+          .map((u) => {
+            try {
+              return new URL(u, page.url()).hostname;
+            } catch {
+              unparseable.push(u);
+              return "";
+            }
+          })
+          .filter((h) => h && h !== ourHostname)
+      ),
+    ];
+    expect(
+      unparseable,
+      "a referenced URL could not be parsed, so its host escaped coverage " +
+        "accounting entirely; fix the reference or the scrape"
+    ).toEqual([]);
+
+    const uncovered = externalHosts.filter(
+      (h) => !THIRD_PARTY_HOSTS.some((known) => matchesHost(h, known))
+    );
+    expect(
+      uncovered,
+      "a third-party host is named in the page but is not in THIRD_PARTY_HOSTS, so " +
+        "nothing here proves the app survives its stall. Add it to the list rather " +
+        "than deleting this assertion."
+    ).toEqual([]);
+
+    // And the converse, which is what stops this test passing on an empty read. If the
+    // scrape ever goes blind (a selector change, the @import moving into the compiled
+    // CSS), `uncovered` would be [] and the test would go green while proving nothing.
+    // Requiring every listed host to be FOUND makes that fail loudly. It also catches a
+    // list entry left behind after its host has left the page, which is a test that
+    // stalls nothing and claims coverage.
+    const listedButNotFound = THIRD_PARTY_HOSTS.filter(
+      (known) => !externalHosts.some((h) => matchesHost(h, known))
+    ).map((known) => known.host);
+    expect(
+      listedButNotFound,
+      "a host in THIRD_PARTY_HOSTS was not found in the served page. Either the page " +
+        "stopped using it (remove it: stalling a host the page never calls proves " +
+        "nothing), or this scrape has gone blind (fix the scrape)."
+    ).toEqual([]);
+  });
+});

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -204,17 +204,29 @@
         })();
     </script>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400..900;1,400..900&family=Quintessential&display=swap&family=EB+Garamond&display=swap&family=Macondo&display=swap&family=Eagle+Lake&display=swap&family=Macondo+Swash+Caps&display=swap');
+        /* Cookie is the coffee button's face (#799). It rides on the request already
+           being made here rather than the separate fonts.googleapis.com <link> the
+           vendor script used to inject, so inlining the button added no new host. */
+        @import url('https://fonts.googleapis.com/css2?family=Alegreya:ital,wght@0,400..900;1,400..900&family=Quintessential&display=swap&family=EB+Garamond&display=swap&family=Macondo&display=swap&family=Eagle+Lake&display=swap&family=Macondo+Swash+Caps&display=swap&family=Cookie&display=swap');
     </style>
 
     <!-- <script src="//unpkg.com/@ungap/custom-elements"></script> -->
+    <!-- No `defer`: it is a no-op on a module script, which is deferred by definition. -->
     <script src="src/ts/common.ts" type="module"></script>
-    <script defer src="src/ts/MusicCanvas.ts" type="module"></script>
-    <script defer src="src/ts/MusicControls.ts" type="module"></script>
-    <script defer src="src/ts/MusicScore.ts" type="module"></script>
-    <script defer src="index.ts" type="module"></script>
+    <script src="src/ts/MusicCanvas.ts" type="module"></script>
+    <script src="src/ts/MusicControls.ts" type="module"></script>
+    <script src="src/ts/MusicScore.ts" type="module"></script>
+    <script src="index.ts" type="module"></script>
     <!-- Cloudflare Web Analytics -->
-    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c6a8a31f6d3d490fb11632f634072912"}'></script>
+    <!-- Must stay `async` (#799). Classic `defer` scripts and module scripts share one
+         ordered queue, so a `defer` beacon sitting ahead of the app holds the whole player
+         behind it when Cloudflare is slow: nothing upgraded, nothing wired, wherever init()
+         lives. `async` keeps it out of that queue entirely, whatever the order.
+         The build does currently emit the app bundle BELOW this tag, which is what makes
+         e2e/third-party-stall.spec.ts fail if anyone reverts this to defer. That guard is
+         therefore only as good as the emission order: if this tag ever moves, or Vite ever
+         emits the bundle above it, check dist/index.html rather than trusting the test. -->
+    <script async src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c6a8a31f6d3d490fb11632f634072912"}'></script>
     <!-- End Cloudflare Web Analytics -->
 
 </head>
@@ -295,10 +307,19 @@
             </table>
             <div class="help-footer">
                 <div class="bmc-wrapper">
-                    <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
-                        data-name="bmc-button" data-slug="wainwmr" data-color="#133354" data-emoji="☕"
-                        data-font="Cookie" data-text="Buy me a coffee" data-outline-color="#ffffff"
-                        data-font-color="#ffffff" data-coffee-color="#FFDD00"></script>
+                    <!-- Our own markup, not the vendor's script (#799). The Buy Me A Coffee embed
+                         was a parser-blocking script sitting ahead of every player element, so a
+                         slow donation host stopped the app being built at all. It could not simply
+                         be made async: it renders with document.writeln, which the browser discards
+                         from any script that is not parser-inserted, so async and defer would each
+                         have deleted the button silently. What it rendered was this anchor, the
+                         Cookie webfont (now on the @import above) and the CSS to style it
+                         (style.scss, .bmc-btn); we supply all three, and the donation host leaves
+                         the page. -->
+                    <a class="bmc-btn" href="https://buymeacoffee.com/wainwmr" target="_blank" rel="noopener">
+                        <span aria-hidden="true">☕</span>
+                        <span class="bmc-btn-text">Buy me a coffee</span>
+                    </a>
                 </div>
                 <div class="help-footer-right">
                     <p class="version">Spem Player v%VERSION%</p>
@@ -324,10 +345,11 @@
                 <p class="feedback-context-note">Playback context (recording, choir, bar, etc.) and platform info are included automatically.</p>
                 <div class="feedback-footer">
                     <div class="bmc-wrapper">
-                        <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
-                            data-name="bmc-button" data-slug="wainwmr" data-color="#133354" data-emoji="☕"
-                            data-font="Cookie" data-text="Buy me a coffee" data-outline-color="#ffffff"
-                            data-font-color="#ffffff" data-coffee-color="#FFDD00"></script>
+                        <!-- See the help-footer button above (#799). -->
+                        <a class="bmc-btn" href="https://buymeacoffee.com/wainwmr" target="_blank" rel="noopener">
+                            <span aria-hidden="true">☕</span>
+                            <span class="bmc-btn-text">Buy me a coffee</span>
+                        </a>
                     </div>
                     <div class="feedback-actions">
                         <button type="submit" id="feedback-submit">Send</button>

--- a/packages/pwa/index.ts
+++ b/packages/pwa/index.ts
@@ -668,8 +668,6 @@ function handleAudioPaused() {
 // Setup page
 // -----------------------------------------------------
 
-window.addEventListener("load", init);
-
 function init(): void {
   // On mobiles, 100vh sometimes is the total vertical space
   // of the browser, but we don't want to include the browser's
@@ -858,3 +856,24 @@ export const exportedForTesting = {
   syncFeedbackRating,
   syncFeedbackMessage,
 };
+
+// Wire the app now, at module scope, rather than on `window load` (#799).
+//
+// This is a module script, so the browser already defers it until the document is
+// parsed: every element init() touches exists by the time this line runs, which is
+// the same guarantee the const lookups at the top of this file have always relied
+// on. `load` is a different promise entirely. It waits for every subresource on the
+// page, third-party analytics and fonts included, so hanging init() off it meant a
+// slow third-party SCRIPT left a fully painted player whose clicks, keys and touches
+// went nowhere, and whose shared deep link showed the wrong bar until the browser
+// gave up on that host. (A slow third-party STYLESHEET is worse and is not fixed
+// here: it blocks this module from executing at all. See #839.)
+//
+// Keep this call LAST in the file. Everything init() reads DURING the call must be
+// initialised by then, and TypeScript will not tell you: it flags a textual
+// use-before-declaration, but does not trace the temporal dead zone through a
+// function body. A module-scope `const` added below this line and read synchronously
+// by init() would compile clean and throw at runtime. (One read only from inside a
+// listener would in fact be fine, since module evaluation finishes before any event
+// fires; "last line" is the simple rule that makes the distinction unnecessary.)
+init();

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spem/pwa",
   "private": true,
-  "version": "2.8.16",
+  "version": "2.8.17",
   "description": "Helping singers learn Thomas Tallis Spem in alium",
   "type": "module",
   "dependencies": {},

--- a/packages/pwa/src/scss/style.scss
+++ b/packages/pwa/src/scss/style.scss
@@ -245,7 +245,12 @@ header {
     margin: 5px;
   }
 
-  a {
+  // Prose links in the help panel. The coffee button is an anchor but not a prose
+  // link, and this rule outranks its own class rule on specificity (#help a beats
+  // .bmc-btn), which painted its label dark-on-dark and invisible. Excluding it
+  // here says why, where !important on every one of the button's declarations (what
+  // the vendor's script did) would only say "win".
+  a:not(.bmc-btn) {
     color: var(--color-on-light);
     text-decoration: none;
     &:hover {
@@ -289,6 +294,51 @@ header {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+}
+
+// The Buy Me A Coffee button (#799). It used to be drawn at runtime by the vendor's
+// script from cdnjs.buymeacoffee.com, which rendered via document.writeln and so only
+// worked while it was blocking the parser. A parser-blocking script ahead of the
+// player markup is the defect #799 removes, and no attribute could have saved it, so
+// the script is gone and we ship what it produced: an anchor (index.html), a Cookie
+// webfont (added to the @import there), and these rules.
+//
+// The colours and geometry are the vendor's own, so the button is unchanged to look
+// at on any platform that renders the coffee emoji, which is what it drew there too.
+// Two things of its are NOT carried, deliberately: it probed canvas for emoji support
+// and swapped in an inline SVG cup where the glyph was missing (so on a system with no
+// emoji font the label now sits beside a tofu box, which is cosmetic and accepted),
+// and its data-outline-color / data-coffee-color tinted only that SVG, which no longer
+// exists. Its !important on every declaration was there to fight the host page's CSS;
+// in our own stylesheet the cascade is ours to arrange, and #help's link rule is
+// excluded above instead.
+.bmc-btn {
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  min-width: 210px;
+  height: 60px;
+  padding: 0 24px;
+  border: none;
+  border-radius: 12px;
+  background-color: #133354;
+  color: #ffffff;
+  font-family: "Cookie", cursive;
+  font-size: 28px;
+  line-height: 27px;
+  text-decoration: none;
+
+  &:hover,
+  &:active,
+  &:focus {
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .bmc-btn-text {
+    margin-left: 8px;
+    white-space: nowrap;
   }
 }
 

--- a/packages/pwa/src/test/darkmode.test.ts
+++ b/packages/pwa/src/test/darkmode.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { setupIntegrationFixture } from "./helpers";
 
 describe("Dark/light mode toggle", () => {
-  // Captured after the load event, before any beforeEach reset can touch the
-  // body class — test 1 asserts this value, not the post-reset DOM (#542).
+  // Captured after the fixture has bootstrapped the app, before any beforeEach
+  // reset can touch the body class — test 1 asserts this value, not the post-reset
+  // DOM (#542).
   let defaultHadLightTheme: boolean;
 
   beforeAll(async () => {

--- a/packages/pwa/src/test/helpers.ts
+++ b/packages/pwa/src/test/helpers.ts
@@ -35,13 +35,15 @@ const BASE_INTEGRATION_FIXTURE = `
 /**
  * Set up the shared jsdom fixture and bootstrap the app for integration tests.
  *
- * The optional `configure` callback runs after the base fixture is injected and
- * the custom-element *modules* are imported, but before `index.ts` is imported
- * (which is what registers the elements, via their static `define()`, and wires
- * the app) and before the load event is dispatched. The `<music-*>` elements are
- * therefore not yet upgraded when `configure` runs, so inject plain DOM here (for
- * example the feedback modal), not interactions with the custom elements. Keeps
- * the shared bootstrap in one place.
+ * Importing `index.ts` IS the bootstrap: it registers the elements via their static
+ * `define()` and calls `init()` at module scope, so nothing further needs to be
+ * dispatched to start the app.
+ *
+ * The optional `configure` callback runs after the base fixture is injected and the
+ * custom-element *modules* are imported, but before `index.ts` is imported. The
+ * `<music-*>` elements are therefore not yet upgraded when `configure` runs, so
+ * inject plain DOM here (the feedback modal, for example), not interactions with the
+ * custom elements. Keeps the shared bootstrap in one place.
  */
 export async function setupIntegrationFixture(
   configure?: () => void | Promise<void>
@@ -70,13 +72,12 @@ export async function setupIntegrationFixture(
     await configure();
   }
 
-  // jsdom has no real media playback; stub play/pause before index.ts runs on
-  // the load event, so app code and tests can drive playback without errors.
+  // jsdom has no real media playback; stub play/pause before index.ts wires the
+  // app, so app code and tests can drive playback without errors.
   vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
   vi.spyOn(HTMLMediaElement.prototype, "pause").mockReturnThis();
 
   await import("../../index.ts");
-  window.dispatchEvent(new Event("load"));
 }
 
 /**

--- a/packages/pwa/src/test/splitter.test.ts
+++ b/packages/pwa/src/test/splitter.test.ts
@@ -44,7 +44,6 @@ describe("splitter drag cursor", () => {
     vi.spyOn(HTMLMediaElement.prototype, "pause").mockReturnThis();
 
     await import("../../index.ts");
-    window.dispatchEvent(new Event("load"));
   }, 30000);
 
   afterAll(async () => {

--- a/packages/pwa/src/test/third-party-markup.test.ts
+++ b/packages/pwa/src/test/third-party-markup.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * #799 — pin the markup half of the third-party-stall fix, on every PR.
+ *
+ * The fix has two halves. The behavioural half (init() at module scope) is
+ * PR-guarded already: src/test/helpers.ts no longer dispatches a synthetic
+ * `load` event, so reverting init() to a load listener kills every integration
+ * test. The MARKUP half had no PR-time guard at all: the e2e suite that pins it
+ * (e2e/third-party-stall.spec.ts) runs nightly, not on pull requests (a settled
+ * trade: e2e is slow, we accept the lag). So a PR re-adding the donation
+ * vendor's parser-blocking script, or reverting the Cloudflare beacon to
+ * `defer`, would go green, merge, and hand the #799 deadlock back to users
+ * until the next morning's run. Same reasoning, same shape, same cost as
+ * fouc-guard-markup.test.ts: read the source, pin the tags, milliseconds.
+ *
+ * This is also the order-independent defer-revert guard. The e2e stall test
+ * catches a `defer` beacon only while Vite emits the app bundle BELOW the
+ * beacon tag (the index.html comment says so itself); this test reads the
+ * attribute in the source and does not care where the bundle lands.
+ */
+describe("third-party markup (#799)", () => {
+  const html = readFileSync(resolve(__dirname, "../../index.html"), "utf-8");
+
+  // A comment must not satisfy a PRESENCE pin. Disable-by-comment is an
+  // established habit in this file (the unpkg polyfill sits commented out
+  // today), and a commented-out beacon, button, or @import is exactly the
+  // disabling each presence pin exists to catch — most of all the #839
+  // premise pin, whose whole job is to go red when that block changes. The
+  // ABSENCE pins keep the raw source deliberately: a commented-out vendor
+  // script tripping them is the safe direction.
+  const live = html.replace(/<!--[\s\S]*?-->/g, "");
+
+  it("keeps the Cloudflare beacon async, never defer", () => {
+    // A `defer` classic script shares one ordered queue with the module
+    // scripts, so a stalled beacon emitted ahead of the app bundle holds the
+    // whole player behind someone else's server. `async` keeps it out of that
+    // queue entirely, whatever the emission order.
+    const beaconTag = live.match(/<script[^>]*cloudflareinsights[^>]*>/i);
+    expect(
+      beaconTag,
+      "the Cloudflare beacon script tag is missing"
+    ).not.toBeNull();
+    expect(beaconTag![0]).toMatch(/\basync\b/);
+    expect(beaconTag![0]).not.toMatch(/\bdefer\b/);
+  });
+
+  it("references nothing from the donation vendor", () => {
+    // #799 removed cdnjs.buymeacoffee.com's parser-blocking, document.writeln
+    // embed and shipped what it rendered as our own markup. The page-errors
+    // ALLOWLIST entry for the host went with it, deliberately: nothing
+    // legitimately produces an error from that host any more. Re-adding the
+    // script would resurrect the deadlock this whole ticket removes.
+    expect(html).not.toMatch(/buymeacoffee\.com\/[^"']*\.js/i);
+    expect(html).not.toMatch(/<script[^>]*buymeacoffee/i);
+  });
+
+  it("carries both first-party coffee buttons", () => {
+    // One in the help footer, one in the feedback modal. The e2e spec proves
+    // they are visible and readable; this pins that they exist at all, so a
+    // template tidy-up cannot silently drop one at PR time.
+    const anchors = live.match(/<a class="bmc-btn"/g) ?? [];
+    expect(anchors).toHaveLength(2);
+  });
+
+  it("still imports the Google Fonts stylesheet from a blocking inline style (#839 premise)", () => {
+    // e2e/third-party-stall.spec.ts declares its fonts.googleapis.com stall
+    // tests `fixme` as a known failure: a pending stylesheet blocks paint and
+    // the deferred-script queue, which no script-loading change can reach.
+    // That knownFailure entry says "delete this when #839 lands" — but a
+    // fixme'd test never runs, so nothing enforces the deletion. THIS does:
+    // #839's fix must make the font stylesheet non-blocking, which means this
+    // assertion goes red. When it does, delete the knownFailure in
+    // e2e/third-party-stall.spec.ts (its three stall tests become #839's
+    // regression guard) and then delete this case.
+    expect(live).toMatch(
+      /<style>[\s\S]{0,400}?@import url\('https:\/\/fonts\.googleapis\.com\/css2/
+    );
+  });
+});


### PR DESCRIPTION
A stalled third-party script (fonts, analytics, the coffee-button widget) could dead-lock the app's render and interactivity, because the page waited on hosts we do not control. This branch stops third-party hosts being able to block render: the app's own load path no longer waits on them, and the e2e fixture stubs every off-origin host so the suite proves it.

## What changed

- `index.html` / `index.ts` / `style.scss`: third-party loads decoupled from the render path (async beacon, vendor-absence tolerance), composed with the FOUC-guard fallback that landed in #834.
- `packages/pwa/e2e`: a dedicated third-party-stall spec driving the app with each host stalled, plus fixture hardening in `page-errors.ts` (composed with the cancelled-audio exemption from #832).
- `src/test/third-party-markup.test.ts`: PR-time pins for the markup invariants (async beacon, vendor absence, both buttons).

## Review history

This branch passed a full seven-reviewer gate twice (cycle 2 tonight, on the rebased composite across today's three merges; 17 findings all resolved, none critical, zero production defects found in either pass). The gate synthesis with the finding-by-finding record is on ticket #799.

## Tests

- Unit suite 367 green; the stall spec green across Chromium, Firefox, and WebKit on a fresh build; full `pnpm run ci` green on this squashed tip.
- Version bumped to 2.8.17 (user-facing fix).

Fixes #799
